### PR TITLE
refactor: drop stale App-Sandbox references from comments and docs

### DIFF
--- a/Glimmer/AWDLHelperManager.swift
+++ b/Glimmer/AWDLHelperManager.swift
@@ -23,8 +23,7 @@ import os.log
 }
 
 enum HelperConstants {
-    /// The daemon's Mach service (matches helper/Protocol.swift + the launchd
-    /// plist + the sandbox mach-lookup exception in Glimmer.entitlements).
+    /// The daemon's Mach service (matches helper/Protocol.swift + the launchd plist).
     static let machServiceName = "io.ugfugl.glimmer.helper"
     /// The launchd plist filename in Contents/Library/LaunchDaemons/.
     static let daemonPlistName = "io.ugfugl.glimmer.helper.plist"

--- a/Glimmer/LogStore.swift
+++ b/Glimmer/LogStore.swift
@@ -4,8 +4,8 @@
 //  In-app ring buffer for a Sunshine-style troubleshooting log.
 //
 //  Why not just read os_log? `OSLogStore(scope: .currentProcessIdentifier)` is
-//  not reliably readable from inside the App Sandbox on this platform - the
-//  Troubleshooting log viewer came up empty even though os_log was emitting.
+//  not reliably readable on this platform - the Troubleshooting log viewer came
+//  up empty even though os_log was emitting.
 //  So the canonical troubleshooting record is THIS in-memory ring buffer, which
 //  the viewer reads directly. Every entry is ALSO mirrored to os_log (.public -
 //  callers pass already-redacted strings, same discipline as the rest of the
@@ -129,11 +129,9 @@ enum Diag {
 /// Buffered background file sink that mirrors the Diag/os_log stream to a
 /// per-session text file when telemetry/debug is enabled. This is the THIRD sink
 /// on `LogStore.log` (after the in-memory ring buffer and os_log): it persists the
-/// rich runtime log to `~/Library/Logs/Glimmer/glimmer-<ISO8601>.log` (which, in
-/// the App Sandbox, resolves to the container's
-/// `Data/Library/Logs/Glimmer` - the SAME directory the telemetry NDJSON writer
-/// uses, so a log shipper can mount one folder and tail both `*.log`
-/// and `*.ndjson`).
+/// rich runtime log to `~/Library/Logs/Glimmer/glimmer-<ISO8601>.log` - the SAME
+/// directory the telemetry NDJSON writer uses, so a log shipper can mount one
+/// folder and tail both `*.log` and `*.ndjson`.
 ///
 /// GATING + HOT-PATH SAFETY (load-bearing - same contract as the telemetry rig):
 ///   * `SessionLogFileSink.shared` is nil unless the telemetry/debug gate is on

--- a/Glimmer/MacSystemStats.swift
+++ b/Glimmer/MacSystemStats.swift
@@ -2,11 +2,11 @@
 //  MacSystemStats.swift
 //
 //  Read host-Mac vitals (battery, CPU, RAM) for the in-stream stats overlay.
-//  Built on the public sandbox-safe APIs: IOPS for battery, Mach
+//  Built on public APIs: IOPS for battery, Mach
 //  `host_statistics`/`host_statistics64` for CPU + RAM. GPU usage is NOT
 //  surfaced here - the only path on macOS is IOReport/IOAccelerator
-//  registry walking, which is technically reachable from a sandboxed app
-//  but needs more careful entitlement / fallback work. Future: GPU.
+//  registry walking, which needs more careful decode / fallback work.
+//  Future: GPU.
 //
 
 import Darwin

--- a/Glimmer/MoonlightManager+Audio.swift
+++ b/Glimmer/MoonlightManager+Audio.swift
@@ -3,8 +3,7 @@
 //
 //  "Mute the Mac while streaming" - captures the default output device's
 //  virtual main volume on stream start, drops it to zero, and restores it on
-//  stop. CoreAudio (sandbox-legal on Developer-ID + Mac App Store) rather than
-//  the osascript shell-out the App Sandbox blocks. Split out of
+//  stop. CoreAudio rather than an osascript shell-out. Split out of
 //  MoonlightManager.swift to keep the core type under the body-length limit.
 //
 
@@ -14,9 +13,7 @@ import Foundation
 
 extension MoonlightManager {
     // Capture the system output level on stream start, drop it to zero, and
-    // restore it on stop. Backed by CoreAudio (see systemVolume/setSystemVolume)
-    // rather than `osascript`, which the App Sandbox blocks - the shell-out
-    // path was a silent no-op in the shipping build.
+    // restore it on stop. Backed by CoreAudio (see systemVolume/setSystemVolume).
     //
     // `prePausedMacVolume` non-nil is the did-mute LATCH: it is set exactly
     // when we drop the volume and cleared exactly when we put it back, so
@@ -52,11 +49,8 @@ extension MoonlightManager {
         }
     }
 
-    // System output volume via CoreAudio. Replaces the prior `osascript`
-    // shell-out, which the App Sandbox blocks (Process exec of
-    // /usr/bin/osascript is denied), making the mute feature a silent no-op.
-    // CoreAudio property access on the default output device is sandbox-legal
-    // on BOTH distribution paths - Developer-ID DMG and the Mac App Store.
+    // System output volume via CoreAudio property access on the default output
+    // device.
     private func defaultOutputDeviceID() -> AudioObjectID? {
         var deviceID = AudioObjectID(kAudioObjectUnknown)
         var size = UInt32(MemoryLayout<AudioObjectID>.size)

--- a/Glimmer/SettingsPCsShortcutsPanes.swift
+++ b/Glimmer/SettingsPCsShortcutsPanes.swift
@@ -269,10 +269,9 @@ struct ShortcutsPane: View {
                     .foregroundStyle(.secondary)
             }
 
-            // (Raw/accel-free mouse was explored here but is impossible while
-            // sandboxed - macOS won't let a sandboxed app open the pointer's HID
-            // (kIOReturnNotPermitted) and CGEventTap deltas are accelerated. See
-            // issue #22, closed not-planned. Mouse motion uses macOS's deltas.)
+            // (Raw/accel-free mouse was explored here but shelved: CGEventTap
+            // deltas are accelerated and the system accel-disable is intrusive.
+            // See issue #22, closed not-planned. Mouse motion uses macOS's deltas.)
         }
         .formStyle(.grouped)
         .sheet(isPresented: $showChordCapture) {

--- a/Glimmer/Stream/DualSenseHID.swift
+++ b/Glimmer/Stream/DualSenseHID.swift
@@ -14,12 +14,12 @@
 //  on the GameController path.
 //
 //  REQUIRES the "Input Monitoring" privacy permission (TCC kTCCServiceListenEvent
-//  - it covers game controllers, not just keyboards) plus the
-//  com.apple.security.device.usb / .bluetooth sandbox entitlements. This is
-//  Developer-ID-legal but NOT Mac-App-Store-compatible (device.usb is a hard
-//  App-Review reject). MAS-STRIP: a future Mac App Store target must remove
-//  this file, its two device.* entitlements, and the call sites that reference
-//  DualSenseHID (ControllerForwarder / InputForwarder / TroubleshootingPane).
+//  - it covers game controllers, not just keyboards). Raw-HID open works under
+//  the unsandboxed Developer-ID build with no device.* entitlement. NOT
+//  Mac-App-Store-compatible (raw device HID is a hard App-Review reject).
+//  MAS-STRIP: a future Mac App Store target must remove this file and the call
+//  sites that reference DualSenseHID (ControllerForwarder / InputForwarder /
+//  TroubleshootingPane).
 //
 
 import Foundation
@@ -100,11 +100,11 @@ final class DualSenseHID: @unchecked Sendable {
     /// them to zero. ControllerHaptics feeds lightbar/rumble here when raw-HID
     /// is live; setAdaptiveTriggers feeds the trigger blocks. Lock-guarded.
     private var outputState = DualSenseOutputState()
-    /// Latch so the "SetReport refused by the sandbox" breadcrumb logs once,
-    /// not per write (host re-arms triggers can arrive at frame rate).
+    /// Latch so the "SetReport refused" breadcrumb logs once, not per write
+    /// (host re-arms triggers can arrive at frame rate).
     private var loggedWriteFailure = false
     /// Latch for the first successful OUTPUT write (proves the raw-HID write
-    /// path is permitted under the sandbox - the P1 open question).
+    /// path reached the device).
     private var loggedWriteSuccess = false
 
     /// Serial queue for the IOKit OUTPUT-report writes. The host feedback
@@ -224,9 +224,8 @@ final class DualSenseHID: @unchecked Sendable {
         // it already provides (sticks/face/triggers/touchpad/rumble/light), and
         // we read the centre buttons + battery alongside it. A non-exclusive
         // open still permits IOHIDDeviceSetReport(Output) - the adaptive-trigger
-        // write path below - for an already-matched device under the USB/HID
-        // gamepad entitlement (degrades to a clean no-op if the sandbox refuses
-        // the write; see writeOutputReport).
+        // write path below - for an already-matched device (degrades to a clean
+        // no-op if the write is refused; see writeOutputReport).
         let rc = IOHIDManagerOpen(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         // NOTICE (was INFO): the open-rc + Input-Monitoring state is the one fact
         // that tells "are the DualSense centre buttons / battery actually
@@ -534,10 +533,10 @@ final class DualSenseHID: @unchecked Sendable {
                 log.info("DualSense OUTPUT report write OK (transport=\(bluetooth ? "BT" : "USB", privacy: .public)) - adaptive triggers live")
             }
         } else if !loggedWriteWasRefused() {
-            // SAFETY no-op: a refused write (e.g. kIOReturnNotPermitted under the
-            // sandbox, or an exclusive grab by gamecontrollerd) degrades to "no
-            // adaptive triggers". Everything else - the read path, buttons,
-            // battery - is unaffected. Logged once so the verdict is in the log.
+            // SAFETY no-op: a refused write (e.g. kIOReturnNotPermitted, or an
+            // exclusive grab by gamecontrollerd) degrades to "no adaptive
+            // triggers". Everything else - the read path, buttons, battery - is
+            // unaffected. Logged once so the verdict is in the log.
             log.error("DualSense OUTPUT report write refused rc=0x\(String(UInt32(bitPattern: rc), radix: 16), privacy: .public) - adaptive triggers disabled (degraded no-op)")
         }
     }

--- a/Glimmer/Stream/IOReportSampler.swift
+++ b/Glimmer/Stream/IOReportSampler.swift
@@ -45,16 +45,12 @@
 //      when bring-up succeeds in a different environment - the many silent nil
 //      paths mean a packaged app could be dead-on-arrival invisibly.
 //
-//  ENTITLE-OR-REMOVE DECISION (made on a packaged run's evidence - do not
+//  FIX-OR-REMOVE DECISION (made on a packaged run's evidence - do not
 //  pre-empt it in code):
-//    * The prime suspect for production darkness is the App Sandbox
-//      (Glimmer.entitlements enables it; a successful bring-up environment may
-//      be unsandboxed). The stage-naming NOTICEs below settle sandbox-vs-API
-//      in one instrumented packaged run.
-//    * If sandbox-blocked: EITHER add the entitlement/exception the failing
-//      stage needs (a deliberate security-surface decision, not a telemetry-pass
-//      change), OR remove this sampler honestly: delete the file, its exporter
-//      hook (TelemetryExporter+CaptureSections.fillResource), the NDJSON/prom
+//    * If a stage fails on a packaged build, the stage-naming NOTICEs below
+//      name it. If the dlopen/subscription is flat-out refused: remove this
+//      sampler honestly - delete the file, its exporter hook
+//      (TelemetryExporter+CaptureSections.fillResource), the NDJSON/prom
 //      render keys, and gate the dashboard power/GPU panels off.
 //    * If API-stage (a group/format change on a newer OS): fix the decode or
 //      drop only the failing group - each group already degrades independently.
@@ -204,8 +200,8 @@ final class IOReportSampler: @unchecked Sendable {
 
     /// Build the sampler, or return nil if IOReport is unavailable - with a
     /// one-time Diag NOTICE naming the FAILING STAGE (dlopen / which dlsym /
-    /// which subscription), so a packaged sandboxed run answers sandbox-vs-API
-    /// from its session log instead of shipping silently-dark fields again.
+    /// which subscription), so a packaged run names the failing stage from its
+    /// session log instead of shipping silently-dark fields again.
     /// Called ONLY on the gate-on path (the exporter constructs it in start(),
     /// after the session log sink is up), so the dlopen + subscription cost is
     /// paid only when telemetry is opt-in ON - and the NOTICEs are bounded to
@@ -213,8 +209,7 @@ final class IOReportSampler: @unchecked Sendable {
     init?() {
         // Resolves from the dyld shared cache - no on-disk file, no link-time dep.
         guard let handle = dlopen("/usr/lib/libIOReport.dylib", RTLD_LAZY) else {
-            Self.noteBringUpFailure("dlopen(/usr/lib/libIOReport.dylib) returned nil"
-                + " - sandbox denial is the prime suspect for a packaged build")
+            Self.noteBringUpFailure("dlopen(/usr/lib/libIOReport.dylib) returned nil")
             return nil
         }
         var missingSymbols: [String] = []

--- a/Glimmer/Stream/Identity+Loading.swift
+++ b/Glimmer/Stream/Identity+Loading.swift
@@ -329,11 +329,6 @@ extension IdentityManager {
     // still use moonlight-qt alongside Glimmer keep their host list
     // intact. (The next time they pair from moonlight-qt itself, qt will
     // regenerate its own identity.)
-    //
-    // Sandbox note: we declare
-    //   com.apple.security.temporary-exception.shared-preference.read-write
-    // scoped narrowly to the moonlight-stream domains in the entitlements
-    // file so this write reaches the actual plist even inside the sandbox.
 
     fileprivate static let moonlightQtSuiteName = "com.moonlight-stream.Moonlight"
 
@@ -349,9 +344,8 @@ extension IdentityManager {
     /// Idempotent.
     func wipeMoonlightQtIdentityPlist() {
         guard let mq = UserDefaults(suiteName: Self.moonlightQtSuiteName) else {
-            // Suite unreadable (sandbox without the temporary-exception, or
-            // CFPreferences misconfig). Not an error per se - just nothing
-            // to wipe from our point of view.
+            // Suite unreadable (CFPreferences misconfig). Not an error per se -
+            // just nothing to wipe from our point of view.
             log.info("moonlight-qt suite not readable; nothing to wipe")
             return
         }

--- a/Glimmer/Stream/Identity.swift
+++ b/Glimmer/Stream/Identity.swift
@@ -13,7 +13,7 @@
 //  Ported (loosely now) from moonlight-qt's app/backend/identitymanager.{h,cpp}.
 //
 //
-// STORAGE DECISION: mode-0600 files in the sandbox container, deliberately.
+// STORAGE DECISION: mode-0600 files under Application Support, deliberately.
 // We evaluated moving to the keychain once builds went Developer-ID signed,
 // and chose to stay on files:
 //
@@ -30,8 +30,8 @@
 //
 //   * The reference (moonlight-qt) stores PLAINTEXT PEM in a mode-0644
 //     QSettings plist under ~/Library/Preferences - no keychain at all. Our
-//     mode-0600 files inside the App Sandbox container are already stricter:
-//     the sandbox blocks other same-UID apps from the container, and 0600 > 0644.
+//     mode-0600 files are already stricter: 0600 keeps every other user out
+//     (0600 > 0644).
 //
 // So: files. See SECURITY.md for the user-facing version.
 //
@@ -42,11 +42,11 @@
 // host indefinitely. If it leaks, the attacker is a permanent imposter against
 // every host this install paired with - until the user unpairs each one.
 //
-// The mode-0600 files live in the App Sandbox container: other users on the Mac
-// are out (0600), and the sandbox keeps other same-UID apps out of the
-// container by default. A TCC-allowlisted app with Full Disk Access can still
-// read them - an OS-level boundary, not a Glimmer-specific defence, and a
-// narrower exposure than moonlight-qt's unsandboxed 0644 plist.
+// The mode-0600 files keep every other user on the Mac out. Unsandboxed, there's
+// no container boundary, so a same-UID process isn't blocked by macOS - the 0600
+// perms are the boundary (still stricter than moonlight-qt's 0644 plist). A
+// TCC-allowlisted app with Full Disk Access can still read them - an OS-level
+// boundary, not a Glimmer-specific defence.
 //
 
 import Foundation

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -276,9 +276,9 @@ public final class InputForwarder {
     /// associated; NSEvent.deltaX/Y goes silent under associate-false), falling
     /// back to NSEvent.deltaX/Y only for a synthetic event with no CGEvent
     /// backing. NOTE: these deltas carry macOS's pointer-acceleration curve -
-    /// there is no accel-free path for the mouse while sandboxed (raw HID open
-    /// is `kIOReturnNotPermitted`; CGEventTap is also accelerated; the system
-    /// accel-disable is sandbox-blocked - see issue #22, closed not-planned).
+    /// no accel-free path was adopted for the mouse (CGEventTap is also
+    /// accelerated; the system accel-disable is intrusive - see issue #22,
+    /// closed not-planned).
     /// Returned in the same down-positive Y convention macOS uses so the
     /// LiSendMouseMoveEvent call site needs no sign flip.
     func mouseDelta(from event: NSEvent) -> (dx: Double, dy: Double) {

--- a/Glimmer/Stream/NativeBackend+Pipeline.swift
+++ b/Glimmer/Stream/NativeBackend+Pipeline.swift
@@ -485,8 +485,9 @@ extension NativeConnectionEvents {
     /// matches DualSenseHID's reader; the singleton resolves the open device
     /// and merges these params with the current lightbar + rumble before
     /// writing (the 0x02/0x31 report is all-or-nothing). A no-op when the
-    /// raw-HID feature is off or the write is refused by the sandbox - adaptive
-    /// triggers simply don't engage, nothing else is affected.
+    /// raw-HID feature is off or the write is refused (e.g. gamecontrollerd
+    /// grabbed the device) - adaptive triggers simply don't engage, nothing
+    /// else is affected.
     func setAdaptiveTriggers(controller: UInt16, eventFlags: UInt8,
                              typeLeft: UInt8, typeRight: UInt8,
                              left: [UInt8], right: [UInt8]) {

--- a/Glimmer/Stream/Types+Cert.swift
+++ b/Glimmer/Stream/Types+Cert.swift
@@ -84,7 +84,7 @@ public enum PinnedCertStore {
     // MARK: File-backed store (mode-0600 files under Application Support)
     //
     // UserDefaults backs onto a plain XML plist in
-    // ~/Library/Preferences/ (sandbox-containered or not). Any same-UID
+    // ~/Library/Preferences/. Any same-UID
     // process can both read and *write* to it via cfprefsd - there is no
     // per-app ACL. For a pinned host cert the read leak is mostly
     // harmless (the cert is public anyway), but the write surface is the
@@ -96,9 +96,8 @@ public enum PinnedCertStore {
     //   <ApplicationSupport>/Glimmer/PinnedHosts/<sanitized-id>.pem
     // with mode 0600 (owner-only). Same enforcement pattern as
     // `FileIdentityStore` in Identity.swift - atomic write, stat(2)
-    // verify, on-failure delete-and-throw. Inside the sandbox this lands
-    // at <Container>/Library/Application Support/Glimmer/PinnedHosts/...
-    // which is per-app private at the filesystem level.
+    // verify, on-failure delete-and-throw. mode 0600 keeps it
+    // owner-only at the filesystem level.
     //
     // Migration: read-side hits the legacy UserDefaults key as a
     // fallback, copies forward to the file store, and deletes the
@@ -159,8 +158,7 @@ public enum PinnedCertStore {
     // MARK: File-store internals
 
     /// `~/Library/Application Support/Glimmer/PinnedHosts/`. Created at
-    /// mode 0700 on first write. Inside the sandbox this resolves to
-    /// the container's Application Support path.
+    /// mode 0700 on first write.
     private static func directoryURL() throws -> URL {
         let fm = FileManager.default
         let base = try fm.url(for: .applicationSupportDirectory,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -448,9 +448,7 @@ acceptable.
 `Identity.swift`: per-machine 32-hex `uniqueID`, an RSA-2048 keypair, and a
 20-year self-signed cert (CN `NVIDIA GameStream Client` - every GameStream
 client identifies as this string, including moonlight-qt). Three mode-0600 files
-under
-`~/Library/Containers/io.ugfugl.Glimmer/Data/Library/Application Support/Glimmer/Identity/`
-(post-sandbox):
+under `~/Library/Application Support/Glimmer/Identity/`:
 
 - `client-cert.pem`
 - `client-key.pem`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -77,14 +77,7 @@ client identifier; moonlight-qt uses the same).
 - `client-key.pem` - RSA private key in PEM (PKCS#8 unencrypted)
 - `client-uniqueid.txt` - 32-hex-char client unique ID
 
-Current state (unsandboxed): `~/Library/Application Support/Glimmer/Identity/`.
-
-Legacy (sandboxed builds):
-`~/Library/Containers/io.ugfugl.Glimmer/Data/Library/Application Support/Glimmer/Identity/`.
-A one-time container -> home migration runs on first launch of an unsandboxed
-build: now that the app can read its old container, the existing identity (and
-pinned hosts) move to the home path with mode 0600 preserved. Existing installs
-keep their paired hosts; no re-pairing.
+Stored at `~/Library/Application Support/Glimmer/Identity/`.
 
 `FileIdentityStore.write` (`Identity.swift`):
 
@@ -121,10 +114,9 @@ The one residual exposure is a Full-Disk-Access same-UID process reading the key
 
 **One-shot moonlight-qt migration.** On first launch, Glimmer reads the
 `com.moonlight-stream.Moonlight` and `com.moonlight-stream.moonlight-qt`
-preference domains (no sandbox entitlement needed now that the app is
-unsandboxed). If a moonlight-qt install left a client identity + paired-host
-list, we adopt it so the user doesn't have to re-pair. After successful
-migration the PEM material in the foreign plist is wiped (it sat in a
+preference domains. If a moonlight-qt install left a client identity +
+paired-host list, we adopt it so the user doesn't have to re-pair. After
+successful migration the PEM material in the foreign plist is wiped (it sat in a
 world-readable plist before - moonlight-qt's storage is not 0600). Idempotent;
 dormant after the first run.
 


### PR DESCRIPTION
The app has been unsandboxed since 2026.6.11, but ~13 files plus SECURITY.md /
ARCHITECTURE.md still described sandbox-era behavior - storage "in the sandbox
container", "the App Sandbox blocks osascript", "sandbox denial is the prime
suspect", entitlement asides for entitlements that no longer exist, and a
container->home migration paragraph. Rewrote them to describe the current
unsandboxed reality and trimmed the sandboxed-vs-unsandboxed distinction.

Comments + docs only, plus one runtime log string (IOReportSampler no longer
blames the sandbox for a dlopen failure). No logic change; 146 tests pass.
