### PR TITLE
control channel openssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.6.16 - 2026-06-18
+
+Root-fixes the "host suddenly stops trusting this Mac after sleep" problem. The
+control channel (pairing, launch, resume) now runs on Glimmer's own OpenSSL
+mutual-TLS client instead of URLSession - which had forced the client identity
+through the login keychain, the thing that locked on sleep and broke the
+connection. The cert + key now load straight from the on-disk PEM, with the host
+cert pinned exactly as before, so there's no keychain in the path to lapse on
+wake. (2026.6.15 was a stopgap that re-imported on demand; this removes the
+cause.)
+
 ## 2026.6.15 - 2026-06-18
 
 Fixes streams suddenly failing with "host doesn't recognize this Mac" after the

--- a/Glimmer-Bridging-Header.h
+++ b/Glimmer-Bridging-Header.h
@@ -26,5 +26,6 @@
 #import <openssl/bn.h>
 #import <openssl/pkcs12.h>
 #import <openssl/err.h>
+#import <openssl/ssl.h>
 
 #endif

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		ABCD20260610000000005F02 /* EnvSignalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD20260610000000005F01 /* EnvSignalController.swift */; };
 		BBF95775D96E9853A40ADED0 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9158C8506080330EC17875A9 /* Host.swift */; };
 		BC8B3FD0322A256049C1CAF8 /* QualityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAE5FA4BA5A94E9668B7089 /* QualityCalculator.swift */; };
+		C6C5CBE04F4781BF9891C433 /* ControlTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48756631ACFBD0A1FFEBD539 /* ControlTransport.swift */; };
 		CC00000002 /* StatsCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000001 /* StatsCollector.swift */; };
 		CC00000004 /* VideoDecoder+HDR.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000003 /* VideoDecoder+HDR.swift */; };
 		CC00000006 /* VideoDecoder+Bitstream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000005 /* VideoDecoder+Bitstream.swift */; };
@@ -228,6 +229,7 @@
 		3A952BEEC96F2A8042E0F4C3 /* StatsOverlaySettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StatsOverlaySettings.swift; sourceTree = "<group>"; };
 		447FF92C9458E21549E4965D /* HostStatusPoller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostStatusPoller.swift; sourceTree = "<group>"; };
 		448F2B492E4B38A0CFF51260 /* StreamingState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingState.swift; sourceTree = "<group>"; };
+		48756631ACFBD0A1FFEBD539 /* ControlTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Stream/ControlTransport.swift; sourceTree = "<group>"; };
 		505E37FB63C22AC476506587 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		68E50C51912216A5F5FDA2C6 /* Glimmer Login Helper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Glimmer Login Helper.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71A5B2E11628E68BFAF05421 /* AppIcon.icon */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 				A647C41163064ECDA1D86EA8 /* MacSystemStats.swift */,
 				71A5B2E11628E68BFAF05421 /* AppIcon.icon */,
 				2C2C61CA646A8599B4EC06C5 /* AWDLHelperManager.swift */,
+				48756631ACFBD0A1FFEBD539 /* ControlTransport.swift */,
 			);
 			path = Glimmer;
 			sourceTree = "<group>";
@@ -978,6 +981,7 @@
 				026FD8A0211FCD7B527606B0 /* StatsOverlaySettings.swift in Sources */,
 				FB153DF267467B06C6BE3467 /* MacSystemStats.swift in Sources */,
 				109EA4B557EB9EFC0400C751 /* AWDLHelperManager.swift in Sources */,
