### PR TITLE
awdl reenable logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.6.14 - 2026-06-17
+
+The AWDL helper now logs each time macOS re-raises `awdl0` mid-stream and it
+re-suppresses - recent macOS auto-enables `awdl0` for AirDrop/Continuity even
+while it's parked, and each re-enable is a brief contention window that can
+hitch the stream. Logged at a level that persists, so a hitch can be checked
+against it. Helper-only; no app changes.
+
 ## 2026.6.13 - 2026-06-17
 
 `make dev` now runs the test suite before building, and releases go through a

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.13
-CURRENT_PROJECT_VERSION = 20260624
+MARKETING_VERSION = 2026.6.14
+CURRENT_PROJECT_VERSION = 20260625

--- a/helper/AWDLSuppressor.swift
+++ b/helper/AWDLSuppressor.swift
@@ -21,6 +21,8 @@ final class AWDLSuppressor: @unchecked Sendable {
     private var _lastHeartbeat = Date()
     private let stateLock = NSLock()
     private var pollTimer: DispatchSourceTimer?
+    private var _initialDownDone = false
+    private var _reSuppressCount = 0
 
     var suppressing: Bool {
         stateLock.lock(); defer { stateLock.unlock() }
@@ -35,7 +37,7 @@ final class AWDLSuppressor: @unchecked Sendable {
     func start() {
         setupMonitoring()
         startPolling()
-        os_log("AWDL suppressor started", log: log, type: .info)
+        os_log("AWDL suppressor started", log: log, type: .default)
     }
 
     func setSuppressing(_ value: Bool, reason: String) {
@@ -43,21 +45,28 @@ final class AWDLSuppressor: @unchecked Sendable {
         let wasSuppressing = _suppressing
         _suppressing = value
         if value { _lastHeartbeat = Date() }
-        if value, _suppressionSince == nil { _suppressionSince = Date() }
+        if value, _suppressionSince == nil {
+            _suppressionSince = Date()
+            _initialDownDone = false
+            _reSuppressCount = 0
+        }
         if !value { _suppressionSince = nil }
         stateLock.unlock()
 
-        os_log("Set suppressing=%{public}@ (was %{public}@), reason=%{public}@",
-               log: log, type: .info,
-               value ? "true" : "false",
-               wasSuppressing ? "true" : "false",
-               reason)
+        // Log only the on/off TRANSITION - the client heartbeats setSuppressing(true)
+        // ~1/s, so logging every call would bury the signal. .default persists to disk.
+        if wasSuppressing != value {
+            os_log("suppression %{public}@ (reason: %{public}@)", log: log, type: .default,
+                   value ? "ON" : "OFF", reason)
+        }
+        // Mutate the interface on `queue` (shared with poll + the SCDynamicStore
+        // handler) so concurrent re-suppressions serialize and can't double-count.
         if value {
-            downIfUp()
+            queue.async { [weak self] in self?.downIfUp() }
         } else {
             // Restore awdl0 - just clearing the flag leaves it down until macOS
             // re-raises it, breaking AirDrop/Continuity meanwhile.
-            upIfDown()
+            queue.async { [weak self] in self?.upIfDown() }
         }
     }
 
@@ -85,7 +94,22 @@ final class AWDLSuppressor: @unchecked Sendable {
             os_log("Failed to bring %{public}@ down", log: log, type: .error, interfaceName)
             return
         }
-        os_log("Brought %{public}@ down", log: log, type: .info, interfaceName)
+        stateLock.lock()
+        let initial = !_initialDownDone
+        _initialDownDone = true
+        if !initial { _reSuppressCount += 1 }
+        let count = _reSuppressCount
+        stateLock.unlock()
+        if initial {
+            os_log("%{public}@ forced down - suppressing", log: log, type: .default, interfaceName)
+        } else {
+            // macOS re-raised awdl0 on its own: recent macOS auto-enables it for
+            // AirDrop/Continuity even while we hold it down. Each re-enable is a brief
+            // AWDL-contention window that can hitch a stream; logged at .default so it
+            // persists in `log show` for exactly this diagnosis.
+            os_log("%{public}@ re-enabled by macOS (#%ld this stream) - re-suppressed",
+                   log: log, type: .default, interfaceName, count)
+        }
     }
 
     /// Restore awdl0 to its normal (up) state once suppression ends - mirror of
@@ -96,7 +120,7 @@ final class AWDLSuppressor: @unchecked Sendable {
             os_log("Failed to bring %{public}@ up", log: log, type: .error, interfaceName)
             return
         }
-        os_log("Brought %{public}@ up", log: log, type: .info, interfaceName)
+        os_log("%{public}@ restored (up) - suppression ended", log: log, type: .default, interfaceName)
     }
 
     // MARK: Heartbeat poll - state-driven safety net
@@ -119,11 +143,11 @@ final class AWDLSuppressor: @unchecked Sendable {
         stateLock.unlock()
         if suppressing {
             if idle > 3 {
-                os_log("heartbeat stale %.1fs - releasing awdl0", log: log, type: .info, idle)
+                os_log("heartbeat stale %.1fs - releasing awdl0", log: log, type: .default, idle)
                 setSuppressing(false, reason: "heartbeat-timeout")
             }
         } else if idle > 8 {
-            os_log("idle %.0fs - exiting for a clean reload", log: log, type: .info, idle)
+            os_log("idle %.0fs - exiting for a clean reload", log: log, type: .default, idle)
             exit(0)
         }
     }


### PR DESCRIPTION
- **chore(lint): attach orphaned doc comment; allow idiomatic n/s/d names**
- **test: add Phase-1 unit-test suite (EnetWire, Reed-Solomon/FEC, InputEncoder, SDP)**
- **ci(hooks): add a pre-push make-test gate**
- **test: Phase-2 unit tests (crypto, RTP seq, keymap, protocol constants)**
- **chore(lint): remove the commit-trailer custom_rules**
- **release: 2026.6.10**
- **build: pin ARCHS=arm64 (openssl/opus are arm64-only)**
- **appcast: Glimmer 2026.6.10**
- **test: cover the Annex-B NAL parsers + RTP audio helpers (17 tests)**
- **feat(helper): restore awdl0 suppression daemon (build + signing)**
- **feat(helper): app-side AWDL helper - register, XPC, stream wiring, Settings**
- **feat(helper): launch-time enable prompt with "Don't ask again"**
- **feat(helper): un-sandbox to allow SMAppService.daemon + harden registration**
- **fix(helper): state-driven awdl0 lifecycle + cmd-tab resume**
- **build: notarize make dev builds**
- **chore(entitlements): drop no-op sandbox keys after un-sandbox**
- **docs: revise for un-sandbox + AWDL helper**
- **docs: host display-mode setup (VDD sample + guide)**
- **test+fix(fec): parser fuzz suite + harden FEC decoders against short shards**
- **build: re-enable library validation (Release) + unify on the notarized pipeline**
- **fix(awdl): self-heal the daemon registration after an app update**
- **release: 2026.6.11**
- **appcast: Glimmer 2026.6.11**
- **docs(release): match the notarized everything-but-publish tier + unsandboxed Sparkle**
- **docs: trim RELEASE.md to the bare runbook**
- **release: 2026.6.12**
- **appcast: Glimmer 2026.6.12**
- **release: 2026.6.13 (make dev runs tests; PR-based release runbook)**
- **appcast: Glimmer 2026.6.13**
- **release: 2026.6.14 (AWDL helper logs macOS awdl0 re-enables)**
