### PR TITLE
awdl fix stale secidentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026.6.15 - 2026-06-18
+
+Fixes streams suddenly failing with "host doesn't recognize this Mac" after the
+Mac sleeps. The client TLS identity is imported into the login keychain, which
+locks on sleep/idle; the long-running app kept using the now-unusable cached
+identity, so the next stream's mutual-TLS handshake couldn't sign - and that was
+misreported as a lost pairing. Glimmer now re-imports the identity on demand
+when its key can't sign, so it self-heals instead of needing a restart.
+
 ## 2026.6.14 - 2026-06-17
 
 The AWDL helper now logs each time macOS re-raises `awdl0` mid-stream and it

--- a/Glimmer/Stream/Identity.swift
+++ b/Glimmer/Stream/Identity.swift
@@ -232,10 +232,33 @@ public actor IdentityManager {
     /// for subsequent calls. The PEM source (file store today, keychain on
     /// signed builds in the future) is transparent to this layer.
     public func secIdentity() throws -> SecIdentity {
-        if let cachedIdentity { return cachedIdentity }
+        if let cachedIdentity, Self.canSign(cachedIdentity) { return cachedIdentity }
+        // No cache yet, OR the cached identity's key can't sign anymore because
+        // the login keychain (where SecPKCS12Import lands it) locked on sleep /
+        // idle. Re-import from the PEMs - the keychain is unlocked whenever the
+        // user is actively here to start a stream. Without this, a locked keychain
+        // fails the mutual-TLS handshake and the failure is misreported downstream
+        // as "host doesn't recognize this Mac" until the app is restarted.
+        cachedIdentity = nil
         let id = try buildOrLoadIdentity()
         cachedIdentity = id
         return id
+    }
+
+    /// True if `identity`'s private key can sign right now - i.e. its keychain is
+    /// unlocked and we're authorized. Probes with keychain UI suppressed so a
+    /// locked keychain reports false (→ re-import) instead of throwing a password
+    /// prompt. The signature itself is thrown away.
+    private static func canSign(_ identity: SecIdentity) -> Bool {
+        var key: SecKey?
+        guard SecIdentityCopyPrivateKey(identity, &key) == errSecSuccess, let key else { return false }
+        SecKeychainSetUserInteractionAllowed(false)
+        defer { SecKeychainSetUserInteractionAllowed(true) }
+        var error: Unmanaged<CFError>?
+        let sig = SecKeyCreateSignature(key, .rsaSignatureDigestPKCS1v15SHA256,
+                                        Data(repeating: 0, count: 32) as CFData, &error)
+        error?.release()
+        return sig != nil
     }
 
     /// Bootstrap step - call this early (from MoonlightManager.bootstrap()) so

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.14
-CURRENT_PROJECT_VERSION = 20260625
+MARKETING_VERSION = 2026.6.15
+CURRENT_PROJECT_VERSION = 20260626


### PR DESCRIPTION
- **refactor: drop stale App-Sandbox references from comments and docs**
- **release: 2026.6.15 (self-heal client TLS identity after the login keychain locks)**