+				C6C5CBE04F4781BF9891C433 /* ControlTransport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Glimmer/HostStatusPoller.swift
+++ b/Glimmer/HostStatusPoller.swift
@@ -160,9 +160,8 @@ extension MoonlightManager {
             await MainActor.run { [weak self] in self?.hostUnreachableStreak = 0 }
             // Step 2: now that we know the host is up, ask /serverinfo who
             // it is and whether it's busy. We do this on a fresh
-            // NetworkClient per poll - the client is cheap to construct,
-            // and reusing one across polls would let stale URLSession
-            // connections age in the background.
+            // NetworkClient per poll - the client is cheap to construct and
+            // holds no persistent connection, so there's nothing to reuse.
             let client = NetworkClient(server: snap.info)
             do {
                 let info = try await client.fetchServerInfo()

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -421,9 +421,9 @@ extension MoonlightManager {
     /// unit-testable.
     static func connectFailureBanner(for error: Error, hostName: String) -> String {
         guard let streamError = error as? StreamError else {
-            // Non-StreamError (NSError from the HTTP/TLS layer, URLSession
-            // timeout, DNS failure) on the start path almost always means the
-            // host never answered - the reach-failure copy is correct.
+            // Any non-StreamError on the start path is unexpected - the control
+            // layer always throws StreamError - so treat it as a reach failure,
+            // by far the most likely cause.
             return "Couldn't reach \(hostName). Make sure it's awake and on the same network."
         }
         switch streamError {

--- a/Glimmer/Stream/CHelpers.h
+++ b/Glimmer/Stream/CHelpers.h
@@ -9,8 +9,15 @@
 #define Glimmer_Stream_CHelpers_h
 
 #include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <netdb.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/uio.h>
 #include <openssl/bio.h>
 #include <openssl/pkcs12.h>
@@ -105,6 +112,53 @@ static inline EVP_PKEY *gl_rsa_keygen(int bits) {
 cleanup:
     EVP_PKEY_CTX_free(ctx);
     return pkey;
+}
+
+// MARK: - TCP connect with timeout (control channel)
+// Plain connect() has no timeout knob, so a dead host would hang the control
+// request until the OS default (~75s). We do a non-blocking connect + poll so it
+// fails fast. On success the socket is returned in BLOCKING mode with
+// SO_RCVTIMEO/SO_SNDTIMEO set to the same deadline, so the TLS handshake and HTTP
+// read/write that follow on this fd inherit the bound. Returns the fd, or -1.
+// `host` may be a hostname or a numeric IP; `port` is the decimal string.
+static inline int gl_tcp_connect(const char *host, const char *port, int timeout_ms) {
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(host, port, &hints, &res) != 0 || !res) return -1;
+
+    int fd = -1;
+    for (struct addrinfo *ai = res; ai; ai = ai->ai_next) {
+        fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd < 0) continue;
+        int fl = fcntl(fd, F_GETFL, 0);
+        fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+        int rc = connect(fd, ai->ai_addr, ai->ai_addrlen);
+        if (rc == 0) goto connected;
+        if (rc < 0 && errno == EINPROGRESS) {
+            struct pollfd pfd = { .fd = fd, .events = POLLOUT, .revents = 0 };
+            if (poll(&pfd, 1, timeout_ms) > 0 && (pfd.revents & POLLOUT)) {
+                int soerr = 0;
+                socklen_t slen = sizeof(soerr);
+                if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &slen) == 0 && soerr == 0) goto connected;
+            }
+        }
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    return -1;
+
+connected:
+    freeaddrinfo(res);
+    fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK);
+    struct timeval tv = { .tv_sec = timeout_ms / 1000, .tv_usec = (timeout_ms % 1000) * 1000 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    return fd;
 }
 
 #endif

--- a/Glimmer/Stream/ControlTransport.swift
+++ b/Glimmer/Stream/ControlTransport.swift
@@ -1,0 +1,234 @@
+//
+//  ControlTransport.swift
+//
+//  Mutual-TLS HTTP/1.1 client for the GameStream control channel, built directly
+//  on the embedded OpenSSL (libssl) + POSIX sockets - NO URLSession, and crucially
+//  NO keychain. The client cert + key load straight from PEM in memory
+//  (SSL_CTX_use_certificate / _PrivateKey); the self-signed host cert is validated
+//  by exact-DER pinning (X509_cmp) in place of CA validation - the same posture
+//  the old URLSession TLSDelegate enforced. macOS only ever forced a
+//  SecIdentity/login-keychain on us to satisfy URLSession; running TLS ourselves
+//  removes it (and the sleep-lock class of bug) entirely.
+//
+
+import Foundation
+import os.log
+
+enum ControlTransport {
+
+    /// One control response. `peerCertPEM` is the host's leaf cert (PEM) seen on
+    /// the TLS handshake - returned on every paired call so the caller can pin it
+    /// after the out-of-band RSA pairing handshake.
+    struct Response: Sendable {
+        let status: Int
+        let body: Data
+    }
+
+    private static let log = Logger(subsystem: "io.ugfugl.Glimmer", category: "Stream.Network.TLS")
+    private static let ioQueue = DispatchQueue(label: "io.ugfugl.Glimmer.control", attributes: .concurrent)
+
+    /// Perform one HTTP/1.1 GET. `tls == false` is plain HTTP (the unpaired probe
+    /// path - no cert, no pin); `tls == true` presents the client cert and pins.
+    /// - pinnedCertPEM: non-nil → the host leaf must match it byte-for-byte (DER)
+    ///   or the handshake is refused (MITM gate). nil → first-contact pairing: any
+    ///   cert is accepted and returned for the caller to pin after RSA verifies.
+    static func get(host: String, port: Int, target: String,
+                    userAgent: String,
+                    tls: Bool,
+                    clientCertPEM: String?, clientKeyPEM: String?,
+                    pinnedCertPEM: String?,
+                    timeout: TimeInterval) async throws -> Response {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Response, Error>) in
+            ioQueue.async {
+                do {
+                    cont.resume(returning: try performBlocking(
+                        host: host, port: port, target: target, userAgent: userAgent,
+                        tls: tls, clientCertPEM: clientCertPEM, clientKeyPEM: clientKeyPEM,
+                        pinnedCertPEM: pinnedCertPEM, timeout: timeout))
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: - Blocking worker (runs off-actor on ioQueue)
+
+    private static func performBlocking(host: String, port: Int, target: String,
+                                        userAgent: String,
+                                        tls: Bool,
+                                        clientCertPEM: String?, clientKeyPEM: String?,
+                                        pinnedCertPEM: String?,
+                                        timeout: TimeInterval) throws -> Response {
+        let timeoutMs = Int32(max(1, timeout) * 1000)
+        let fd = gl_tcp_connect(host, String(port), timeoutMs)
+        guard fd >= 0 else {
+            throw StreamError.hostUnreachable("connect to \(host):\(port) failed or timed out")
+        }
+        defer { close(fd) }
+
+        // Build the request bytes once - same for the TLS and plaintext paths.
+        var request = "GET \(target) HTTP/1.1\r\n"
+        request += "Host: \(host):\(port)\r\n"
+        request += "User-Agent: \(userAgent)\r\n"
+        request += "Accept: */*\r\n"
+        request += "Connection: close\r\n\r\n"
+        let requestBytes = Array(request.utf8)
+
+        if !tls {
+            try writeAll(fd: fd, ssl: nil, requestBytes)
+            let raw = try readAll(fd: fd, ssl: nil)
+            return try parse(raw)
+        }
+
+        // --- TLS ----------------------------------------------------------
+        guard let method = TLS_client_method(),
+              let ctx = SSL_CTX_new(method) else {
+            throw StreamError.crypto("SSL_CTX_new failed")
+        }
+        defer { SSL_CTX_free(ctx) }
+        // We pin instead of CA-validating (the host cert is self-signed); do the
+        // pin check by hand after the handshake. VERIFY_NONE keeps SSL_connect
+        // from rejecting the self-signed leaf before we get to look at it.
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nil)
+
+        if let certPEM = clientCertPEM, let keyPEM = clientKeyPEM {
+            try loadClientCredential(ctx: ctx, certPEM: certPEM, keyPEM: keyPEM)
+        }
+
+        guard let ssl = SSL_new(ctx) else { throw StreamError.crypto("SSL_new failed") }
+        defer { SSL_free(ssl) }
+        SSL_set_fd(ssl, fd)
+        guard SSL_connect(ssl) == 1 else {
+            throw StreamError.hostUnreachable("TLS handshake to \(host):\(port) failed (SSL_connect)")
+        }
+
+        // Pinning + leaf capture.
+        guard let peer = SSL_get1_peer_certificate(ssl) else {
+            throw StreamError.hostUnreachable("host presented no certificate")
+        }
+        defer { X509_free(peer) }
+        if let pinPEM = pinnedCertPEM {
+            guard let pinned = x509(fromPEM: pinPEM) else {
+                throw StreamError.crypto("could not parse pinned host cert")
+            }
+            defer { X509_free(pinned) }
+            guard X509_cmp(peer, pinned) == 0 else {
+                log.error("pinned host cert mismatch - refusing (possible MITM or host re-imaged)")
+                throw StreamError.hostUnreachable("pinned host cert mismatch")
+            }
+        }
+
+        try writeAll(fd: fd, ssl: ssl, requestBytes)
+        let raw = try readAll(fd: fd, ssl: ssl)
+        SSL_shutdown(ssl)   // best-effort clean close; body is already read
+        return try parse(raw)
+    }
+
+    // MARK: - Client credential (PEM → SSL_CTX, no keychain)
+
+    private static func loadClientCredential(ctx: OpaquePointer, certPEM: String, keyPEM: String) throws {
+        guard let cert = x509(fromPEM: certPEM) else {
+            throw StreamError.crypto("could not parse client cert PEM")
+        }
+        defer { X509_free(cert) }
+        guard SSL_CTX_use_certificate(ctx, cert) == 1 else {
+            throw StreamError.crypto("SSL_CTX_use_certificate failed")
+        }
+        guard let key = pkey(fromPEM: keyPEM) else {
+            throw StreamError.crypto("could not parse client key PEM")
+        }
+        defer { EVP_PKEY_free(key) }
+        guard SSL_CTX_use_PrivateKey(ctx, key) == 1 else {
+            throw StreamError.crypto("SSL_CTX_use_PrivateKey failed")
+        }
+        guard SSL_CTX_check_private_key(ctx) == 1 else {
+            throw StreamError.crypto("client cert/key mismatch")
+        }
+    }
+
+    // MARK: - PEM <-> OpenSSL helpers
+
+    private static func x509(fromPEM pem: String) -> OpaquePointer? {
+        Array(pem.utf8).withUnsafeBytes { raw -> OpaquePointer? in
+            guard let bio = BIO_new_mem_buf(raw.baseAddress, Int32(raw.count)) else { return nil }
+            defer { BIO_free(bio) }
+            return PEM_read_bio_X509(bio, nil, nil, nil)
+        }
+    }
+
+    private static func pkey(fromPEM pem: String) -> OpaquePointer? {
+        Array(pem.utf8).withUnsafeBytes { raw -> OpaquePointer? in
+            guard let bio = BIO_new_mem_buf(raw.baseAddress, Int32(raw.count)) else { return nil }
+            defer { BIO_free(bio) }
+            return PEM_read_bio_PrivateKey(bio, nil, nil, nil)
+        }
+    }
+
+    // MARK: - Socket / TLS IO
+
+    private static func writeAll(fd: Int32, ssl: OpaquePointer?, _ bytes: [UInt8]) throws {
+        var sent = 0
+        try bytes.withUnsafeBytes { raw in
+            let base = raw.baseAddress!
+            while sent < bytes.count {
+                let n: Int
+                if let ssl {
+                    n = Int(SSL_write(ssl, base + sent, Int32(bytes.count - sent)))
+                } else {
+                    n = write(fd, base + sent, bytes.count - sent)
+                }
+                guard n > 0 else { throw StreamError.hostUnreachable("control write failed") }
+                sent += n
+            }
+        }
+    }
+
+    /// Read until the peer closes (we send `Connection: close`) or `Content-Length`
+    /// bytes of body have arrived. The socket's SO_RCVTIMEO bounds a stuck read.
+    private static func readAll(fd: Int32, ssl: OpaquePointer?) throws -> Data {
+        var data = Data()
+        var buf = [UInt8](repeating: 0, count: 16 * 1024)
+        var contentLength: Int?
+        var headerEnd: Int?
+        while true {
+            let n: Int = buf.withUnsafeMutableBytes { raw in
+                if let ssl { return Int(SSL_read(ssl, raw.baseAddress, Int32(raw.count))) }
+                return read(fd, raw.baseAddress, raw.count)
+            }
+            if n <= 0 { break }   // clean close, EOF, or recv timeout
+            data.append(contentsOf: buf[0..<n])
+
+            // Once headers are complete, learn Content-Length so we can stop
+            // exactly at the body end instead of waiting on the close.
+            if headerEnd == nil, let r = data.range(of: Data("\r\n\r\n".utf8)) {
+                headerEnd = r.upperBound
+                let head = String(decoding: data[data.startIndex..<r.lowerBound], as: UTF8.self)
+                for line in head.split(separator: "\r\n") where line.lowercased().hasPrefix("content-length:") {
+                    contentLength = Int(line.split(separator: ":")[1].trimmingCharacters(in: .whitespaces))
+                }
+            }
+            if let headerEnd, let contentLength, data.count - headerEnd >= contentLength { break }
+        }
+        return data
+    }
+
+    // MARK: - HTTP/1.1 response parse
+
+    private static func parse(_ raw: Data) throws -> Response {
+        guard let sep = raw.range(of: Data("\r\n\r\n".utf8)) else {
+            throw StreamError.hostUnreachable("malformed HTTP response (no header terminator)")
+        }
+        let head = String(decoding: raw[raw.startIndex..<sep.lowerBound], as: UTF8.self)
+        guard let statusLine = head.split(separator: "\r\n").first else {
+            throw StreamError.hostUnreachable("empty HTTP response")
+        }
+        // "HTTP/1.1 200 OK" -> 200
+        let parts = statusLine.split(separator: " ")
+        guard parts.count >= 2, let status = Int(parts[1]) else {
+            throw StreamError.hostUnreachable("unparseable HTTP status line: \(statusLine)")
+        }
+        let body = Data(raw[sep.upperBound...])
+        return Response(status: status, body: body)
+    }
+}

