### PR TITLE
dev tests pr flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.6.13 - 2026-06-17
+
+`make dev` now runs the test suite before building, and releases go through a
+PR. Dev-workflow only; no app changes.
+
 ## 2026.6.12 - 2026-06-17
 
 Docs only - trimmed the release runbook. No app changes.

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.12
-CURRENT_PROJECT_VERSION = 20260623
+MARKETING_VERSION = 2026.6.13
+CURRENT_PROJECT_VERSION = 20260624

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 # adhoc/Debug divergence to chase:
 #   make                   Build (Release: Dev-ID + notarized) + install to
 #                          /Applications. Falls back to adhoc Release w/o a cert.
-#   make dev / reinstall   Same as `make`, plus quit + relaunch. The inner loop.
+#   make dev               Run tests, then build + install + relaunch. Inner loop.
+#   make reinstall         Build + install + quit-and-relaunch (no tests).
 #   make install           Build + install, no relaunch (same as bare `make`).
 #   make open              Build + install + open.
 #   make release           Build the notarized Release app only (no install).
@@ -272,11 +273,11 @@ reinstall: install
 	@COMMIT=$$(sed -nE 's/.*static let commit = "([^"]+)".*/\1/p' Glimmer/BuildInfo.generated.swift); \
 	echo "  ✓ now running build $$COMMIT"
 
-# `make dev` == `make reinstall`: everything-but-publish (notarized Release),
-# installed, and relaunched. Kept as a name out of muscle memory; the pipeline
-# itself lives in `all` (build/sign/embed/notarize) + `install` (stage) + the
-# quit/relaunch below.
-dev: reinstall
+# `make dev` is the inner loop: run the unit tests, THEN build + install +
+# relaunch the notarized Release build. Tests run first so a failure skips the
+# slow notarize. (Pipeline: `all` build/sign/embed/notarize + `install` stage +
+# `reinstall` quit/relaunch.)
+dev: test reinstall
 
 uninstall:
 	@echo "▶ Uninstalling Glimmer..."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,27 +1,26 @@
 # Release
 
-Glimmer ships continuously off `main`. CalVer `YYYY.M.MICRO`, bumped only in
-`Glimmer/Version.xcconfig`.
+Continuous off `main`, CalVer `YYYY.M.MICRO` (bump only in
+`Glimmer/Version.xcconfig`). Every change ships through a PR.
 
-## Make a change
+## 1. Branch + build
 
 ```bash
 git switch main && git pull && git switch -c my-change
-# ...edit...
-make dev     # build + install + relaunch, notarized = exactly what ships
-make test    # unit tests
+# ...edit; bump both lines in Glimmer/Version.xcconfig + add a CHANGELOG entry...
+make dev     # tests, then build + install + relaunch (notarized = what ships)
 ```
 
 `make app` = fast compile-only check. `make dist` = notarized DMG, no publish.
 
-## Ship it
+## 2. PR + release
 
 ```bash
-git switch main && git merge my-change
-# bump both lines in Glimmer/Version.xcconfig (MICRO +1, build +1); add a CHANGELOG entry
-git commit -am "release: 2026.6.X" && git push
-make release-publish    # sign, notarize, GitHub release + Sparkle appcast
+git push -u origin my-change && gh pr create --fill
+# merge the PR on GitHub, then:
+git switch main && git pull && make release-publish
 ```
 
-Clients auto-update within a day. Fresh machine, one-time: `make creds-init`,
-`codesign-setup`, `setup-notary`, `sparkle-keys`.
+`release-publish` signs, notarizes, cuts the GitHub release, and updates the
+Sparkle appcast (clients auto-update within a day). Fresh machine, one-time:
+`make creds-init`, `codesign-setup`, `setup-notary`, `sparkle-keys`.


### PR DESCRIPTION
- **chore(lint): attach orphaned doc comment; allow idiomatic n/s/d names**
- **test: add Phase-1 unit-test suite (EnetWire, Reed-Solomon/FEC, InputEncoder, SDP)**
- **ci(hooks): add a pre-push make-test gate**
- **test: Phase-2 unit tests (crypto, RTP seq, keymap, protocol constants)**
- **chore(lint): remove the commit-trailer custom_rules**
- **release: 2026.6.10**
- **build: pin ARCHS=arm64 (openssl/opus are arm64-only)**
- **appcast: Glimmer 2026.6.10**
- **test: cover the Annex-B NAL parsers + RTP audio helpers (17 tests)**
- **feat(helper): restore awdl0 suppression daemon (build + signing)**
- **feat(helper): app-side AWDL helper - register, XPC, stream wiring, Settings**
- **feat(helper): launch-time enable prompt with "Don't ask again"**
- **feat(helper): un-sandbox to allow SMAppService.daemon + harden registration**
- **fix(helper): state-driven awdl0 lifecycle + cmd-tab resume**
- **build: notarize make dev builds**
- **chore(entitlements): drop no-op sandbox keys after un-sandbox**
- **docs: revise for un-sandbox + AWDL helper**
- **docs: host display-mode setup (VDD sample + guide)**
- **test+fix(fec): parser fuzz suite + harden FEC decoders against short shards**
- **build: re-enable library validation (Release) + unify on the notarized pipeline**
- **fix(awdl): self-heal the daemon registration after an app update**
- **release: 2026.6.11**
- **appcast: Glimmer 2026.6.11**
- **docs(release): match the notarized everything-but-publish tier + unsandboxed Sparkle**
- **docs: trim RELEASE.md to the bare runbook**
- **release: 2026.6.12**
- **appcast: Glimmer 2026.6.12**
- **release: 2026.6.13 (make dev runs tests; PR-based release runbook)**
