### PR TITLE
ux hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026.6.17 - 2026-06-18
+
+Fixes visible frame-skipping on high-refresh displays. The present-pacing floor
+was re-pinning the display's refresh rate every couple of seconds to chase
+content cadence, and each renegotiation dropped a frame (reproducible on
+testufo.com/frameskipping). The floor now holds the requested refresh steady -
+skipping gone, and the top end is preserved (the panel max is still honored).
+
+Also in this release: audio drift is now corrected by a continuous resampler
+instead of the old silence-insertion stretch, so playback stays smoother under
+host/Mac clock skew; the launcher's primary button reads "Stream &lt;app&gt;"
+instead of the misleading "Resume &lt;app&gt;"; and the control channel is
+floored at TLS 1.2.
+
 ## 2026.6.16 - 2026-06-18
 
 Root-fixes the "host suddenly stops trusting this Mac after sleep" problem. The

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -285,7 +285,7 @@ private struct ConnectBanner: View {
                         moonlight.nativeStreamError = nil
                         // The hero verb's target, NOT streamDefaultApp(): the
                         // failed launch stamped lastPlayedApp at start, so the
-                        // hero above still reads "Resume <app>" - a Retry that
+                        // hero above still reads "Stream <app>" - a Retry that
                         // launched the default app would contradict it.
                         moonlight.streamHeroApp()
                     }

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -318,9 +318,9 @@ struct StreamButton: View {
     /// Four button states, depending on session lifecycle and selection:
     ///   * `.noPC`        - no host paired/selected. "Choose a PC"; tap is a
     ///                       no-op, the label tells the user what to do next.
-    ///   * `.connect`     - host selected, no stream yet. "Resume <app>" when
-    ///                       a resume target is known (host-reported session
-    ///                       or last-played), else "Connect". Tap launches.
+    ///   * `.connect`     - host selected, no stream yet. "Stream <app>" (the
+    ///                       resume target if known - host-reported session or
+    ///                       last-played - else the default app). Tap launches.
     ///   * `.connecting`  - handshake in flight. "Connecting to <Host>..." +
     ///                       stage subtext. Tap (or ⎋) CANCELS the attempt -
     ///                       a stuck connect must never strand the user.

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -95,10 +95,12 @@ extension MoonlightManager {
         resumableAppName ?? defaultAppName
     }
 
-    /// Primary-button copy: "Resume <app>" when a resume target exists,
-    /// plain "Connect" otherwise.
+    /// Primary-button copy. Always "Stream <app>" - this button only shows on the
+    /// launcher (never mid-stream), so "Resume" read as confusing. The verb is the
+    /// same whether we resume the host's running session or launch fresh;
+    /// `streamHeroApp()` still picks /resume vs /launch under the hood.
     var heroActionLabel: String {
-        resumableAppName.map { "Resume \($0)" } ?? "Connect"
+        "Stream \(heroTargetAppName)"
     }
 
     /// Launch the hero target (the primary click / Return-key action).
@@ -223,8 +225,8 @@ extension MoonlightManager {
         let cfg = nativeStreamConfig(for: host)
         let info = nativeServerInfo(for: host)
         // Hero-verb memory: stamp the app NAME at stream START (unlike the
-        // lastConnected DATE above) so the next launcher visit can offer
-        // "Resume <app>" even if this session ends badly.
+        // lastConnected DATE above) so the next launcher visit names the app in
+        // "Stream <app>" even if this session ends badly.
         UserDefaults.standard.set(app.name, forKey: Self.lastPlayedAppKey(for: host.id))
         // Arm the session-receipt latch with this session's identity (host +
         // requested mode). The live edge stamps the wall clock; the teardown

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -368,103 +368,50 @@ extension AudioDecoder {
     //  post-(re)prime grace belong to the under-run/rebuild machinery, which
     //  keeps sole custody of recovery there.
 
-    /// Accumulated UNREPAID drift (ms) before the micro-stretch arms. Low end
-    /// of the 30-50ms design window: at the measured 40ppm the first repayment
-    /// lands ~12min in, while the learned wired targets (40-60ms) keep the
-    /// cushion above empty until it does. Once armed, repayment tracks accrual
-    /// step-for-step, so the residual rides just inside the threshold.
-    static let driftStretchArmMs: Double = 30
-    /// One repayment quantum (ms) - exactly one packet, the same splice size
-    /// the steady-state trim already takes at a far higher allowed cadence.
-    static let driftStretchStepMs: Double = 5
-    /// Minimum spacing (ns) between stretches: bounds the worst case at one
-    /// packet per 30s (~167µs/s, +0.017% - far below audibility) even against
-    /// a haywire gauge; the measured 40ppm need is one per ~125s.
-    static let driftStretchMinIntervalNanos: UInt64 = 30_000_000_000
-
-    /// One micro-stretch check, on the decode path after each scheduled packet
-    /// (`stateLock` held by the caller - the schedule below stays serialized
-    /// against `shutdown()`: the completion-handler-vs-shutdown discipline).
-    /// Steady-state cost: one lock + a few compares; the clock read only runs
-    /// past the cheap gates while the fill is actually short. Inserts at most
-    /// ONE silence quantum, when ALL hold: primed and not draining/rebuilding
-    /// (the distress disarms), fill a full step short of target
-    /// (corroboration), rate-limit clear, and the segment's unrepaid drift
-    /// past the arm threshold (the long-window key).
-    func driftMicroStretch(format: AVAudioFormat) {
-        audioMeterLock.lock()
-        guard primed, playoutStarted, !playoutDrained, driftAnchorNanos != 0,
-              meterSampleRate > 0 else {
-            audioMeterLock.unlock()
-            return
-        }
-        let rate = meterSampleRate
-        let aheadFrames = framesScheduled &- framesPlayed
-        let fillMs = Double(aheadFrames) / rate * 1000.0
-        // Corroboration gate - and the insert cap: fill ≤ target − step keeps
-        // post-insert fill ≤ target, a full hysteresis band below the trim, so
-        // a stretch can never feed the very trim that would undo it.
-        guard fillMs <= playoutTargetMs - Self.driftStretchStepMs else {
-            audioMeterLock.unlock()
-            return
-        }
+    /// Drift-tracking resampler PI loop. Called ~per decoded packet from
+    /// `publishAudioState`; self-rate-limits to ~4Hz (drift is ppm-slow). When
+    /// `engaged` (steady playout - `primed && !playoutDrained`) it steers the
+    /// varispeed rate by the buffer-fill error: the INTEGRAL absorbs the steady
+    /// host↔Mac clock offset (its whole job), the PROPORTIONAL answers transient
+    /// fill excursions, both slew-limited so the rate (hence pitch) never steps
+    /// audibly. When NOT engaged (pre-roll / re-prime / drain) it forgets the
+    /// estimate and slews back to rate 1.0 so a resumed segment starts neutral -
+    /// the under-run + rebuild machinery owns recovery there. Single caller, so the
+    /// resampler state needs no lock.
+    func driveResampler(fillMs: Double, targetMs: Double, engaged: Bool) {
+        // Self-rate-limit to ~4Hz: publishAudioState fires per decoded packet
+        // (~200Hz) and drift is ppm-slow, so a fast loop only adds noise.
         let now = DispatchTime.now().uptimeNanoseconds
-        guard now >= gateGraceUntilNanos,
-              now &- lastDriftStretchNanos >= Self.driftStretchMinIntervalNanos,
-              now >= driftAnchorNanos, framesPlayed >= driftAnchorFramesPlayed else {
-            audioMeterLock.unlock()
-            return
-        }
-        // The same per-segment identity `publishAudioState` exports: wall
-        // elapsed − media played − standing fill = the segment's clock slip.
-        let wallMs = Double(now &- driftAnchorNanos) / 1_000_000.0
-        let mediaMs = Double(framesPlayed &- driftAnchorFramesPlayed) / rate * 1000.0
-        let driftMs = wallMs - mediaMs - fillMs
-        let unrepaidMs = driftMs + driftCompAppliedMs
-        guard unrepaidMs <= -Self.driftStretchArmMs else {
-            audioMeterLock.unlock()
-            return
-        }
-        // Claim the rate-limit slot before dropping the lock for the alloc -
-        // re-entry inside the window is then impossible however the alloc
-        // goes (a failed alloc simply retries a window later; self-healing,
-        // and the under-run machinery still backstops a drain meanwhile).
-        lastDriftStretchNanos = now
-        audioMeterLock.unlock()
+        guard now &- lastResamplerUpdateNanos >= Self.resamplerUpdateIntervalNanos else { return }
+        lastResamplerUpdateNanos = now
 
-        let frames = AVAudioFrameCount((Self.driftStretchStepMs / 1000.0) * format.sampleRate)
-        guard frames > 0,
-              let silence = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else { return }
-        silence.frameLength = frames
-        // Zero explicitly - AVAudioPCMBuffer does not guarantee zeroed memory,
-        // and "silence" must never be heap garbage (same rule as the backfill).
-        if let channels = silence.floatChannelData {
-            for channel in 0..<Int(format.channelCount) {
-                channels[channel].update(repeating: 0, count: Int(frames))
+        guard engaged else {
+            // Pre-roll / re-prime / drain: the under-run + rebuild machinery owns
+            // recovery. Forget the drift estimate and slew the rate back to 1.0 so
+            // a resumed segment starts neutral. (Slew, never snap - no pitch step.)
+            resamplerIntegralPpm = 0
+            if resamplerEpsPpm != 0 {
+                resamplerEpsPpm += max(-Self.resamplerSlewPpm,
+                                       min(Self.resamplerSlewPpm, -resamplerEpsPpm))
+                varispeed.rate = Float(1.0 + resamplerEpsPpm * 1e-6)
             }
+            return
         }
-        let stretchFrames = UInt64(frames)
-        audioMeterLock.lock()
-        framesScheduled &+= stretchFrames
-        // Resident silence for the av_skew correction (-= at completion): this
-        // stretch silence inflates buffer fill without advancing the audio RTP.
-        pendingSilenceFrames &+= stretchFrames
-        // Keep the drift gauge RAW (the backfill idiom): the silence is media
-        // the wall-time stream never delivered, so credit the segment's
-        // media-played reference - the gauge keeps showing the true skew slope
-        // (how later measurement verifies the skew is still there AND repaid),
-        // while the ledger carries what has been repaid so far.
-        driftAnchorFramesPlayed &+= stretchFrames
-        driftCompAppliedMs += Self.driftStretchStepMs
-        let appliedMs = driftCompAppliedMs
-        audioMeterLock.unlock()
-        playerNode.scheduleBuffer(silence) { [weak self] in
-            self?.meterCompleteOnePlayout(frames: stretchFrames, isSilence: true)
-        }
-        Diag.notice(
-            "audio drift micro-stretch +\(Int(Self.driftStretchStepMs))ms silence "
-            + "(\(Int(appliedMs.rounded()))ms repaid this segment) - segment clock skew "
-            + "\(Int(driftMs.rounded()))ms",
-            "Stream")
+        // Fill above the cushion setpoint ⇒ too much buffered ⇒ consume faster
+        // (rate > 1). The INTEGRAL absorbs the steady ppm clock offset (its whole
+        // job); the PROPORTIONAL term answers transient fill excursions. The
+        // deadband stops the integral accruing on sub-ms noise once converged.
+        let error = fillMs - targetMs
+        let e = abs(error) < Self.resamplerDeadbandMs ? 0 : error
+        resamplerIntegralPpm = clampResamplerPpm(resamplerIntegralPpm + Self.resamplerKiPpmPerMs * e)
+        let targetPpm = clampResamplerPpm(Self.resamplerKpPpmPerMs * e + resamplerIntegralPpm)
+        // Slew-limit the APPLIED offset so the rate (hence pitch) never steps.
+        resamplerEpsPpm += max(-Self.resamplerSlewPpm,
+                               min(Self.resamplerSlewPpm, targetPpm - resamplerEpsPpm))
+        varispeed.rate = Float(1.0 + resamplerEpsPpm * 1e-6)
+    }
+
+    private func clampResamplerPpm(_ v: Double) -> Double {
+        max(-Self.resamplerBoundPpm, min(Self.resamplerBoundPpm, v))
     }
 }

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -446,6 +446,9 @@ extension AudioDecoder {
         let stretchFrames = UInt64(frames)
         audioMeterLock.lock()
         framesScheduled &+= stretchFrames
+        // Resident silence for the av_skew correction (-= at completion): this
+        // stretch silence inflates buffer fill without advancing the audio RTP.
+        pendingSilenceFrames &+= stretchFrames
         // Keep the drift gauge RAW (the backfill idiom): the silence is media
         // the wall-time stream never delivered, so credit the segment's
         // media-played reference - the gauge keeps showing the true skew slope
@@ -456,7 +459,7 @@ extension AudioDecoder {
         let appliedMs = driftCompAppliedMs
         audioMeterLock.unlock()
         playerNode.scheduleBuffer(silence) { [weak self] in
-            self?.meterCompleteOnePlayout(frames: stretchFrames)
+            self?.meterCompleteOnePlayout(frames: stretchFrames, isSilence: true)
         }
         Diag.notice(
             "audio drift micro-stretch +\(Int(Self.driftStretchStepMs))ms silence "

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -269,6 +269,9 @@ extension AudioDecoder {
         let silenceFrames = UInt64(frames)
         audioMeterLock.lock()
         framesScheduled &+= silenceFrames
+        // Resident silence for the av_skew correction (-= at completion): this
+        // silence inflates buffer fill without advancing the audio RTP position.
+        pendingSilenceFrames &+= silenceFrames
         // Keep the drift gauge honest: the silence is media the wall-time stream
         // never delivered, so advance the segment's media-played reference by the
         // same amount - wall − media − fill stays an identity instead of stepping
@@ -284,7 +287,7 @@ extension AudioDecoder {
         // discipline): a completion in the sliver between sees fill briefly
         // overstated - harmless, and it can't mistake the moment for a drain.
         playerNode.scheduleBuffer(silence) { [weak self] in
-            self?.meterCompleteOnePlayout(frames: silenceFrames)
+            self?.meterCompleteOnePlayout(frames: silenceFrames, isSilence: true)
         }
         playerNode.play() // no-op mid-stream; keeps the prime edge uniform
         Diag.notice(
@@ -301,9 +304,14 @@ extension AudioDecoder {
     /// pause()/play() here would race teardown. The post-drain cushion rebuild
     /// belongs to the DECODE path - the catch-up clump under the gate grace, or
     /// the grace-expiry silence backfill - never this handler's.
-    func meterCompleteOnePlayout(frames: UInt64) {
+    func meterCompleteOnePlayout(frames: UInt64, isSilence: Bool = false) {
         audioMeterLock.lock()
         framesPlayed &+= frames
+        // A corrector-inserted silence buffer finished: release its resident
+        // contribution so the av_skew fill correction tracks only buffered silence.
+        if isSilence {
+            pendingSilenceFrames = pendingSilenceFrames >= frames ? pendingSilenceFrames &- frames : 0
+        }
         // The scheduled-ahead trough right at this completion - the truest low of the
         // backlog (a completion is exactly where the queue is shallowest). Fed to the
         // reset-on-read MIN-fill window below so the exporter can prove the cushion
@@ -424,6 +432,7 @@ extension AudioDecoder {
     func publishAudioState() {
         audioMeterLock.lock()
         let aheadFrames = framesScheduled &- framesPlayed
+        let residentSilenceFrames = pendingSilenceFrames
         let rate = meterSampleRate
         let started = playoutStarted
         let anchorNanos = driftAnchorNanos
@@ -442,6 +451,11 @@ extension AudioDecoder {
         audioMeterLock.unlock()
         if needsLinkResolve { resolveCushionLink() }
         guard rate > 0 else { return }
+        // Surface resident corrector-silence to the A/V-skew meter so it subtracts
+        // it from buffer fill: the silence is buffered media the audio RTP clock
+        // never advanced past, so counting it makes audio read falsely "late".
+        AudioVideoSkewStore.shared.setResidentSilenceMs(
+            Double(residentSilenceFrames) / rate * 1000.0)
 
         let bufferFillMs = Double(aheadFrames) / rate * 1000.0
         var driftMs: Double?

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -487,7 +487,10 @@ extension AudioDecoder {
                 // (`takeAudioBufferFillMinMs`), not this last-writer-wins gauge, so
                 // it isn't carried here; the exporter pulls it directly.
                 bufferFillMinMs: nil,
-                rePrimeTotal: rePrimes))
+                rePrimeTotal: rePrimes,
+                // The resampler's applied rate offset (read on this same ~4Hz single-
+                // caller path, no extra lock) - makes the loop visible vs av_skew noise.
+                resamplerPpm: resamplerEpsPpm))
     }
 
     // MARK: - Audio OUTPUT route (under-run attribution breadcrumbs)

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -128,10 +128,6 @@ extension AudioDecoder {
             playoutStarted = true
             driftAnchorNanos = DispatchTime.now().uptimeNanoseconds
             driftAnchorFramesPlayed = framesPlayed
-            // The micro-stretch repayment ledger is per-segment like the drift
-            // gauge it offsets (AudioDecoder+CushionMemory.swift) - fresh
-            // anchor, fresh ledger.
-            driftCompAppliedMs = 0
             // Arm the gate grace on this same edge (cold start or post-drain
             // restart): the next ~250ms of arrivals are the cushion (re)build - the
             // catch-up clump the link just proved it needs - so neither the trim nor
@@ -445,6 +441,10 @@ extension AudioDecoder {
         // target - without it a fill hugging a flat ceiling is indistinguishable
         // from the old disguised-permanent-give-up re-pin.
         let targetMs = playoutTargetMs
+        // Engage the drift resampler only in steady playout - the SAME gate the trim
+        // uses (Meter trim path). During pre-roll / re-prime / drain the rebuild
+        // machinery owns recovery and driveResampler slews the rate back to 1.0.
+        let resamplerEngaged = primed && !playoutDrained
         // One Bool under the lock already held: the cushion memory's one-shot
         // link resolve (the route probe feeds ~1-2s after audio bring-up).
         let needsLinkResolve = !cushionLinkResolved
@@ -458,6 +458,10 @@ extension AudioDecoder {
             Double(residentSilenceFrames) / rate * 1000.0)
 
         let bufferFillMs = Double(aheadFrames) / rate * 1000.0
+        // Drive the drift-tracking resampler (self-rate-limited to ~4Hz inside):
+        // steers the varispeed rate by the buffer-fill error to absorb the host↔Mac
+        // clock skew. Single caller, so the resampler state needs no lock.
+        driveResampler(fillMs: bufferFillMs, targetMs: targetMs, engaged: resamplerEngaged)
         var driftMs: Double?
         // Measure drift over the CURRENT playout segment only: wall and media-played
         // are both relative to the segment anchor (re-baselined on each restart),

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -57,6 +57,14 @@ public final class AudioDecoder: @unchecked Sendable {
     /// incremented in the scheduleBuffer completion handler (off-thread). The
     /// scheduled-ahead backlog = framesScheduled − framesPlayed.
     var framesPlayed: UInt64 = 0
+    /// Corrector-inserted silence frames currently RESIDENT in the buffer
+    /// (scheduled but not yet played): the running sum of micro-stretch + backfill
+    /// silence, += at each silence schedule and -= at each silence completion.
+    /// Subtracted from buffer fill before deriving `av_skew_ms` so the audio
+    /// playhead reflects REAL media - inserted silence inflates fill without
+    /// advancing the audio RTP position, which otherwise biases the skew toward
+    /// "audio late" by exactly the resident silence. Guarded by `audioMeterLock`.
+    var pendingSilenceFrames: UInt64 = 0
     /// Output sample rate (Hz) - set at init so the meter can convert frames↔ms.
     var meterSampleRate: Double = 48_000
     /// Wall-clock (`DispatchTime` ns) anchor for the audio-clock-drift metric: the

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -27,6 +27,13 @@ public final class AudioDecoder: @unchecked Sendable {
     private var decoder: OpaquePointer?            // OpusMSDecoder*
     private let engine = AVAudioEngine()
     let playerNode = AVAudioPlayerNode()
+    /// Drift-tracking resampler, inserted between `playerNode` and the mixer. A
+    /// slew-limited PI loop (`driveResampler`, driven ~1Hz from `publishAudioState`)
+    /// steers `rate = 1+ε` to hold buffer fill at the cushion setpoint, cancelling
+    /// the steady host↔Mac clock drift continuously - replacing the old
+    /// one-directional/clicky silence micro-stretch. ε is ppm-scale (the bound is
+    /// ±500ppm = ±0.5 cents, inaudible; the slew limit keeps the pitch from stepping).
+    let varispeed = AVAudioUnitVarispeed()
     private var inputFormat: AVAudioFormat?
     private var channelCount: Int = 2
     private var samplesPerFrame: Int = 240         // 5ms at 48kHz, common GFE/Sunshine config
@@ -85,15 +92,29 @@ public final class AudioDecoder: @unchecked Sendable {
     /// the current segment. Drift uses (framesPlayed − this) so a re-baseline after a
     /// drain doesn't double-count media already played in an earlier segment.
     var driftAnchorFramesPlayed: UInt64 = 0
-    /// Media (ms) the drift MICRO-STRETCH has inserted this playout segment to
-    /// repay measured clock skew (AudioDecoder+CushionMemory.swift). The drift
-    /// gauge stays RAW - each insert credits `driftAnchorFramesPlayed`, the
-    /// backfill idiom - so this ledger is what separates skew already repaid
-    /// from skew still standing. Reset wherever the drift anchor re-baselines.
-    var driftCompAppliedMs: Double = 0
-    /// `DispatchTime` ns of the last micro-stretch - its rate limit (the
-    /// haywire-gauge bound). Guarded by `audioMeterLock`. 0 = none yet.
-    var lastDriftStretchNanos: UInt64 = 0
+    /// Drift-resampler PI state (the loop lives in `driveResampler`,
+    /// AudioDecoder+CushionMemory.swift). `resamplerIntegralPpm` accumulates the
+    /// steady host↔Mac clock offset; the applied `resamplerEpsPpm` slews toward the
+    /// PI target so the varispeed rate never steps audibly. Touched only on the
+    /// ~1Hz `publishAudioState` cadence (single caller) so no lock; reset toward 0
+    /// whenever the loop disengages (pre-roll / re-prime / drain).
+    var resamplerIntegralPpm: Double = 0
+    var resamplerEpsPpm: Double = 0
+    /// `DispatchTime` ns of the last PI update - `publishAudioState` (hence
+    /// `driveResampler`) fires per decoded packet (~200Hz), so the loop rate-limits
+    /// itself to ~4Hz off this; drift is ppm-slow and a fast loop only adds noise.
+    var lastResamplerUpdateNanos: UInt64 = 0
+    /// Drift-resampler PI tuning. Conservative starting values: the SLEW limit and the
+    /// BOUND are the safety guards (the varispeed rate can never step audibly nor run
+    /// away), so the gains can be tuned up in an A/B with no warble risk. The drift to
+    /// correct is tens of ppm (host↔Mac clock offset), so ε settles ppm-scale ⇒ pitch
+    /// shift well under a cent.
+    static let resamplerUpdateIntervalNanos: UInt64 = 250_000_000  // ~4Hz; drift is ppm-slow
+    static let resamplerDeadbandMs = 1.0    // ignore sub-ms fill noise (integral anti-windup)
+    static let resamplerKpPpmPerMs = 3.0    // proportional: answers transient fill excursions
+    static let resamplerKiPpmPerMs = 0.03   // integral: absorbs the steady ppm clock offset
+    static let resamplerSlewPpm = 2.0       // max ppm change per update ⇒ rate never steps
+    static let resamplerBoundPpm = 500.0    // hard clamp ≫ any real drift (~1 cent worst case)
     /// Mirror of `isShutdown` in the METER lock's domain, raised by `shutdown()`
     /// BEFORE `playerNode.stop()`. Stopping a node with a standing cushion fires
     /// the completion handler of EVERY queued buffer (.dataConsumed semantics:
@@ -337,7 +358,7 @@ public final class AudioDecoder: @unchecked Sendable {
         meterSampleRate = Double(sampleRate)
         framesScheduled = 0; framesPlayed = 0
         driftAnchorNanos = 0; driftAnchorFramesPlayed = 0
-        driftCompAppliedMs = 0; lastDriftStretchNanos = 0
+        resamplerIntegralPpm = 0; resamplerEpsPpm = 0; varispeed.rate = 1.0
         playoutStarted = false; playoutDrained = false; meterShutdown = false
         // Cushion / pre-roll state for this session: start paused (no play() at
         // engine start), at the SEEDED adaptive target, re-prime count reset. (The
@@ -419,7 +440,14 @@ public final class AudioDecoder: @unchecked Sendable {
         inputFormat = fmt
 
         engine.attach(playerNode)
-        engine.connect(playerNode, to: engine.mainMixerNode, format: fmt)
+        engine.attach(varispeed)
+        // playerNode → varispeed → mixer. The varispeed resamples the player's
+        // output by `rate=1+ε` (driveResampler), pulling the player's buffers at
+        // the consumption rate - so completion timing (framesPlayed) still tracks
+        // real consumption and the input-frame fill/cushion math reads true (the
+        // ε factor on the frames→ms convert is ppm-negligible).
+        engine.connect(playerNode, to: varispeed, format: fmt)
+        engine.connect(varispeed, to: engine.mainMixerNode, format: fmt)
         do {
             // Start the engine but DO NOT `play()` the player node yet. Playback is
             // deferred until a `playoutTargetMs` cushion of decoded audio is queued
@@ -609,10 +637,8 @@ public final class AudioDecoder: @unchecked Sendable {
         // format, hence the parameter). No-op once primed, so this stays one lock
         // + a compare on the steady-state path.
         maybePrime(format: fmt)
-        // Deterministic clock-skew repayment (the measured −40ppm drain): DECODE
-        // path only - it schedules into the node, which must stay serialized
-        // against `shutdown()`. Design + gates: AudioDecoder+CushionMemory.swift.
-        driftMicroStretch(format: fmt)
+        // Drives the drift resampler's PI loop (self-rate-limited to ~4Hz) + the
+        // 1Hz audio-state gauge. The resampler replaced the decode-path micro-stretch.
         publishAudioState()
         return true
     }

--- a/Glimmer/Stream/CHelpers.h
+++ b/Glimmer/Stream/CHelpers.h
@@ -21,6 +21,7 @@
 #include <sys/uio.h>
 #include <openssl/bio.h>
 #include <openssl/pkcs12.h>
+#include <openssl/ssl.h>
 
 // MARK: - Batched UDP receive (recvmsg_x)
 // `recvmsg_x` is Darwin's batched datagram receive (the macOS analogue of
@@ -94,6 +95,15 @@ static inline int gl_surround_audio_info_from_audio_configuration(int x) {
 /// into `*out_data`. Equivalent to the `BIO_get_mem_data` macro.
 static inline long gl_bio_get_mem_data(BIO *bio, char **out_data) {
     return BIO_ctrl(bio, BIO_CTRL_INFO, 0, (char *)out_data);
+}
+
+// MARK: - TLS minimum-version floor (control channel)
+// SSL_CTX_set_min_proto_version is a macro, so Swift can't call it. Exact-DER
+// cert PINNING is the security guarantee (see ControlTransport); flooring at
+// TLS 1.2 just keeps the handshake off legacy protocol versions - cheap defense
+// in depth. Returns 1 on success.
+static inline int gl_ssl_ctx_set_min_tls12(SSL_CTX *ctx) {
+    return SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 }
 
 // MARK: - OpenSSL keygen wrapper

--- a/Glimmer/Stream/ControlTransport.swift
+++ b/Glimmer/Stream/ControlTransport.swift
@@ -87,6 +87,9 @@ enum ControlTransport {
             throw StreamError.crypto("SSL_CTX_new failed")
         }
         defer { SSL_CTX_free(ctx) }
+        // Floor the handshake at TLS 1.2 - the pin is the real guarantee, this just
+        // keeps us off legacy protocol versions. (Sunshine speaks 1.2/1.3.)
+        _ = gl_ssl_ctx_set_min_tls12(ctx)
         // We pin instead of CA-validating (the host cert is self-signed); do the
         // pin check by hand after the handshake. VERIFY_NONE keeps SSL_connect
         // from rejecting the self-signed leaf before we get to look at it.

--- a/Glimmer/Stream/FramePacer+FrameRateRange.swift
+++ b/Glimmer/Stream/FramePacer+FrameRateRange.swift
@@ -13,147 +13,65 @@ import AppKit
 import QuartzCore
 
 extension FramePacer {
-    /// Hz deadband before the present-callback floor is re-pinned from the
-    /// SMOOTHED refined cadence. Widened 5→8 after a wired-link run:
-    /// bimodal game content flipped the PTS-median floor 169.81↔175.27Hz
-    /// (5.46Hz apart - just past the old 5Hz band) at 12-28 re-pins/s for
-    /// ~68k log lines. 8Hz swallows that wobble class outright; a real fps
-    /// change (60→120, 240→60) still blows past it within a few ticks.
+    /// Hz deadband below which the floor is treated as already at the requested
+    /// rate. The floor is pinned to the FIXED configured fps and held, so a
+    /// steady stream never re-pins; this mainly guards the rare panel-max change
+    /// (a display switch) from a needless `preferredFrameRateRange` rewrite.
     static let frameRateReapplyHysteresisHz = 8.0
 
-    /// Per-tick EWMA coefficient for the refined-cadence smoother feeding the
-    /// floor re-pin. ~80ms time constant at 240Hz ticks (~170ms at 120):
-    /// layered UNDER the deadband, it averages bimodal cadence modes WIDER
-    /// than the deadband (game render-rate duty-cycling, e.g. 170↔186) into a
-    /// stable midpoint instead of flapping the floor between the extremes,
-    /// while a genuine fps change crosses the 8Hz deadband in tens of ms. The
-    /// due gate keeps pacing from the RAW median - only the advisory floor is
-    /// smoothed, so this can never delay or judder an actual present.
-    static let refinedFloorEwmaAlpha = 0.05
-
-    /// Minimum dwell between floor re-pins. Hard-caps `preferredFrameRateRange`
-    /// write churn at ≤0.5/s no matter what the estimator does (the same
-    /// once-per-MATERIAL-change medicine as the 959a574 screen-rebind gate,
-    /// one layer down). A re-pin deferred by the dwell lands when it expires
-    /// if the drift persists; a too-low floor in the meantime only permits
-    /// static-scene callback throttling for ≤2s (preferred=panelMax still
-    /// asks for the full grid), and a too-high floor stays ≤panelMax - both
-    /// harmless on any link, jittery or clean.
-    static let frameRateRePinMinDwellSeconds = 2.0
-
-    /// Canonical content cadences the Diag mirror rounds to before its dedupe
-    /// compare (on a wired-link run the PTS-median cadence legitimately
-    /// mode-hopped 66↔92↔144↔240Hz, so the EWMA was mid-transition at almost
-    /// every dwell expiry and the raw ≥8Hz compare passed nearly every re-pin -
-    /// 3,427 mirror lines = 91.5% of an otherwise 319-line session log).
-    /// Rounding collapses the EWMA's transit points onto the mode endpoints,
-    /// so the file logs once per CONTENT-MODE change instead of once per
-    /// dwell. Advisory-floor telemetry only - pacing never reads this.
-    static let contentModesHz: [Double] = [24, 30, 48, 60, 72, 90, 120, 144, 165, 240]
-
-    /// The nearest canonical content mode for a floor value (pass-through for
-    /// degenerate input). Pure + nonisolated so it's unit-checkable.
-    static func nearestContentModeHz(_ hz: Double) -> Double {
-        guard hz.isFinite, hz > 0 else { return hz }
-        return contentModesHz.min { abs($0 - hz) < abs($1 - hz) } ?? hz
-    }
-
-    /// Re-pin the CADisplayLink's `preferredFrameRateRange` floor (FIX #1) from
-    /// the PTS-refined stream cadence when the CLAMPED, SMOOTHED candidate has
-    /// drifted past `frameRateReapplyHysteresisHz` from the floor we last
-    /// applied. Called from the main-actor `handleTick`; the steady-state path
-    /// is pure arithmetic (no AppKit reads), so it stays free on every tick
-    /// where cadence is stable.
+    /// Hold the present-callback floor at the REQUESTED stream refresh - the same
+    /// `min(streamHz, panelMax)` that `installLink` pins - re-pinning only if the
+    /// panel max changes under us (a display switch that didn't route through
+    /// installLink). Called from the main-actor `handleTick`; the steady-state path
+    /// is a single pure-math compare (no AppKit read), free on every tick.
     ///
-    /// RE-PIN STORM FIX (a wired-link run: 97,772 re-pin lines = 78% of
-    /// the log - two distinct branches, two medicines):
-    ///  1. CLAMP-BEFORE-COMPARE: the old code compared the UNCLAMPED refined
-    ///     cadence against `appliedFloorHz`, but applied/stored floors are
-    ///     clamped to min(streamHz, panelMax). The PTS median legitimately
-    ///     overshoots true content rate on bursty bring-up arrival (read
-    ///     247.9-248.6Hz vs fps_received max 241), so whenever refined >
-    ///     panelMax + deadband the compare could NEVER settle → a re-pin every
-    ///     tick at exactly 240/s (29,132 lines, ~121 cumulative seconds of
-    ///     CADisplayLink range writes). Clamping the candidate FIRST makes the
-    ///     overshoot benign: 248 clamps to 240, equals the applied floor, done.
-    ///  2. EWMA + wider deadband + min-dwell for the bimodal-wobble churn (the
-    ///     other ~68k lines) - see the constants above.
-    ///
-    /// The due-gate cadence base is deliberately NOT touched on a re-pin: a
-    /// range write does not make the link's targetTimestamp timebase
-    /// discontinuous (the due gate's defensive clamp + starvation failsafe own
-    /// real discontinuities), and re-anchoring here would inject a forced
-    /// early release per re-pin - a periodic judder source on wobbly cadence.
+    /// FIDELITY (does NOT track content cadence): the old behavior re-pinned the
+    /// floor toward the measured PTS-refined cadence, so wobbly content (Desktop at
+    /// ~150fps straddling the 144/165 panel modes) fired a re-pin every dwell
+    /// (~0.5/s) - and every `preferredFrameRateRange` write makes the display
+    /// renegotiate its refresh rate, which drops a frame (the photographed TestUFO
+    /// frameskip gap). The requested refresh is fixed per session, so this re-pins
+    /// once (matching install) then early-returns. `preferred`/`maximum` stay at the
+    /// panel max - the top end is never given up; only the anti-throttle FLOOR is
+    /// held at the requested rate. `refinedIntervalSeconds` is now unused (the due
+    /// gate still paces from the raw median, untouched).
     @MainActor
     func reapplyPreferredRangeIfNeeded(refinedIntervalSeconds: Double) {
         guard let link = displayLink, let view = boundView else { return }
         // Item-9 'link installed' replay - one optional load + identity compare
         // per tick in the steady state; see the helper for the WHY.
         replayLinkInstalledBreadcrumbIfNeeded(link: link, view: view)
-        guard refinedIntervalSeconds.isFinite, refinedIntervalSeconds > 0 else { return }
-        let refinedFloorHz = 1.0 / refinedIntervalSeconds
-        refinedFloorEwmaHz = refinedFloorEwmaHz.isFinite
-            ? refinedFloorEwmaHz
-                + Self.refinedFloorEwmaAlpha * (refinedFloorHz - refinedFloorEwmaHz)
-            : refinedFloorHz
-        // Cheap pure-math pre-check first (no NSScreen read on the hot path):
-        // if even the UNCLAMPED smoothed cadence is inside the deadband of the
-        // applied floor, the clamped candidate is too (clamping only moves it
-        // closer to the applied, panel-clamped value).
+        let streamHz = configuredFrameIntervalSeconds > 0
+            ? 1.0 / configuredFrameIntervalSeconds : 0
+        guard streamHz > 0 else { return }
+        // Cheap pure-math steady-state exit (no NSScreen read on the hot path):
+        // already pinned at the requested refresh. When the request exceeds the
+        // panel, appliedFloorHz settles at panelMax and we fall through to the
+        // rare NSScreen-read path below, which re-clamps and then no-ops.
         if appliedFloorHz.isFinite,
-           abs(refinedFloorEwmaHz - appliedFloorHz) < Self.frameRateReapplyHysteresisHz {
+           abs(streamHz - appliedFloorHz) < Self.frameRateReapplyHysteresisHz {
             return
         }
-        // CLAMP BEFORE COMPARE - branch 1 of the storm fix (see the doc above).
         let panelMax = Self.panelMaxHz(for: view)
-        let candidateFloorHz = min(refinedFloorEwmaHz, panelMax)
+        let targetFloorHz = min(streamHz, panelMax)
         if appliedFloorHz.isFinite,
-           abs(candidateFloorHz - appliedFloorHz) < Self.frameRateReapplyHysteresisHz {
-            return
-        }
-        // MIN-DWELL: never re-pin within the dwell of the last re-pin. Checked
-        // AFTER the deadband so a deferred drift still lands when the dwell
-        // expires; the first-ever application (appliedFloorHz .nan) is exempt.
-        let now = CFAbsoluteTimeGetCurrent()
-        if appliedFloorHz.isFinite, lastFloorRePinAt.isFinite,
-           now - lastFloorRePinAt < Self.frameRateRePinMinDwellSeconds {
+           abs(targetFloorHz - appliedFloorHz) < Self.frameRateReapplyHysteresisHz {
             return
         }
         let range = Self.preferredRange(
-            forStreamIntervalSeconds: 1.0 / refinedFloorEwmaHz, panelMaxHz: panelMax)
+            forStreamIntervalSeconds: configuredFrameIntervalSeconds, panelMaxHz: panelMax)
         link.preferredFrameRateRange = range
         appliedFloorHz = Double(range.minimum)
-        lastFloorRePinAt = now
         // Mirror under the lock for the off-main floor-violation detector
         // (FramePacer+TickDeficit.swift) - same dual-write as installLink.
         os_unfair_lock_lock(&lock)
         pinnedFloorHz = Double(range.minimum)
         os_unfair_lock_unlock(&lock)
-        // DEBUG, not info: every dwell-ceiling re-pin is designed behavior on
-        // mode-hopping content (≤0.5/s by the dwell), and at INFO the unified
-        // log carried one line per re-pin all session. `log show --debug`
-        // still recovers the full record when a re-pin storm needs autopsy.
-        log.debug(
-            // swiftlint:disable:next line_length
-            "FramePacer re-pinned present-callback floor to \(self.appliedFloorHz, privacy: .public)Hz (refined cadence \(refinedFloorHz, privacy: .public)Hz, smoothed \(self.refinedFloorEwmaHz, privacy: .public)Hz)")
-        // Diag/LogStore mirror, demoted to ONCE PER CONTENT-MODE CHANGE: the
-        // floor is ROUNDED to the nearest canonical mode before the ≥deadband
-        // compare (see `contentModesHz` - the raw compare passed nearly every
-        // dwell because the EWMA was mid-transition between legitimate modes,
-        // 91.5% of one session log). `lastDiagMirroredFloorHz`
-        // therefore stores the MODE, not the exact floor; the exact floor
-        // rides along in the line for postmortems.
-        let mirroredModeHz = Self.nearestContentModeHz(appliedFloorHz)
-        if !lastDiagMirroredFloorHz.isFinite
-            || abs(mirroredModeHz - lastDiagMirroredFloorHz)
-                >= Self.frameRateReapplyHysteresisHz {
-            lastDiagMirroredFloorHz = mirroredModeHz
-            Diag.info(
-                "FramePacer re-pinned present-callback floor to "
-                + "\(Double(range.minimum))Hz (mode \(mirroredModeHz)Hz, refined cadence "
-                + "\(String(format: "%.2f", refinedFloorHz))Hz)",
-                "Stream.Pacer")
-        }
+        Diag.info(
+            "FramePacer pinned present floor to requested \(Double(range.minimum))Hz "
+            + "(preferred/max \(Double(range.maximum))Hz, panelMax \(panelMax)Hz; "
+            + "content-tracking off for fidelity)",
+            "Stream.Pacer")
     }
 
     /// One-shot 'link installed' replay into the per-session Diag FILE sink.

--- a/Glimmer/Stream/FramePacer+Recovery.swift
+++ b/Glimmer/Stream/FramePacer+Recovery.swift
@@ -137,7 +137,7 @@ extension FramePacer {
         // ignored / mis-honored - the floor must never exceed the panel max.
         let panelMax = Self.panelMaxHz(for: view)
         let range = Self.preferredRange(
-            forStreamIntervalSeconds: self.streamFrameIntervalSeconds,
+            forStreamIntervalSeconds: self.configuredFrameIntervalSeconds,
             panelMaxHz: panelMax)
         link.preferredFrameRateRange = range
         // Record the floor we just pinned so the per-tick re-apply (FIX #1) only

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -134,6 +134,13 @@ final class FramePacer: @unchecked Sendable {
     /// of recent hostPTS deltas. Seeded from the configured stream fps so the
     /// very first ticks have a sane cadence before PTS history accrues.
     var streamFrameIntervalSeconds: Double
+    /// The FIXED configured-fps interval (set once at init, never refined). The
+    /// present-callback FLOOR pins to THIS, not to the per-frame-refined
+    /// `streamFrameIntervalSeconds` (which jitters with measured PTS cadence) - so
+    /// the floor never re-pins on cadence wobble, which makes the display
+    /// renegotiate its refresh and drop a frame (the TestUFO frameskip gap). The
+    /// due gate still paces from the refined interval; only the floor is fixed.
+    let configuredFrameIntervalSeconds: Double
     /// Last hostPTS we saw at submit, to compute the next delta.
     var lastSubmittedPTSSeconds: Double = .nan
     /// Recent hostPTS deltas (seconds) for the median estimate. Bounded.
@@ -402,27 +409,16 @@ final class FramePacer: @unchecked Sendable {
     /// VideoDecoder and so the selector signature stays clean.
     @MainActor private var tickProxy: DisplayLinkProxy?
 
-    /// The stream Hz (floor) we last pinned `preferredFrameRateRange` to (FIX
-    /// #1). Seeded from the configured fps at install; re-applied from the
-    /// PTS-refined cadence on the main-actor tick when it drifts past
-    /// `frameRateReapplyHysteresisHz`, so a configured-vs-actual fps mismatch
-    /// (or a mid-stream fps change) updates the throttle floor without a
-    /// per-frame cross-queue hop from `submit`. `.nan` until first applied.
+    /// The Hz (floor) we last pinned `preferredFrameRateRange` to (FIX #1).
+    /// Pinned to the FIXED configured fps at install and held there; the
+    /// main-actor re-apply only touches it again if the panel max changes under
+    /// us (deadband `frameRateReapplyHysteresisHz`). `.nan` until first applied.
     /// Module-internal (not private) so the re-apply helper in
     /// FramePacer+FrameRateRange.swift can read/update it.
     @MainActor var appliedFloorHz: Double = .nan
 
-    // Floor re-pin smoothing state (the re-pin-storm fix - see
-    // `reapplyPreferredRangeIfNeeded`): the EWMA-smoothed refined cadence the
-    // clamped candidate is built from, the last re-pin instant (min-dwell),
-    // and the last floor MIRRORED to Diag (once-per-change-class demotion).
-    // All main-actor: written only on the tick path where the link lives.
-    @MainActor var refinedFloorEwmaHz: Double = .nan
-    @MainActor var lastFloorRePinAt: CFTimeInterval = .nan
-    @MainActor var lastDiagMirroredFloorHz: Double = .nan
-
-    // `frameRateReapplyHysteresisHz` and the EWMA/dwell tuning live in
-    // FramePacer+FrameRateRange.swift with the re-apply helper that uses them.
+    // `frameRateReapplyHysteresisHz` lives in FramePacer+FrameRateRange.swift
+    // with the re-apply helper that uses it.
 
     /// Dedicated serial queue for the present path. `.userInteractive` because
     /// a missed release is a dropped frame the user sees. NEVER the main actor.
@@ -436,7 +432,9 @@ final class FramePacer: @unchecked Sendable {
         // Seed the cadence from the configured fps; refined from PTS deltas
         // once frames flow. Guard against a zero/garbage config.
         let fps = configuredFps > 0 ? Double(configuredFps) : 60.0
-        self.streamFrameIntervalSeconds = FramePacer.clampFrameInterval(1.0 / fps)
+        let interval = FramePacer.clampFrameInterval(1.0 / fps)
+        self.streamFrameIntervalSeconds = interval
+        self.configuredFrameIntervalSeconds = interval
     }
 
     /// Clamp a frame-interval estimate to a sane [1ms, 1s] range. A poisoned
@@ -475,10 +473,11 @@ final class FramePacer: @unchecked Sendable {
         rateWindowStartHostTime = now
         rateWindowStartTicks = tickCount
         rateWindowStartReleases = releaseCount
-        // D3 (warm re-enable floor seed): a re-enabled pacer is freshly built
+        // D3 (warm re-enable cadence seed): a re-enabled pacer is freshly built
         // from the CONFIGURED fps, but its predecessor had already refined the
-        // true content cadence - adopt it so installLink pins the refined
-        // floor (~174Hz), not the configured 240. See the helper for the WHY.
+        // true content cadence - adopt it to warm-start the DUE GATE's pacing
+        // cadence. The present-callback floor is unaffected: it always pins the
+        // FIXED configured rate (configuredFrameIntervalSeconds), never this.
         adoptStashedRefinedCadenceLocked()
         os_unfair_lock_unlock(&lock)
 

--- a/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
@@ -292,6 +292,11 @@ final class AudioVideoSkewStore: @unchecked Sendable {
     private var audioRateAnchorNanos: UInt64 = 0
     private var audioTicksPerMs = 1.0
     private var audioRateResolved = false
+    /// Latest RESIDENT corrector-inserted silence (ms) in the audio buffer, pushed
+    /// by `publishAudioState`. Subtracted from the buffer-fill term in `deriveSkewMs`
+    /// so the playhead reflects real media, not inserted silence (see the type doc
+    /// + `AudioDecoder.pendingSilenceFrames`). 0 until audio flows / no inserts.
+    private var residentSilenceMs: Double = 0
     // Session accumulator (scorecard percentiles): bucket counts + exact
     // min/max/sum, plus an explicit OVERFLOW count for samples past the last
     // bound so the quantile walk's rank space covers EVERY sample - the old
@@ -339,6 +344,15 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         os_unfair_lock_unlock(lock)
     }
 
+    /// Push the latest resident corrector-inserted silence (ms). Called from
+    /// `publishAudioState` at the schedule + completion cadence; one lock + one
+    /// store - the same always-live budget as the audio meter's per-packet work.
+    func setResidentSilenceMs(_ ms: Double) {
+        os_unfair_lock_lock(lock)
+        residentSilenceMs = ms > 0 ? ms : 0
+        os_unfair_lock_unlock(lock)
+    }
+
     /// Re-anchors after the first latch are counted so a mid-session
     /// re-baseline (suppression window, RTP discontinuity) is visible next to
     /// the skew series it steps.
@@ -377,7 +391,12 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         // type); both monotone within any realistic session.
         let videoMs = Double(videoLastRtp &- videoAnchorRtp) / Self.videoRtpTicksPerMs
         let audioMs = Double(audioLastRtp &- audioAnchorRtp) / audioTicksPerMs
-        let skewMs = videoMs - audioMs + fillMs
+        // Subtract resident corrector-silence from the fill: the audio playhead is
+        // (audioMs − REAL buffered media), and inserted silence inflates `fillMs`
+        // without advancing `audioMs`, so counting it biases skew toward "audio
+        // late". Clamp ≥0 (silence is a subset of fill; guards snapshot skew).
+        let realFillMs = max(0, fillMs - residentSilenceMs)
+        let skewMs = videoMs - audioMs + realFillMs
         guard abs(skewMs) <= Self.sanityBoundMs else {
             anchored = false // discontinuity: re-anchor next tick, never wedge
             return nil

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -448,6 +448,12 @@ final class TelemetryCounters: @unchecked Sendable {
         /// re-arm and the cushion rebuilds via the post-gap catch-up clump (see
         /// AudioDecoder). Directly countable alongside under-runs.
         var rePrimeTotal: UInt64
+        /// RESAMPLER applied rate offset (ppm): the drift-tracking resampler's live
+        /// `varispeed.rate − 1` in parts-per-million. 0 when disengaged (pre-roll /
+        /// re-prime / drain); when converged it sits at the steady host↔Mac clock
+        /// offset (~tens of ppm) - the direct view of the resampler holding the fill
+        /// it's steering (vs the av_skew that bounces with video-side timing).
+        var resamplerPpm: Double = 0
     }
     // Module-internal (not private) so the audio accessors in
     // TelemetryCounters+AudioGauges.swift can reach these (and the min-window

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -89,6 +89,7 @@ extension TelemetryExporter {
             audio.bufferFillMs = state.bufferFillMs
             audio.audioClockDriftMs = state.audioClockDriftMs
             audio.rePrimeTotal = state.rePrimeTotal
+            audio.resamplerPpm = state.resamplerPpm
         }
         // Windowed MIN buffer-fill: pulled (and reset) directly off its own
         // reset-on-read window so each tick's min covers only that window's troughs

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -88,6 +88,12 @@ extension TelemetryRenderer {
                             "A/V-skew pair re-anchors after the first (stale stream or RTP "
                             + "discontinuity) - each one steps the skew baseline.",
                             AudioVideoSkewStore.shared.rebaseTotal)
+        builder.emit("glimmer_audio_resampler_ppm",
+                     "Drift resampler applied rate offset, ppm signed (varispeed rate − 1): "
+                     + "0 = disengaged, ~the steady host↔Mac clock offset (tens of ppm) when "
+                     + "converged. The loop steering buffer fill - the direct view of the "
+                     + "corrector vs the video-side-noisy av_skew.",
+                     audio.resamplerPpm)
         let cushionFloorMs = AudioCushionTelemetry.shared.floorMs
         builder.emit("glimmer_audio_cushion_floor_ms",
                      "Learned audio cushion LOSS FLOOR, ms (EWMA of the target at each under-run; "

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -123,6 +123,7 @@ extension TelemetryRenderer {
         builder.add("audio_loss_rate", audio.lossRate)
         builder.add("audio_fec_recovery_rate", audio.fecRecoveryRate)
         builder.add("audio_buffer_fill_ms", audio.bufferFillMs)
+        builder.add("audio_resampler_ppm", audio.resamplerPpm)
         builder.add("audio_buffer_fill_min_ms", audio.bufferFillMinMs)
         // The adaptive target the fill is steered toward - fill vs target is
         // the cushion judge (base 30 / cap 150 / ceiling 190).

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -273,6 +273,11 @@ struct AudioSnapshot: Sendable {
     // ---- Output / playout health ----
     /// Decoded audio buffered ahead of the playhead (ms) - the buffer level/fill.
     var bufferFillMs: Double?
+    /// RESAMPLER applied rate offset (ppm): the drift-tracking resampler's live
+    /// `varispeed.rate − 1`, parts-per-million. 0 disengaged; ~the steady host↔Mac
+    /// clock offset (tens of ppm) when converged - the direct view of the loop
+    /// holding the fill, vs the av_skew that bounces with video-side timing.
+    var resamplerPpm: Double?
     /// Windowed MINIMUM buffer fill this tick (ms) - the trough of the
     /// scheduled-ahead backlog, reset-on-read. The 1Hz `bufferFillMs` gauge can
     /// miss the instantaneous low that precedes an under-run; this is the field that

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.16
-CURRENT_PROJECT_VERSION = 20260627
+MARKETING_VERSION = 2026.6.17
+CURRENT_PROJECT_VERSION = 20260628


### PR DESCRIPTION
- **refactor: drop stale App-Sandbox references from comments and docs**
- **release: 2026.6.15 (self-heal client TLS identity after the login keychain locks)**
- **appcast: Glimmer 2026.6.15**
- **refactor(net): run the control channel on OpenSSL, delete the keychain/SecIdentity/URLSession layer**
- **release: 2026.6.16 (control channel on OpenSSL; no keychain)**
- **appcast: Glimmer 2026.6.16**
- **fix(ui): hero button reads "Stream <app>", not "Resume <app>"**
- **harden(net): floor the control channel at TLS 1.2**
- **fix(pacer): hold present floor at the FIXED configured refresh, stop content-tracking**
- **fix(audio): av_skew_ms stops counting the corrector's own silence inserts**
- **feat(audio): continuous drift-tracking resampler replaces the micro-stretch**
- **feat(telemetry): export glimmer_audio_resampler_ppm for the drift resampler**
- **release: 2026.6.17 (frame-skip fix + audio resampler + skew telemetry)**