--- a/Glimmer/Stream/Identity+Crypto.swift
+++ b/Glimmer/Stream/Identity+Crypto.swift
@@ -165,41 +165,17 @@ extension IdentityManager {
         return pem
     }
 
-    // MARK: - SecIdentity construction (one-time per process)
+    // MARK: - Legacy login-keychain cleanup
     //
-    // The SecIdentity for mutual-TLS comes from the file-store PEMs. We build
-    // it by feeding the PEMs through OpenSSL → PKCS#12 → SecPKCS12Import,
-    // grab the SecIdentityRef the import returns, and cache it for the
-    // lifetime of the process. The keychain item the import creates is
-    // pre-authorized for this process via SecAccess, deleted on the next
-    // launch, and re-imported fresh. That's the only documented way for an
-    // adhoc-signed app to use a SecIdentity without prompting the user; once
-    // we ship a real Developer ID, this whole path collapses into a single
-    // SecItemCopyMatching on the data-protection keychain (see the
-    // "Future: when signed with a Developer ID" note at the top of the file).
+    // Pre-OpenSSL builds laundered the client cert/key through a SecIdentity in
+    // the login keychain. The control channel now runs on OpenSSL straight from
+    // the PEMs, so that item is dead weight - preflight() deletes it on launch.
 
     private static let dpLabel = "Glimmer Client Identity"
 
-    func buildOrLoadIdentity() throws -> SecIdentity {
-        // We deliberately do NOT reuse the existing labelled identity from a
-        // prior launch. Its ACL is pinned (via SecTrustedApplication) to the
-        // Glimmer executable's CDHash at the time of import - which means
-        // every rebuild during development (and every signed app-update for
-        // shipped users without a stable Developer ID) invalidates the ACL,
-        // making the "Glimmer wants to use the key" prompt fire.
-        //
-        // Re-importing on every launch costs a few ms of OpenSSL work and a
-        // round-trip through Security.framework. The benefit is that the new
-        // SecAccess is built from the current process's SecTrustedApplication,
-        // so the ACL always matches the running binary and there's no prompt.
-        deleteLabelledIdentity()
-        let identity = try load()
-        return try importLabelledIdentity(certPEM: identity.certPEM,
-                                          keyPEM: identity.keyPEM)
-    }
-
-    /// Wipe any previous "Glimmer Client Identity" entry (and its associated
-    /// cert / key) so the re-import lands cleanly without colliding.
+    /// Delete the orphaned "Glimmer Client Identity" item (+ its cert/key) that
+    /// older builds imported into the login keychain. Idempotent; SecItemDelete
+    /// on absent items is a harmless no-op.
     func deleteLabelledIdentity() {
         for cls in [kSecClassIdentity, kSecClassKey, kSecClassCertificate] {
             let query: [String: Any] = [
@@ -209,101 +185,5 @@ extension IdentityManager {
             ]
             _ = SecItemDelete(query as CFDictionary)
         }
-    }
-
-    func importLabelledIdentity(certPEM: String, keyPEM: String) throws -> SecIdentity {
-        let pkcs12Pass = "glimmer-transient"
-        guard let p12 = makePKCS12(certPEM: certPEM, keyPEM: keyPEM, passphrase: pkcs12Pass) else {
-            throw StreamError.crypto("Failed to build PKCS#12 from client identity")
-        }
-
-        // Pre-authorize Glimmer via SecAccess so the import into login keychain
-        // doesn't fire the "Glimmer wants to sign using key" prompt. SecAccess
-        // is deprecated (the data-protection keychain replaces it, but
-        // requires entitlements adhoc-signed apps can't claim), but the API
-        // still works on macOS 26 and is the only documented way to silently
-        // authorize a non-entitled app to use a keychain item.
-        var glimmerApp: SecTrustedApplication?
-        var status = SecTrustedApplicationCreateFromPath(nil, &glimmerApp)
-        guard status == errSecSuccess, let glimmerApp else {
-            throw StreamError.crypto("SecTrustedApplicationCreateFromPath failed (\(status))")
-        }
-        let trustedApps: [SecTrustedApplication] = [glimmerApp]
-        var access: SecAccess?
-        status = SecAccessCreate(Self.dpLabel as CFString, trustedApps as CFArray, &access)
-        guard status == errSecSuccess, let access else {
-            throw StreamError.crypto("SecAccessCreate failed (\(status))")
-        }
-
-        let options: [String: Any] = [
-            kSecImportExportPassphrase as String: pkcs12Pass,
-            kSecImportExportAccess as String: access
-        ]
-        var rawItems: CFArray?
-        let importStatus = SecPKCS12Import(p12 as CFData, options as CFDictionary, &rawItems)
-        guard importStatus == errSecSuccess,
-              let items = rawItems as? [[String: Any]],
-              let first = items.first,
-              let identityAny = first[kSecImportItemIdentity as String] else {
-            throw StreamError.crypto("SecPKCS12Import failed (OSStatus \(importStatus))")
-        }
-        // The CF type for kSecImportItemIdentity is documented as SecIdentityRef,
-        // but defend against keychain misbehaviour with a typeID check before
-        // casting - an unexpected value throws a crypto error rather than
-        // trapping. Past the check, unsafeDowncast is the established idiom for
-        // a typeID-verified CF cast (mirrors the CGColorSpace casts in
-        // VideoDecoder+HDR) and avoids a force-cast.
-        let identityRef = identityAny as CFTypeRef
-        guard CFGetTypeID(identityRef) == SecIdentityGetTypeID() else {
-            throw StreamError.crypto("SecPKCS12Import returned a non-identity (typeID \(CFGetTypeID(identityRef)))")
-        }
-        let identity = unsafeDowncast(identityRef, to: SecIdentity.self)
-
-        // Label the imported items so we can find them on the next launch
-        // (and so they show up as something human-readable in Keychain Access
-        // rather than the default "Imported Private Key").
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassIdentity,
-            kSecValueRef as String: identity,
-            kSecAttrLabel as String: Self.dpLabel
-        ]
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
-            log.error("SecItemAdd for labelled identity failed: \(addStatus, privacy: .public) (continuing - identity still usable)")
-        }
-
-        log.info("Imported SecIdentity from file-store PEMs (pre-authorized for current binary, no prompt)")
-        return identity
-    }
-
-    /// Re-implemented here so we don't depend on Network.swift's private
-    /// helpers. Same OpenSSL dance: build PKCS#12 from PEM.
-    func makePKCS12(certPEM: String, keyPEM: String, passphrase: String) -> Data? {
-        guard let certBio = certPEM.withCString({ BIO_new_mem_buf($0, -1) }) else { return nil }
-        defer { BIO_free(certBio) }
-        guard let cert = PEM_read_bio_X509(certBio, nil, nil, nil) else { return nil }
-        defer { X509_free(cert) }
-
-        guard let keyBio = keyPEM.withCString({ BIO_new_mem_buf($0, -1) }) else { return nil }
-        defer { BIO_free(keyBio) }
-        guard let pkey = PEM_read_bio_PrivateKey(keyBio, nil, nil, nil) else { return nil }
-        defer { EVP_PKEY_free(pkey) }
-
-        let name = "Glimmer Client Identity"
-        guard let p12 = name.withCString({ namePtr in
-            passphrase.withCString { passPtr in
-                PKCS12_create(passPtr, namePtr, pkey, cert, nil, 0, 0, 0, 0, 0)
-            }
-        }) else { return nil }
-        defer { PKCS12_free(p12) }
-
-        guard let outBio = BIO_new(BIO_s_mem()) else { return nil }
-        defer { BIO_free(outBio) }
-        guard i2d_PKCS12_bio(outBio, p12) == 1 else { return nil }
-
-        var ptr: UnsafeMutablePointer<CChar>?
-        let len = gl_bio_get_mem_data(outBio, &ptr)
-        guard len > 0, let ptr else { return nil }
-        return Data(bytes: ptr, count: Int(len))
     }
 }

--- a/Glimmer/Stream/Identity.swift
+++ b/Glimmer/Stream/Identity.swift
@@ -53,21 +53,6 @@ import Foundation
 import os.log
 import Security
 
-// MARK: - Sendable bridge for Security-framework CF types
-//
-// SecIdentity / SecCertificate / SecKey are CoreFoundation reference types
-// (SecIdentityRef etc). Apple documents the Security framework's object types
-// as thread-safe for retain/release, and the values themselves are immutable
-// once created - so they're effectively `Sendable`. The SDK headers do not
-// (yet) declare the conformance, so we add it retroactively. The
-// `@retroactive` attribute makes the intent explicit to readers and silences
-// the Swift 6 warning about adopting a protocol the type's owner did not
-// declare.
-extension SecIdentity: @retroactive @unchecked Sendable {}
-extension SecCertificate: @retroactive @unchecked Sendable {}
-extension SecKey: @retroactive @unchecked Sendable {}
-extension SecTrust: @retroactive @unchecked Sendable {}
-
 // MARK: - Storage keys
 //
 // These string literals match QSettings keys written by moonlight-qt. Keeping
@@ -205,7 +190,6 @@ public actor IdentityManager {
     }
 
     var cached: Identity?
-    var cachedIdentity: SecIdentity?    // built once, reused for life of process
 
     let log = Logger(subsystem: "io.ugfugl.Glimmer",
                              category: "Stream.Identity")
@@ -226,52 +210,15 @@ public actor IdentityManager {
         try load().uniqueID
     }
 
-    /// Returns the SecIdentity used for mutual TLS client authentication.
-    ///
-    /// Built once per process from the PEMs returned by `load()` and cached
-    /// for subsequent calls. The PEM source (file store today, keychain on
-    /// signed builds in the future) is transparent to this layer.
-    public func secIdentity() throws -> SecIdentity {
-        if let cachedIdentity, Self.canSign(cachedIdentity) { return cachedIdentity }
-        // No cache yet, OR the cached identity's key can't sign anymore because
-        // the login keychain (where SecPKCS12Import lands it) locked on sleep /
-        // idle. Re-import from the PEMs - the keychain is unlocked whenever the
-        // user is actively here to start a stream. Without this, a locked keychain
-        // fails the mutual-TLS handshake and the failure is misreported downstream
-        // as "host doesn't recognize this Mac" until the app is restarted.
-        cachedIdentity = nil
-        let id = try buildOrLoadIdentity()
-        cachedIdentity = id
-        return id
-    }
-
-    /// True if `identity`'s private key can sign right now - i.e. its keychain is
-    /// unlocked and we're authorized. Probes with keychain UI suppressed so a
-    /// locked keychain reports false (→ re-import) instead of throwing a password
-    /// prompt. The signature itself is thrown away.
-    private static func canSign(_ identity: SecIdentity) -> Bool {
-        var key: SecKey?
-        guard SecIdentityCopyPrivateKey(identity, &key) == errSecSuccess, let key else { return false }
-        SecKeychainSetUserInteractionAllowed(false)
-        defer { SecKeychainSetUserInteractionAllowed(true) }
-        var error: Unmanaged<CFError>?
-        let sig = SecKeyCreateSignature(key, .rsaSignatureDigestPKCS1v15SHA256,
-                                        Data(repeating: 0, count: 32) as CFData, &error)
-        error?.release()
-        return sig != nil
-    }
-
     /// Bootstrap step - call this early (from MoonlightManager.bootstrap()) so
     /// the identity setup happens during launch, not on the user's first
     /// stream click. Idempotent.
     public func preflight() async {
         cleanupOrphanLoginKeychainEntries()
-        do {
-            _ = try secIdentity()
-            log.info("Client SecIdentity ready")
-        } catch {
-            log.error("Failed to prepare client SecIdentity: \(String(describing: error), privacy: .public)")
-        }
+        // Remove the now-orphaned "Glimmer Client Identity" item that pre-OpenSSL
+        // builds imported into the login keychain - the control channel no longer
+        // uses a SecIdentity, so nothing of ours should linger there.
+        deleteLabelledIdentity()
         // SECURITY (#5): for users whose moonlight-qt migration already ran
         // in a pre-#5 build, the source plist still has the PEM material
         // even though we've long since stopped reading from it. Do a

--- a/Glimmer/Stream/Network+Support.swift
+++ b/Glimmer/Stream/Network+Support.swift
@@ -2,13 +2,11 @@
 //  Network+Support.swift
 //
 //  Supporting types for NetworkClient: the optional-knobs extension on
-//  StreamConfig, the URLSession TLS delegate (client credential + server-cert
-//  pinning), and the SAX XML tree builder. Split out of Network.swift to keep
+//  StreamConfig and the SAX XML tree builder. Split out of Network.swift to keep
 //  each unit focused.
 //
 
 import Foundation
-import Network
 import os.log
 
 // MARK: - Optional knobs on StreamConfig
@@ -26,128 +24,6 @@ extension StreamConfig {
     var remoteInputKey: Data? { nil }
     /// Optional override for the AES IV used on the remote-input channel.
     var remoteInputIV: Data? { nil }
-}
-
-// MARK: - URLSession TLS delegate
-//
-// All of this runs on URLSession's delegate queue - synchronous, non-actor
-// context. The delegate is a class (URLSessionDelegate requires it) and
-// stores its credentials behind a small lock. We can't make it an actor
-// because URLSession won't await us.
-
-final class TLSDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
-
-    private let lock = NSLock()
-    private var clientCredential: URLCredential?
-    private var pinnedServerCert: SecCertificate?
-    private var lastServerCert: SecCertificate?
-
-    private let log = Logger(subsystem: "io.ugfugl.Glimmer",
-                             category: "Stream.Network.TLS")
-
-    func setClientCredential(_ credential: URLCredential) {
-        lock.lock(); defer { lock.unlock() }
-        clientCredential = credential
-    }
-
-    func setPinnedServerCert(_ cert: SecCertificate) {
-        lock.lock(); defer { lock.unlock() }
-        pinnedServerCert = cert
-    }
-
-    func lastSeenServerCert() -> SecCertificate? {
-        lock.lock(); defer { lock.unlock() }
-        return lastServerCert
-    }
-
-    // MARK: URLSessionDelegate
-
-    func urlSession(_ session: URLSession,
-                    didReceive challenge: URLAuthenticationChallenge,
-                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let space = challenge.protectionSpace
-
-        switch space.authenticationMethod {
-
-        case NSURLAuthenticationMethodClientCertificate:
-            // Host is asking us to prove who we are. Hand over the SecIdentity
-            // we built from IdentityManager. If it isn't ready yet (very
-            // first call before identity prep finished), drop to default -
-            // URLSession will cancel and we surface that as a TLS error.
-            lock.lock(); let cred = clientCredential; lock.unlock()
-            if let cred {
-                completionHandler(.useCredential, cred)
-            } else {
-                log.warning("Client-cert challenge with no credential available")
-                completionHandler(.performDefaultHandling, nil)
-            }
-
-        case NSURLAuthenticationMethodServerTrust:
-            // Threat model (C2):
-            //
-            //   - pin set, leaf matches:    accept, use credential.
-            //   - pin set, leaf mismatches: REFUSE. This is the MITM gate.
-            //     We do not log fingerprints at public privacy because that
-            //     would let a hostile log scraper read the pinned cert; but
-            //     we do log the mismatch so a real cert rotation is
-            //     diagnosable from `log show` under our subsystem.
-            //   - pin set, no leaf in chain: refuse - handshake is too
-            //     broken to evaluate. Better to fail than to fall through
-            //     to "accept blindly".
-            //   - no pin set, leaf present: this is the unpaired first-
-            //     contact path. Sunshine over HTTPS during /pair is the
-            //     only path that hits this. We record the leaf so the
-            //     actor can pin it after the RSA-validated pairing
-            //     handshake - but we DO NOT auto-pin here.
-            guard let trust = space.serverTrust else {
-                completionHandler(.cancelAuthenticationChallenge, nil)
-                return
-            }
-
-            let leaf: SecCertificate? = {
-                if #available(macOS 12.0, *) {
-                    return (SecTrustCopyCertificateChain(trust) as? [SecCertificate])?.first
-                } else {
-                    return SecTrustGetCertificateAtIndex(trust, 0)
-                }
-            }()
-
-            if let leaf {
-                lock.lock(); lastServerCert = leaf; lock.unlock()
-            }
-
-            lock.lock(); let pin = pinnedServerCert; lock.unlock()
-
-            if let pin {
-                // Pin set - only accept exact match.
-                guard let leaf else {
-                    log.error("Pinned host returned no leaf cert in chain - refusing")
-                    completionHandler(.cancelAuthenticationChallenge, nil)
-                    return
-                }
-                let pinData = SecCertificateCopyData(pin) as Data
-                let leafData = SecCertificateCopyData(leaf) as Data
-                if pinData == leafData {
-                    completionHandler(.useCredential, URLCredential(trust: trust))
-                } else {
-                    log.error("Pinned cert mismatch - refusing TLS handshake (possible MITM or host re-imaged)")
-                    completionHandler(.cancelAuthenticationChallenge, nil)
-                }
-            } else {
-                // No pin yet. This is reachable only on the unpaired
-                // discovery path (Pairing.swift's HTTPS pairchallenge
-                // round-trip after the symmetric handshake). The cert is
-                // recorded into `lastServerCert` but not yet binding;
-                // the actor pins it only after the RSA signature in
-                // pairing verifies, which is what gives "this is the real
-                // host" its meaning.
-                completionHandler(.useCredential, URLCredential(trust: trust))
-            }
-
-        default:
-            completionHandler(.performDefaultHandling, nil)
-        }
-    }
 }
 
 // MARK: - XML parser

--- a/Glimmer/Stream/Network.swift
+++ b/Glimmer/Stream/Network.swift
@@ -18,8 +18,9 @@
 //  Ported from moonlight-qt's app/backend/nvhttp.{h,cpp} (GPLv3; see CREDITS.md).
 //  The big differences from the C++ side:
 //
-//    * URLSession instead of QNetworkAccessManager. Means we do the TLS
-//      identity dance through URLSessionDelegate, not QSslConfiguration.
+//    * Our own OpenSSL mutual-TLS HTTP client (ControlTransport) instead of
+//      QNetworkAccessManager - the client cert + host-cert pin run straight
+//      through libssl, no URLSession and no keychain in the path.
 //    * Trust-on-first-use: the very first /serverinfo call goes over plain
 //      HTTP, pulls the host cert out of the response (well - out of the next
 //      HTTPS handshake), pins it, and from then on we refuse to talk HTTPS to
@@ -29,7 +30,8 @@
 //    * XMLParser-driven tree builder instead of QXmlStreamReader's pull API.
 //
 //  This file is concurrency-strict. `NetworkClient` is an actor, so all its
-//  state is isolated; URLSession callbacks bridge back via continuations.
+//  state is isolated; the transport's blocking IO runs off-actor and bridges
+//  back via continuations.
 //
 
 import Foundation
@@ -257,10 +259,10 @@ public actor NetworkClient {
     /// successful HTTPS handshake.
     var server: ServerInfo
 
-    /// Snapshot of the client identity grabbed at init time. We can't reach
-    /// into IdentityManager from a URLSessionDelegate callback (sync, non-async
-    /// context), so we cache the PEM blobs here and convert to a SecIdentity
-    /// lazily on first HTTPS call.
+    /// Client cert + key (PEM), snapshotted from IdentityManager on first use.
+    /// ControlTransport feeds them straight into OpenSSL for mutual TLS - no
+    /// SecIdentity, no keychain. The host-cert pin lives on `server.serverCertPEM`
+    /// and is passed per request.
     var clientCertPEM: String?
     var clientKeyPEM: String?
 
@@ -269,23 +271,6 @@ public actor NetworkClient {
     /// the comment above `Self.wireUniqueID`.
     var clientUniqueID: String?
 
-    /// Lazily-built TLS identity for mutual auth on HTTPS. Built once, reused
-    /// for every HTTPS request. `nil` until prepareIdentity() runs.
-    var clientIdentity: SecIdentity?
-
-    /// The host cert we trust for HTTPS (TOFU). Populated either from a prior
-    /// pairing run (server.serverCertPEM) or by extracting whatever cert the
-    /// host presents on the first HTTPS handshake after we've started trusting
-    /// it. Once set, ANY mismatch fails the connection.
-    var pinnedHostCert: SecCertificate?
-
-    /// URLSession + its delegate. Held as instance state so we can share a
-    /// connection pool across requests. The delegate is a class because that's
-    /// what URLSession requires; it's `Sendable` because it's stateless past
-    /// init - every callback reads the credential from immutable storage.
-    let session: URLSession
-    let delegate: TLSDelegate
-
     let log = Logger(subsystem: "io.ugfugl.Glimmer",
                              category: "Stream.Network")
 
@@ -293,66 +278,25 @@ public actor NetworkClient {
 
     public init(server: ServerInfo) {
         self.server = server
-
-        // Pre-seed the pinned cert from any previously persisted PEM. This is
-        // what makes "I paired with this host yesterday" survive an app
-        // restart - the caller pulled the PEM from disk and stuffed it onto
-        // ServerInfo before constructing us.
-        if let pem = server.serverCertPEM,
-           let cert = Self.parsePEMCertificate(pem) {
-            self.pinnedHostCert = cert
-        }
-
-        let delegate = TLSDelegate()
-        self.delegate = delegate
-        if let pinned = pinnedHostCert {
-            delegate.setPinnedServerCert(pinned)
-        }
-
-        // Per-host config: GFE 3.20+ misbehaves with HTTP/2 + persistent
-        // connections (moonlight-qt has the same workaround). HTTP/2 is off by
-        // default for ephemeral sessions on macOS, and pipelining was removed
-        // entirely from URLSession in macOS 15.4. We don't try to re-enable
-        // either.
-        let config = URLSessionConfiguration.ephemeral
-        config.httpMaximumConnectionsPerHost = 2
-        config.httpAdditionalHeaders = [:]
-        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        config.urlCache = nil
-        config.timeoutIntervalForRequest = 20
-        config.timeoutIntervalForResource = 30
-
-        self.session = URLSession(configuration: config,
-                                  delegate: delegate,
-                                  delegateQueue: nil)
+        // The host-cert pin (if any) rides on `server.serverCertPEM` already;
+        // ControlTransport reads it per request. Nothing else to set up - the
+        // control channel is connectionless from this object's point of view.
     }
 
-    /// Drain any pending requests on the underlying URLSession. Safe to call
-    /// from a deinit-like sequence; we don't expose deinit because URLSession
-    /// itself owns a strong reference back to the delegate until invalidated.
-    public func shutdown() {
-        session.invalidateAndCancel()
-    }
+    /// No-op: the control channel is per-request (ControlTransport opens and
+    /// closes a connection per call), so there's nothing persistent to tear
+    /// down. Kept only so the existing `await net.shutdown()` call sites don't churn.
+    public func shutdown() {}
 
-    /// Called by `PairingClient` once the host has proven possession of
-    /// its private key (the RSA-signature step in /pair's pairingsecret
-    /// round-trip). Any cert installed via this entry point is treated as
-    /// fully validated and is what subsequent HTTPS connections must
-    /// match. This is the ONE write path for the pin - `fetchServerInfo`
-    /// no longer auto-pins.
-    ///
-    /// Returns the parsed SecCertificate so the caller can also persist
-    /// the PEM to durable storage (UserDefaults under
-    /// `glimmer.pinnedCert.<hostUUID>` is the suggested key shape).
-    public func setPinnedHostCert(pem: String) throws -> SecCertificate {
-        guard let parsed = Self.parsePEMCertificate(pem) else {
-            throw StreamError.crypto("Failed to parse host cert PEM during pin install")
-        }
-        pinnedHostCert = parsed
+    /// Called by `PairingClient` once the host has proven possession of its
+    /// private key (the RSA-signature step in /pair's pairingsecret round-trip).
+    /// The cert installed here is fully validated and is what subsequent HTTPS
+    /// connections must match - ControlTransport pins `server.serverCertPEM` by
+    /// exact DER. This is the ONE write path for the pin - `fetchServerInfo` no
+    /// longer auto-pins.
+    public func setPinnedHostCert(pem: String) {
         server.serverCertPEM = pem
-        delegate.setPinnedServerCert(parsed)
         log.info("Host cert pinned (length \(pem.count, privacy: .public) bytes)")
-        return parsed
     }
 
     /// Currently-pinned host cert in PEM form, if any. Useful for the UI
@@ -363,10 +307,8 @@ public actor NetworkClient {
 
     // MARK: Identity prep
     //
-    // Has to run before any HTTPS call. We snapshot the cert + key out of the
-    // IdentityManager actor and lazily build a SecIdentity (which Keychain
-    // Services needs us to construct via SecPKCS12Import) the first time
-    // anyone asks for HTTPS auth.
+    // Snapshot the client cert + key (PEM) out of the IdentityManager actor
+    // before any HTTPS call. ControlTransport feeds them straight into OpenSSL.
 
     func ensureIdentityLoaded() async throws {
         if clientCertPEM != nil { return }
@@ -374,59 +316,6 @@ public actor NetworkClient {
         clientCertPEM   = try await im.clientCertPEM()
         clientKeyPEM    = try await im.clientKeyPEM()
         clientUniqueID  = try await im.uniqueID()
-    }
-
-    func ensureClientIdentity() async throws -> SecIdentity {
-        try await ensureIdentityLoaded()
-        if let id = clientIdentity { return id }
-
-        // Identity setup happens at install time in IdentityManager - see
-        // IdentityManager.secIdentity(). It builds the SecIdentity inside
-        // Glimmer's own keychain so the user never sees a "wants to sign"
-        // prompt. We just borrow it here.
-        let id = try await IdentityManager.shared.secIdentity()
-        clientIdentity = id
-
-        // Push the credential through to the delegate so URLSession's
-        // synchronous challenge handler can serve it without re-entering the
-        // actor.
-        delegate.setClientCredential(URLCredential(identity: id,
-                                                   certificates: nil,
-                                                   persistence: .forSession))
-        return id
-    }
-
-    // MARK: - PEM/DER + Identity helpers
-
-    /// Parse a PEM "BEGIN CERTIFICATE" block into a SecCertificate. Returns
-    /// nil on any failure; callers treat "no pinned cert" the same as "first
-    /// connection".
-    static func parsePEMCertificate(_ pem: String) -> SecCertificate? {
-        guard let der = pemBody(pem, marker: "CERTIFICATE") else { return nil }
-        return SecCertificateCreateWithData(nil, der as CFData)
-    }
-
-    /// Export a SecCertificate back to PEM for persistence in ServerInfo.
-    static func exportPEM(_ cert: SecCertificate) -> String {
-        let der = SecCertificateCopyData(cert) as Data
-        let base64 = der.base64EncodedString(options: [.lineLength64Characters,
-                                                       .endLineWithLineFeed])
-        return "-----BEGIN CERTIFICATE-----\n\(base64)\n-----END CERTIFICATE-----\n"
-    }
-
-    /// Strip the PEM armor and base64-decode the body of the first matching
-    /// block. `marker` is "CERTIFICATE", "RSA PRIVATE KEY", etc.
-    static func pemBody(_ pem: String, marker: String) -> Data? {
-        let begin = "-----BEGIN \(marker)-----"
-        let end   = "-----END \(marker)-----"
-        guard let beginRange = pem.range(of: begin),
-              let endRange = pem.range(of: end, range: beginRange.upperBound..<pem.endIndex)
-        else { return nil }
-        let body = pem[beginRange.upperBound..<endRange.lowerBound]
-            .replacingOccurrences(of: "\r", with: "")
-            .replacingOccurrences(of: "\n", with: "")
-            .replacingOccurrences(of: " ", with: "")
-        return Data(base64Encoded: body)
     }
 
     /// Flatten the immediate-child element names + brief text of an XML node
@@ -467,28 +356,10 @@ public actor NetworkClient {
     // names AND XML tag names (the host echoes some of them back).
 
     /// Lowercased query/tag names whose values must be redacted before
-    /// logging. Used by `redactedURL`, the query-dump in `runLaunchLike`,
-    /// and `dumpXMLRedacted`.
+    /// logging. Used by the query-dump in `runLaunchLike` and `dumpXMLRedacted`.
     static let sensitiveQueryKeys: Set<String> = [
         "rikey", "rikeyid", "gcmkey", "gcmkeyid", "uuid", "uniqueid"
     ]
-
-    /// Build a log-safe absolute-URL string. Host + path are preserved
-    /// (they're useful for debugging); query-string values matching
-    /// `sensitiveQueryKeys` are replaced with `<redacted>`. Returns
-    /// `<invalid-url>` on parse failure so the log line is never empty.
-    static func redactedURL(_ url: URL) -> String {
-        guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return "<invalid-url>"
-        }
-        comps.queryItems = comps.queryItems?.map { item in
-            if sensitiveQueryKeys.contains(item.name.lowercased()) {
-                return URLQueryItem(name: item.name, value: "<redacted>")
-            }
-            return item
-        }
-        return comps.string ?? "<invalid-url>"
-    }
 
     /// Same shape as `dumpXML`, but every child whose tag name matches
     /// `sensitiveQueryKeys` has its body replaced with `<redacted>` so

--- a/Glimmer/Stream/NetworkClient+Endpoints.swift
+++ b/Glimmer/Stream/NetworkClient+Endpoints.swift
@@ -42,7 +42,7 @@ extension NetworkClient {
 
         var xml: XMLNode
         var fetchedOverPaired = false   // implicit pair-proof: HTTPS succeeded
-        if pinnedHostCert != nil {
+        if server.serverCertPEM != nil {
             // Pinned. HTTPS only. Any TLS failure here is either a real
             // outage or a possible MITM - we don't try to disambiguate,
             // we just refuse and ask the user to re-pair if their host
@@ -181,7 +181,7 @@ extension NetworkClient {
         // We still expose the host cert opportunistically on ServerInfo so
         // a future "show fingerprint to user" UI has something to render -
         // but it does not become a pin until pairing succeeds.
-        if pinnedHostCert == nil {
+        if server.serverCertPEM == nil {
             if let pemFromXML = xml.string(forChild: "PlainCert"), !pemFromXML.isEmpty {
                 server.serverCertPEM = pemFromXML
             }

--- a/Glimmer/Stream/NetworkClient+Request.swift
+++ b/Glimmer/Stream/NetworkClient+Request.swift
@@ -41,7 +41,6 @@ extension NetworkClient {
                     timeout: TimeInterval) async throws -> XMLNode {
 
         try await ensureIdentityLoaded()
-        if usePaired { _ = try await ensureClientIdentity() }
 
         // IMPORTANT: GFE keys its per-session state on `uniqueid`. moonlight-qt
         // intentionally hard-codes "0123456789ABCDEF" so any moonlight client
@@ -51,102 +50,57 @@ extension NetworkClient {
         // still load the IdentityManager-generated client uniqueid in
         // ensureIdentityLoaded() because it's persisted for debugging /
         // forward-compat, but it must not be sent.
-        let uid = Self.wireUniqueID
-        let scheme = usePaired ? "https" : "http"
         let port = usePaired ? server.httpsPort : server.httpPort
 
+        // Build the request-URI (path + query). URLComponents does the percent-
+        // encoding; we extract just the origin-form target for the raw HTTP line.
         var components = URLComponents()
-        components.scheme = scheme
-        components.host = server.address
-        components.port = port
         components.path = "/" + path
-
         var items: [URLQueryItem] = [
-            URLQueryItem(name: "uniqueid", value: uid),
+            URLQueryItem(name: "uniqueid", value: Self.wireUniqueID),
             URLQueryItem(name: "uuid", value: Self.requestNonce())
         ]
         for (key, value) in query.sorted(by: { $0.key < $1.key }) {
             items.append(URLQueryItem(name: key, value: value))
         }
         components.queryItems = items
-
-        guard var url = components.url else {
-            throw StreamError.hostUnreachable("Failed to build URL for /\(path)")
+        guard let encodedQuery = components.percentEncodedQuery else {
+            throw StreamError.hostUnreachable("Failed to build query for /\(path)")
         }
-        // Append the launch-params tail literally - it carries its own
-        // pre-encoded form and percent-encoding it again would break it.
+        var target = "\(components.percentEncodedPath)?\(encodedQuery)"
+        // Append the launch-params tail literally - it carries its own pre-encoded
+        // form and percent-encoding it again would break it.
         if let extra = extraQuery, !extra.isEmpty {
-            let trimmed = extra.hasPrefix("&") ? extra : "&" + extra
-            if let appended = URL(string: url.absoluteString + trimmed) {
-                url = appended
-            }
+            target += extra.hasPrefix("&") ? extra : "&" + extra
         }
 
-        var req = URLRequest(url: url)
-        req.httpMethod = "GET"
-        req.timeoutInterval = timeout
-        // Belt + braces against any cached "Hey, you connected to this host
-        // five minutes ago, want to reuse?" behavior from URLSession.
-        req.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        // Match moonlight-qt's User-Agent so Sunshine's per-client capability
-        // gating doesn't refuse HDR or other features on an unknown UA. Qt's
-        // QNetworkAccessManager sends "Mozilla/5.0" by default; moonlight-qt
-        // doesn't override it, so the wire UA reads as Qt's stock string.
-        // Sunshine's HDR negotiation has at times refused unknown clients, so
-        // we put on the same hat.
-        req.setValue("Mozilla/5.0 (compatible; Moonlight/Glimmer)", forHTTPHeaderField: "User-Agent")
+        // SECURITY: log the path only - the query carries rikey/rikeyid/uuid
+        // (session AES key + nonce) that must never reach the unified log.
+        log.debug("GET /\(path, privacy: .public)")
 
-        // SECURITY: redact the URL before logging - query string may carry
-        // rikey/rikeyid/uuid/uniqueid (session AES key + per-request nonce)
-        // which must not appear in unified log even at .debug level.
-        log.debug("GET \(Self.redactedURL(url), privacy: .public)")
+        // Mutual-TLS HTTP over our own OpenSSL transport (no URLSession, no
+        // keychain). usePaired=true presents the client cert + pins the host cert
+        // by DER; usePaired=false is the plain-HTTP unpaired probe. The UA matches
+        // moonlight-qt so Sunshine's per-client feature gating (HDR etc.) doesn't
+        // refuse us as an unknown client.
+        let resp = try await ControlTransport.get(
+            host: server.address, port: port, target: target,
+            userAgent: "Mozilla/5.0 (compatible; Moonlight/Glimmer)",
+            tls: usePaired,
+            clientCertPEM: usePaired ? clientCertPEM : nil,
+            clientKeyPEM: usePaired ? clientKeyPEM : nil,
+            pinnedCertPEM: usePaired ? server.serverCertPEM : nil,
+            timeout: timeout)
 
-        let (data, response) = try await performRequest(req)
-
-        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-            // GameStream actually puts errors in the body XML and returns
-            // HTTP 200, so this only fires for transport-level breakage like
-            // a 401 from a misconfigured reverse proxy.
-            throw StreamError.launchFailed("HTTP \(http.statusCode) on /\(path)")
+        // GameStream puts protocol errors in the body XML with HTTP 200, so a
+        // non-2xx is transport-level breakage (e.g. a 401 from a reverse proxy).
+        if !(200...299).contains(resp.status) {
+            throw StreamError.launchFailed("HTTP \(resp.status) on /\(path)")
         }
-
         do {
-            return try XMLTreeBuilder.parse(data: data)
+            return try XMLTreeBuilder.parse(data: resp.body)
         } catch {
             throw StreamError.launchFailed("Malformed XML on /\(path): \(error)")
-        }
-    }
-
-    /// Bridges URLSession's data-task API into async/await with a real timeout.
-    /// We use `dataTask(with:completionHandler:)` rather than the async helper
-    /// so the URLSession delegate's TLS challenge runs on the session's own
-    /// queue - the async helper short-circuits some delegate callbacks on
-    /// older macOS releases.
-    func performRequest(_ req: URLRequest) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<(Data, URLResponse), Error>) in
-            let task = session.dataTask(with: req) { data, response, error in
-                if let error {
-                    let nserr = error as NSError
-                    switch nserr.code {
-                    case NSURLErrorTimedOut:
-                        cont.resume(throwing: StreamError.hostUnreachable("Request timed out"))
-                    case NSURLErrorServerCertificateUntrusted,
-                         NSURLErrorClientCertificateRejected,
-                         NSURLErrorClientCertificateRequired,
-                         NSURLErrorSecureConnectionFailed:
-                        cont.resume(throwing: StreamError.hostUnreachable("TLS handshake failed: \(nserr.localizedDescription)"))
-                    default:
-                        cont.resume(throwing: StreamError.hostUnreachable(nserr.localizedDescription))
-                    }
-                    return
-                }
-                guard let data, let response else {
-                    cont.resume(throwing: StreamError.hostUnreachable("Empty response"))
-                    return
-                }
-                cont.resume(returning: (data, response))
-            }
-            task.resume()
         }
     }
 

--- a/Glimmer/Stream/Pairing.swift
+++ b/Glimmer/Stream/Pairing.swift
@@ -235,7 +235,7 @@ public actor PairingClient {
         // auto-pins; the earlier behaviour (silent re-bind on TLS
         // error) is C2.
         // ---------------------------------------------------------------
-        _ = try await network.setPinnedHostCert(pem: serverCertPEM)
+        await network.setPinnedHostCert(pem: serverCertPEM)
 
         try await completeClientPairing(
             clientSecret: clientSecret,

--- a/Glimmer/Stream/StreamSession+Lifecycle.swift
+++ b/Glimmer/Stream/StreamSession+Lifecycle.swift
@@ -142,13 +142,8 @@ extension StreamSession {
         //    be unreachable here if the network just dropped.
         if let net = network {
             try? await net.cancel()
-            // Invalidate the per-session URLSession now that its last request
-            // (the /cancel above) has completed. URLSession retains its
-            // delegate - and its connection pool + dispatch queues - until
-            // explicitly invalidated, so just dropping the reference below
-            // leaked one ephemeral URLSession + TLSDelegate per session for
-            // process lifetime. Same contract HostStatusPoller already honors
-            // after every probe.
+            // shutdown() is a no-op now (the control channel is per-request) -
+            // kept for symmetry with the rest of the teardown.
             await net.shutdown()
         }
         network = nil

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -90,17 +90,12 @@ extension StreamSession {
         var serverInfo = server
         let network = NetworkClient(server: serverInfo)
         self.network = network
-        // Invalidate the per-session URLSession on any exit where stop() can't
-        // own it. URLSession retains its delegate (and connection pool +
-        // queues) until explicitly invalidated, so a pre-bridge throw - the
-        // serverinfo fetch, the pairing check, or launchWithBusyRecovery below
-        // - that just dropped the actor leaked one ephemeral URLSession +
-        // TLSDelegate PER ATTEMPT, including every error-banner Retry against
-        // a sleeping host. On the success path stop() owns the shutdown (and
-        // nils `network`, making the helper a no-op); on the startConnection-
-        // failure path stop() has already run inside connectBackend's catch,
-        // with the same result. shutdown() is invalidateAndCancel -
-        // idempotent, so the belt-and-braces overlap with stop() is harmless.
+        // Drop the orphaned NetworkClient on any exit where stop() can't own it
+        // (a pre-bridge throw from the serverinfo fetch, the pairing check, or
+        // launchWithBusyRecovery below). shutdown() is a no-op now - the control
+        // channel is per-request - so this is just lifecycle symmetry, and the
+        // belt-and-braces overlap with stop() on the success / backend-failure
+        // paths is harmless.
         defer { if !startHandedOff { shutdownOrphanedNetwork() } }
         serverInfo = try await network.fetchServerInfo()
         // swiftlint:disable:next line_length
@@ -243,8 +238,7 @@ extension StreamSession {
     /// NetworkClient is an actor and this helper runs from a synchronous
     /// `defer`, so the shutdown hops into a detached task. Fire-and-forget is
     /// correct: the client is ORPHANED (no consumer can reach it once the
-    /// field is nil'd synchronously below), and shutdown() only closes its
-    /// socket + invalidates its URLSession.
+    /// field is nil'd synchronously below), and shutdown() is a no-op now anyway.
     private func shutdownOrphanedNetwork() {
         guard let net = network else { return }
         network = nil

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.15
-CURRENT_PROJECT_VERSION = 20260626
+MARKETING_VERSION = 2026.6.16
+CURRENT_PROJECT_VERSION = 20260627


### PR DESCRIPTION
- **refactor: drop stale App-Sandbox references from comments and docs**
- **release: 2026.6.15 (self-heal client TLS identity after the login keychain locks)**
- **appcast: Glimmer 2026.6.15**
- **refactor(net): run the control channel on OpenSSL, delete the keychain/SecIdentity/URLSession layer**
- **release: 2026.6.16 (control channel on OpenSSL; no keychain)**
