### PR TITLE
release: 2026.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026.6.18 - 2026-06-20
+
+Fixes controller input dying after you record a custom quit chord. Recording a
+chord temporarily borrows the gamepad's input handlers, and dismissing the
+recorder left them detached - so controller input stayed dead until the stream
+was restarted. Input now re-attaches automatically whenever the stream window
+regains focus, so it recovers on its own.
+
+Also in this release: the Mac's own mouse acceleration is now turned off while a
+stream is focused, so only the game's sensitivity shapes your aim instead of the
+Mac's pointer curve stacking on top of it - on by default, with a toggle in
+Settings > General > Mouse (mice only; the trackpad is untouched). Audio on a
+fresh, jittery, or remote connection starts at a smarter playout cushion instead
+of walking up to it through a few audible blips. And the telemetry now surfaces
+the FEC loss-recovery headroom - including how close each frame came to
+unrecoverable - for better visibility into marginal links.
+
 ## 2026.6.17 - 2026-06-18
 
 Fixes visible frame-skipping on high-refresh displays. The present-pacing floor

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -133,6 +133,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
         Diag.notice("app launching - Glimmer \(version) (\(build)) commit \(BuildInfo.commit) "
             + "built \(BuildInfo.date) (launchedAtLogin=\(launchedAtLogin))", "Launch")
+
+        // Default-ON prefs (registered, not written - the user's explicit choice
+        // still overrides). disableMouseAccelWhileStreaming linearizes the system
+        // pointer acceleration while the stream window is focused so forwarded
+        // mouse deltas are raw 1:1; the non-UI gate reads it via UserDefaults.bool,
+        // which needs the registered default to read `true` before first toggle.
+        UserDefaults.standard.register(defaults: [
+            MouseAccelerationControl.enabledDefaultsKey: true
+        ])
+        // Crash recovery: if a prior session died mid-stream with the pointer
+        // acceleration linearized, restore the user's saved value now (no-op in
+        // the clean case). Runs before any window/stream can re-engage capture.
+        MouseAccelerationControl.restoreOrphanedOverride()
+
         if let mgr = Self.boundManager {
             self.moonlight = mgr
             mgr.attach(appDelegate: self)

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -96,6 +96,11 @@ struct GeneralPane: View {
     @Environment(MoonlightManager.self) private var moonlight
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = false
     @AppStorage("launchMinimized") private var launchMinimized: Bool = false
+    // Default-ON: linearize the Mac's mouse acceleration while a stream is
+    // focused so only the game's own sensitivity shapes aim. Key mirrors
+    // MouseAccelerationControl.enabledDefaultsKey (registered true in GlimmerApp,
+    // which is what makes the non-UI UserDefaults.bool read default to on too).
+    @AppStorage("disableMouseAccelWhileStreaming") private var rawMouseWhileStreaming: Bool = true
 
     /// True when macOS has the login item but it's pending the user's approval
     /// in System Settings ▸ Login Items - surfaced inline so the user isn't left
@@ -203,6 +208,20 @@ struct GeneralPane: View {
                     Label("Network helper unavailable: \(why)", systemImage: "xmark.octagon")
                         .font(.footnote).foregroundStyle(.red)
                 }
+            }
+            Section("Mouse") {
+                Toggle(isOn: $rawMouseWhileStreaming) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Aim with raw mouse motion while streaming").fontWeight(.medium)
+                        Text("Turns off the Mac's own mouse acceleration while the stream window "
+                            + "is focused, so only the game's sensitivity shapes your aim instead of "
+                            + "the Mac's pointer curve stacking on top of it. Restored the instant "
+                            + "you leave the stream. Affects mice only - the trackpad is untouched.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .help("Linearizes the system mouse acceleration (like `com.apple.mouse.scaling -1`) for the duration of each focused stream.")
             }
             Section("Default action") {
                 // Picker sourced from the selected host's announced app

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -80,6 +80,42 @@ extension AudioDecoder {
     /// preference storage - the host never rides telemetry or logs.
     static let cushionMemoryKeyPrefix = "audioCushionMemory."
 
+    /// COLD-SEED jitter coefficient. On a FRESH link (no per-host memory to
+    /// adopt) the starting cushion is biased by `coldSeedJitterK * smoothedJitterMs`
+    /// so a standing-jitter remote/VPN link starts near the depth it needs instead
+    /// of blip-walking up from the bare base (the first-contact ratchet the per-host
+    /// memory only papers over on the SECOND session). 2.0 ≈ 2σ of the jitter
+    /// envelope. DO-NO-HARM (hard constraint): a clean/wired link's smoothed jitter
+    /// is sub-ms, so the biased term stays well under `playoutCushionBaseMs` and the
+    /// seed's `max(base, …)` returns the base UNCHANGED - byte-identical to the old
+    /// fixed seed. Given the margin below, only standing jitter above ~10ms lifts it.
+    static let coldSeedJitterK: Double = 2.0
+    /// Fixed RTT-variance / scheduling-slack margin (ms) added to the jitter term in
+    /// the cold seed. RTT variance isn't cheaply reachable from the reconciler's
+    /// published decision (smoothed jitter is), so this stands in for it - one
+    /// cushion step. Small enough that it never lifts a clean link off the base
+    /// (the `max(base, …)` still picks the base when jitter is sub-ms).
+    static let coldSeedRttVarMarginMs: Double = AudioDecoder.playoutCushionStepMs
+
+    /// Jitter-aware COLD seed (ms) for a fresh link with NO per-host memory to
+    /// adopt: bias the starting cushion off the reconciler's live smoothed jitter
+    /// so a standing-jitter link doesn't blip-walk up from the bare base. Pure read
+    /// of `EnvSignalController`'s published decision; touches no control flow, no
+    /// grow/decay/floor, no steady-state.
+    ///
+    /// DO-NO-HARM: a clean/wired link's smoothed jitter is sub-ms, so
+    /// `k*jitter + margin` stays under `base` and `max(base, …)` returns `base`
+    /// UNCHANGED - byte-identical to the old fixed 30ms seed. A cold/zero estimate
+    /// (pre-roll before the reconciler has data) returns `base` via the `jitter > 0`
+    /// guard. The result is clamped to `cap` so it can never seed past the over-run
+    /// envelope. Callers only reach this on the no-memory path (memory still wins).
+    static func jitterAwareColdSeedMs(base: Double, cap: Double) -> Double {
+        let jitter = EnvSignalController.shared.decision.smoothedJitterMs
+        guard jitter.isFinite, jitter > 0 else { return base }
+        let biased = (coldSeedJitterK * jitter).rounded(.up) + coldSeedRttVarMarginMs
+        return min(max(base, biased), cap)
+    }
+
     // MARK: - Persistence (UserDefaults, per host+link)
 
     /// One session's starting cushion, resolved at decoder init.
@@ -180,8 +216,15 @@ extension AudioDecoder {
                                    fromMemory: true)
             }
         }
+        // No memory for this host+link. Bias the cold seed off the live link
+        // estimate (jitter-aware); a clean link reads the base unchanged. At INIT
+        // the reconciler usually has no jitter yet (link still "unknown"), so this
+        // typically resolves to the base here and actually bites at the one-shot
+        // link resolve (resolveCushionLink) ~1-2s later, where jitter is meaningful.
         return CushionSeed(key: key, host: host, link: link,
-                           targetMs: playoutCushionBaseMs, floorMs: 0, fromMemory: false)
+                           targetMs: jitterAwareColdSeedMs(
+                               base: playoutCushionBaseMs, cap: cushionMaxMs(forLink: link)),
+                           floorMs: 0, fromMemory: false)
     }
 
     /// Announce the seed (sensor-honesty: a new dial self-describes) and latch
@@ -289,6 +332,13 @@ extension AudioDecoder {
         // the tiny-lock discipline stands even on this one-shot path).
         let key = Self.cushionMemoryKey(host: host, link: link)
         let stored = Self.readCushionMemory(key: key)
+        // Jitter-aware cold seed for the no-memory branch below - computed HERE,
+        // OUTSIDE the meter lock (it reads EnvSignal's own lock; the tiny-lock
+        // discipline this file keeps). By now (~1-2s in) the reconciler HAS jitter,
+        // unlike at the init seed, so this is where the cold seed actually bites.
+        // Clean link → base (do-no-harm).
+        let coldSeedMs = Self.jitterAwareColdSeedMs(
+            base: Self.playoutCushionBaseMs, cap: Self.cushionMaxMs(forLink: link))
 
         audioMeterLock.lock()
         // Re-check after the lock gap: the decode and completion threads both
@@ -300,6 +350,7 @@ extension AudioDecoder {
         // to the deeper tunnel cap; a resolved-wired link tightens it back to 150ms).
         effectiveCushionMaxMs = Self.cushionMaxMs(forLink: link)
         effectiveOverrunCeilingMs = effectiveCushionMaxMs + Self.bufferOverrunCeilingSlackMs
+        var coldSeedApplied = false
         if let stored {
             if cushionHadUnderrun {
                 // This session already produced real evidence: the resolved
@@ -315,18 +366,23 @@ extension AudioDecoder {
             quietWindowMinFillMs = .infinity
         } else if !cushionHadUnderrun {
             // No memory for the RESOLVED link and no real evidence yet this
-            // session: drop the borrowed bring-up guess back to defaults so a
-            // wrong-link seed can't persist into this link's bucket - the
-            // ladder re-learns this link from its own evidence (one blip
-            // worst-case re-arms the floor immediately).
-            playoutTargetMs = Self.playoutCushionBaseMs
+            // session: seed off the now-meaningful live jitter (cold seed) rather
+            // than dropping flat to base, so a standing-jitter link starts near the
+            // depth it needs. The borrowed bring-up guess is still discarded - we
+            // seed from THIS link's OWN measured jitter, not the borrow, so a
+            // wrong-link seed can't persist into this bucket. DO-NO-HARM: a clean
+            // link's coldSeedMs == base, byte-identical to the old `= base`. The
+            // ladder still re-learns this link from its own evidence on top.
+            playoutTargetMs = coldSeedMs
             learnedFloorMs = 0
+            coldSeedApplied = true
             quietSinceNanos = now
             floorQuietSinceNanos = now
             quietWindowMinFillMs = .infinity
         }
         let target = playoutTargetMs
         let floor = learnedFloorMs
+        let cap = effectiveCushionMaxMs
         audioMeterLock.unlock()
         AudioCushionTelemetry.shared.setFloorMs(floor)
         Diag.notice(
@@ -334,6 +390,20 @@ extension AudioDecoder {
             + "floor \(Int(floor.rounded()))ms"
             + (stored != nil ? " (per-host memory adopted)" : " (no memory for this link yet)"),
             "Stream")
+        // Cold-seed breadcrumb: greppable record of the jitter-aware decision when
+        // it actually lifted the seed above base on this fresh link. Updates the
+        // seed gauge to the resolve-time value (the init latch held the base).
+        if coldSeedApplied {
+            AudioCushionTelemetry.shared.setSeedMs(target)
+            if target > Self.playoutCushionBaseMs {
+                Diag.notice(
+                    "audio cushion cold-seed (jitter-aware): \(Int(target.rounded()))ms from "
+                    + "smoothed jitter "
+                    + "\(String(format: "%.1f", EnvSignalController.shared.decision.smoothedJitterMs))ms "
+                    + "(base \(Int(Self.playoutCushionBaseMs))ms, cap \(Int(cap))ms) - link \(link)",
+                    "Audio")
+            }
+        }
     }
 
     // MARK: - Drift micro-stretch (deterministic clock-skew repayment)

--- a/Glimmer/Stream/CHelpers.h
+++ b/Glimmer/Stream/CHelpers.h
@@ -171,4 +171,51 @@ connected:
     return fd;
 }
 
+// MARK: - Global mouse pointer-acceleration (relative-aim linearization)
+// macOS runs even relative (associate-false) HID deltas through its pointer-
+// acceleration curve before they reach kCGMouseEventDeltaX/Y, so a streamed game
+// sees the Mac's acceleration STACKED on top of its own in-game sensitivity.
+// Flooring the global mouse acceleration to linear while the stream window is
+// focused removes the Mac curve so only the host's sensitivity shapes aim;
+// MouseAccelerationControl (InputForwarder+Capture.swift) saves the prior value
+// and restores it on blur/teardown. The IOHID*AccelerationWithKey pair is the
+// long-standing (if deprecated) control surface; a NEGATIVE value (-1.0) is the
+// "disabled / linear" sentinel - the same one `com.apple.mouse.scaling -1`
+// writes. Affects MICE only (kIOHIDMouseAccelerationType); the trackpad has its
+// own acceleration type and is left untouched.
+#include <IOKit/hidsystem/IOHIDLib.h>
+#include <IOKit/hidsystem/IOHIDParameter.h>
+#include <IOKit/hidsystem/event_status_driver.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+/// Read the current global mouse acceleration. Returns the value on success
+/// (>= -1.0; -1.0 means the user already runs linear), or -2.0 on failure - a
+/// value the API never produces, so it is an unambiguous error sentinel.
+static inline double gl_get_mouse_acceleration(void) {
+    NXEventHandle handle = NXOpenEventStatus();
+    if (!handle) return -2.0;
+    double value = -2.0;
+    if (IOHIDGetAccelerationWithKey(handle, CFSTR(kIOHIDMouseAccelerationType), &value)
+        != KERN_SUCCESS) {
+        value = -2.0;
+    }
+    NXCloseEventStatus(handle);
+    return value;
+}
+
+/// Set the global mouse acceleration. A negative value (e.g. -1.0) disables
+/// acceleration entirely (linear 1:1). Returns 1 on success, 0 on failure.
+static inline int gl_set_mouse_acceleration(double value) {
+    NXEventHandle handle = NXOpenEventStatus();
+    if (!handle) return 0;
+    int ok = (IOHIDSetAccelerationWithKey(handle, CFSTR(kIOHIDMouseAccelerationType), value)
+              == KERN_SUCCESS);
+    NXCloseEventStatus(handle);
+    return ok;
+}
+
+#pragma clang diagnostic pop
+
 #endif

--- a/Glimmer/Stream/ControllerForwarder.swift
+++ b/Glimmer/Stream/ControllerForwarder.swift
@@ -165,21 +165,12 @@ extension InputForwarder {
                 "Controller")
         }
         if useHID {
+            // Retain the raw-HID reader (Options/Create/Mute centre buttons +
+            // battery). The onChange handler that turns a centre-button edge into
+            // a host push is installed by installInputHandlers(for:) below - one
+            // place installs BOTH the GameController and raw-HID handlers so a
+            // focus-regain resync can re-install (heal) them together.
             DualSenseHID.shared.retain()
-            // Drive a gamepad update when the HID-only buttons (Options /
-            // Create / Mute) change - GameController never fires for them, so
-            // without this the quit chord and host-forwarding only update when
-            // some *other* (GameController) input changes. That's why holding
-            // L1+R1 and then adding Options+Create never triggered the chord.
-            let hidSlot = slot
-            DualSenseHID.shared.onChange = { [weak self, weak gamepad] in
-                guard let self, let ex = gamepad?.extendedGamepad else { return }
-                // Center-button edge only (DualSenseHID gates onChange on a real
-                // bit change). Push controller state WITHOUT re-forwarding the
-                // touchpad - that stays on the GameController valueChangedHandler,
-                // the single full-state source. Kills the old double-feed.
-                self.sendCenterButtonUpdate(pad: ex, slot: hidSlot)
-            }
         }
 
         let state = AttachedController(
@@ -211,16 +202,13 @@ extension InputForwarder {
             + "caps=0x\(String(caps, radix: 16)) buttons=0x\(String(buttons, radix: 16))",
             "Controller")
 
-        // Hook the value-changed handler. GameController invokes this on the
-        // main queue by default; we explicitly assume MainActor isolation so
-        // Swift 6 strict concurrency is satisfied.
-        let slotForClosure = slot
-        gamepad.extendedGamepad?.valueChangedHandler = { [weak self] (pad, _) in
-            MainActor.assumeIsolated {
-                guard let self else { return }
-                self.sendGamepadUpdate(pad: pad, slot: slotForClosure)
-            }
-        }
+        // Install the live input handlers (GameController valueChangedHandler +
+        // the raw-HID centre-button onChange). Factored into installInputHandlers
+        // so resyncControllers() can RE-install them on every focus regain: the
+        // Settings chord-capture sheet grabs both single-slot handlers to record a
+        // chord and nils them on dismiss, which otherwise left controller input
+        // dead until a stream restart. See installInputHandlers.
+        installInputHandlers(for: state)
 
         // If the stream is already up, announce arrival immediately;
         // otherwise it'll go out when `setReady(true)` is called.
@@ -596,6 +584,43 @@ extension InputForwarder {
         }
     }
 
+    // MARK: - Input handler install / heal
+
+    /// (Re)install the live input handlers for an attached controller: the
+    /// GameController `valueChangedHandler` (the single full-state forward) and,
+    /// for a raw-HID DualSense, `DualSenseHID.shared.onChange` (the centre-button
+    /// edge GameController never delivers). Idempotent, so it doubles as a HEAL:
+    /// the Settings chord-capture sheet (ChordCaptureSheet.engage/disengage) takes
+    /// over both single-slot handlers to record a chord and sets them to `nil` on
+    /// dismiss - which, with a stream live, left the forwarder's input path dead
+    /// until a session restart re-ran attach(). resyncControllers() calls this on
+    /// every focus regain, so returning to the stream restores input with no
+    /// restart.
+    func installInputHandlers(for state: AttachedController) {
+        guard let gamepad = state.controller else { return }
+        let slot = state.slot
+        // GameController invokes this on the main queue; assume MainActor so
+        // Swift 6 strict concurrency is satisfied.
+        gamepad.extendedGamepad?.valueChangedHandler = { [weak self] (pad, _) in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.sendGamepadUpdate(pad: pad, slot: slot)
+            }
+        }
+        // Raw-HID centre buttons (Options/Create/Mute): GameController never fires
+        // valueChangedHandler for them, so this onChange is the only path that
+        // carries a centre-button edge (e.g. the Moonlight-default chord's Create)
+        // to the host. DualSenseHID gates onChange on a real bit change; the push
+        // does NOT re-forward the touchpad (that stays on the GameController path,
+        // the single full-state source - no double-feed).
+        if state.retainedHID {
+            DualSenseHID.shared.onChange = { [weak self, weak gamepad] in
+                guard let self, let ex = gamepad?.extendedGamepad else { return }
+                self.sendCenterButtonUpdate(pad: ex, slot: slot)
+            }
+        }
+    }
+
     // MARK: - Focus resync (#8)
 
     /// Re-send every attached controller's current state to the host. Called
@@ -606,6 +631,13 @@ extension InputForwarder {
     func resyncControllers() {
         guard isReady else { return }
         for state in attachedControllers.values {
+            // Re-install handlers FIRST: a component that grabbed the single-slot
+            // valueChangedHandler / DualSenseHID.onChange while we were not key -
+            // the Settings chord-capture sheet - may have nil'd ours, leaving
+            // controller input dead. Healing here means returning focus to the
+            // stream restores live input without a session restart. Then push
+            // current state so a held stick/button snaps to live immediately.
+            installInputHandlers(for: state)
             guard let pad = state.controller?.extendedGamepad else { continue }
             sendGamepadUpdate(pad: pad, slot: state.slot)
         }

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -148,6 +148,22 @@ extension InputForwarder {
             savedMouseCoalescing = NSEvent.isMouseCoalescingEnabled
         }
         NSEvent.isMouseCoalescingEnabled = false
+        // Linearize the system pointer acceleration so the relative deltas we
+        // forward to the host are raw 1:1 - macOS otherwise runs even
+        // associate-false HID motion through its acceleration curve, stacking the
+        // Mac's curve on top of the game's own in-game sensitivity. Default-on;
+        // opt out in Settings. Saved + restored like coalescing above, with a
+        // UserDefaults crash-safety sentinel (see MouseAccelerationControl).
+        // engageLinear() returns nil - leaving savedMouseAcceleration nil so
+        // exitCapturedMode skips the restore - when the feature is off, the
+        // read/write fails, or the user already runs linear (nothing of ours to
+        // undo). The guard mirrors the coalescing save: only on the first engage.
+        if savedMouseAcceleration == nil, MouseAccelerationControl.isEnabled {
+            savedMouseAcceleration = MouseAccelerationControl.engageLinear()
+            if let prior = savedMouseAcceleration {
+                log.info("Mouse capture: pointer acceleration linearized (was \(prior), now \(MouseAccelerationControl.linear))")
+            }
+        }
         isMouseCaptured = true
         log.info("Mouse capture: relative aim engaged (associate-false; coalescing off; cursor disassociated, visibility owned by StreamWindow)")
     }
@@ -172,6 +188,14 @@ extension InputForwarder {
         if let prior = savedMouseCoalescing {
             NSEvent.isMouseCoalescingEnabled = prior
             savedMouseCoalescing = nil
+        }
+        // Restore the pointer acceleration we linearized on engage (pairs with
+        // engageLinear; also clears the crash-safety sentinel). nil = we never
+        // overrode it (feature off / already linear / failed), so nothing to undo.
+        if let prior = savedMouseAcceleration {
+            MouseAccelerationControl.restore(prior)
+            savedMouseAcceleration = nil
+            log.info("Mouse capture: pointer acceleration restored to \(prior)")
         }
         log.info("Mouse capture: relative aim disengaged (associate-true; coalescing restored; cursor re-associated, visibility owned by StreamWindow)")
     }
@@ -412,5 +436,76 @@ extension InputForwarder {
     /// falls back to its raw value, which is enough to identify the type.
     func diagnosticEventTypeName(_ type: NSEvent.EventType) -> String {
         Self.diagnosticEventTypeNames[type] ?? "type(\(type.rawValue))"
+    }
+}
+
+// MARK: - System mouse pointer-acceleration control (relative-aim linearization)
+
+/// Floors the global mouse pointer-acceleration to linear while the stream
+/// window is focused, so the relative deltas InputForwarder forwards are raw 1:1
+/// and only the host game's own sensitivity shapes aim. macOS otherwise runs
+/// even associate-false HID motion through its acceleration curve (the
+/// "accel-free under associate-false" assumption is optimistic - the curve is
+/// applied before kCGMouseEventDeltaX/Y), stacking the Mac's curve on the host's.
+/// This is the same save→override→restore discipline `enterCapturedMode()`
+/// already uses for `NSEvent.isMouseCoalescingEnabled`.
+///
+/// CRASH-SAFETY: the override is a GLOBAL system setting, not process-local. If
+/// Glimmer dies while focused (crash / SIGKILL) the in-memory saved value is
+/// gone and the mouse would stay linear system-wide. So `engageLinear()` ALSO
+/// persists the pre-override value to UserDefaults the instant it overrides;
+/// `restoreOrphanedOverride()` (called once at launch, GlimmerApp) detects a
+/// leftover and restores it - a crash can never strand the pointer in linear
+/// mode past the next launch. The normal blur/teardown path clears the sentinel.
+enum MouseAccelerationControl {
+    /// Default-ON opt-out preference. Registered `true` in GlimmerApp so both
+    /// this gate and the Settings `@AppStorage` toggle read on by default.
+    static let enabledDefaultsKey = "disableMouseAccelWhileStreaming"
+    /// Crash-safety sentinel: holds the pre-override acceleration WHILE the
+    /// override is engaged; absent at rest (cleared on every clean restore).
+    private static let pendingRestoreKey = "mouseAccelPendingRestore"
+    /// The "disabled / linear" acceleration value (mirrors `com.apple.mouse.scaling -1`).
+    static let linear = -1.0
+
+    /// Whether the linearize-while-focused feature is on (default true).
+    static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }
+
+    /// Engage linear mode. Returns the saved prior acceleration to hand back on
+    /// disengage, or nil when there is nothing of ours to undo: the read failed,
+    /// the user already runs linear (prior < 0), or the write was refused. Stamps
+    /// the crash-safety sentinel only when it actually overrides.
+    static func engageLinear() -> Double? {
+        let prior = gl_get_mouse_acceleration()
+        // -2.0 = read failure; < 0 (e.g. -1) = already disabled - either way
+        // there is no positive value of ours to restore later, so do nothing.
+        guard prior >= 0 else { return nil }
+        let defaults = UserDefaults.standard
+        defaults.set(prior, forKey: pendingRestoreKey)
+        guard gl_set_mouse_acceleration(linear) == 1 else {
+            defaults.removeObject(forKey: pendingRestoreKey)
+            return nil
+        }
+        return prior
+    }
+
+    /// Restore a previously-saved acceleration value and clear the sentinel.
+    static func restore(_ value: Double) {
+        _ = gl_set_mouse_acceleration(value)
+        UserDefaults.standard.removeObject(forKey: pendingRestoreKey)
+    }
+
+    /// Launch-time crash recovery: if a prior run died with the override engaged,
+    /// the sentinel still holds the pre-override value - restore it now and clear
+    /// it. No-op when the sentinel is absent (the clean, common case). The stored
+    /// value is always a real >= 0 acceleration (engageLinear only writes it after
+    /// guarding `prior >= 0`), so restoring it unconditionally is safe.
+    static func restoreOrphanedOverride() {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: pendingRestoreKey) != nil else { return }
+        let saved = defaults.double(forKey: pendingRestoreKey)
+        _ = gl_set_mouse_acceleration(saved)
+        defaults.removeObject(forKey: pendingRestoreKey)
+        Diag.notice("Mouse: restored orphaned pointer-acceleration override to \(saved) "
+            + "(prior session ended while streaming)", "Launch")
     }
 }

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -311,6 +311,14 @@ public final class InputForwarder {
     /// `enterCapturedMode()` for why we turn coalescing OFF in relative aim.
     var savedMouseCoalescing: Bool?
 
+    /// Saved global mouse pointer-acceleration from BEFORE we linearized it for
+    /// relative aim, restored on disengage. nil while we have NOT overridden it
+    /// (feature off, read/write failed, or the user already runs linear) - so the
+    /// restore in `exitCapturedMode()` is paired exactly once with the override.
+    /// The same value is also persisted to UserDefaults while engaged so a crash
+    /// can't strand the pointer in linear mode; see `MouseAccelerationControl`.
+    var savedMouseAcceleration: Double?
+
     /// NSEvent local-monitor token for gesture suppression. While the stream
     /// window is key, we swallow gesture-family events so macOS's pinch-to-
     /// zoom, smart-zoom, swipe-to-Mission-Control, and rotate don't reach

--- a/Glimmer/Stream/Native/RtpVideoQueue+Reconstruct.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue+Reconstruct.swift
@@ -106,6 +106,10 @@ extension RtpVideoQueue {
         // periodic FEC-recovery-rate metric (latched; tallied at submit time).
         currentFrameNeededFec = true
         let recovered = bufferDataPackets - receivedDataPackets
+        // FEC observability (read-only): track the worst parity headroom this window
+        // - how many spare parity shards remained after this frame's deficit.
+        // Published + reset in maybeLogMetrics. Pure book-keeping, no control effect.
+        windowMinParityMargin = min(windowMinParityMargin, bufferParityPackets - recovered)
         if !loggedFirstFecRecovery {
             loggedFirstFecRecovery = true
             Diag.notice("NativeVideo first FEC recovery: \(recovered) shards, frame \(currentFrameNumber)", Self.cat)

--- a/Glimmer/Stream/Native/RtpVideoQueue.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue.swift
@@ -229,6 +229,12 @@ final class RtpVideoQueue {
     var windowLostPreFec = 0
     var windowOutOfOrder = 0
     var windowDuplicate = 0
+    /// FEC observability (read-only): the smallest parity headroom seen on a
+    /// FEC-recovered frame this window (parity − data deficit), tracked in
+    /// logFecRecovery and published + reset in maybeLogMetrics. `Int.max` = no
+    /// recovery this window, in which case the publish reports the current frame's
+    /// full parity count (the healthy baseline) instead.
+    var windowMinParityMargin = Int.max
     /// CROSS-WINDOW reorder credit (metric honesty). A reorder that fills a gap
     /// counted as loss should UNCOUNT one loss slot - but the gap and its filling
     /// reorder often straddle a maybeLogMetrics window boundary (the forward jump
@@ -495,6 +501,19 @@ final class RtpVideoQueue {
                 Self.cat)
         }
 
+        // FEC HEALTH gauge (read-only): publish the controller's just-stepped
+        // response + the per-frame parity headroom for the dashboard. Pure read-out
+        // - nothing here feeds back into the FEC/reorder logic. `fecPercentage` and
+        // `bufferParityPackets` are the latest frame's (they persist across windows);
+        // `windowMinParityMargin` is this window's worst recovered-frame headroom, or
+        // the current frame's full parity when no recovery occurred.
+        counters.setFecHealth(TelemetryCounters.FecHealthSnapshot(
+            reorderHoldMs: Double(reorderWindowUs) / 1000.0,
+            headroomLevel: fecHeadroom.level,
+            lossLevel: fecHeadroom.lossLevel,
+            fecPercentage: fecPercentage,
+            parityMargin: windowMinParityMargin == Int.max ? bufferParityPackets : windowMinParityMargin))
+
         framesInWindow = 0
         fecRecoveredFramesInWindow = 0
         packetsInWindow = 0
@@ -508,6 +527,7 @@ final class RtpVideoQueue {
         windowLostPreFec = 0
         windowOutOfOrder = 0
         windowDuplicate = 0
+        windowMinParityMargin = Int.max
         for index in gapBuckets.indices { gapBuckets[index] = 0 }
         gapCount = 0
         gapMaxUs = 0

--- a/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
@@ -551,6 +551,7 @@ final class AudioCushionTelemetry: @unchecked Sendable {
     private let lock = os_unfair_lock_t.allocate(capacity: 1)
     private var seedValue: Seed?
     private var floorMsValue: Double = 0
+    private var seedMsValue: Double = 0
     init() { lock.initialize(to: os_unfair_lock_s()) }
     deinit { lock.deallocate() }
 
@@ -558,6 +559,7 @@ final class AudioCushionTelemetry: @unchecked Sendable {
         os_unfair_lock_lock(lock)
         seedValue = seed
         floorMsValue = seed.floorMs
+        seedMsValue = seed.targetMs
         os_unfair_lock_unlock(lock)
     }
     var seed: Seed? {
@@ -573,5 +575,17 @@ final class AudioCushionTelemetry: @unchecked Sendable {
     var floorMs: Double {
         os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
         return floorMsValue
+    }
+
+    /// The COLD-START seed target (ms): the t=0 cushion chosen before the grow
+    /// ratchet runs. Set at init (latchSeed, from the per-host/default seed) and
+    /// updated when the one-shot link resolve applies a jitter-aware cold seed on
+    /// a fresh (no-memory) link. A clean/wired link reads the 30ms base.
+    func setSeedMs(_ value: Double) {
+        os_unfair_lock_lock(lock); seedMsValue = value; os_unfair_lock_unlock(lock)
+    }
+    var seedMs: Double {
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        return seedMsValue
     }
 }

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -75,6 +75,41 @@ extension TelemetryCounters {
         return packetGapValue
     }
 
+    /// Live FEC-HEALTH gauge: the FecHeadroomController's RESPONSE (the reorder-
+    /// hold it is holding + both headroom axes) plus the per-frame parity headroom,
+    /// published once per ~2s receive-metrics window by the RTP path. READ-ONLY
+    /// observability - none of these values feed back into the FEC/reorder logic;
+    /// they let a degrading link be SEEN on the dashboard (the controller's
+    /// transitions were previously diag-log-only). Last-writer-wins behind one lock,
+    /// the same idiom as `packetGap`. nil before the first window.
+    struct FecHealthSnapshot: Sendable {
+        /// Live reorder-hold window the queue applies (ms): base 24, cap 48 - the
+        /// controller's combined response to jitter + loss.
+        var reorderHoldMs: Double
+        /// Jitter / out-of-order / retransmit axis level (0 on a clean link).
+        var headroomLevel: Int
+        /// Direct-loss axis level (0 on a clean link).
+        var lossLevel: Int
+        /// Host-driven per-frame FEC percentage of the latest frame.
+        var fecPercentage: Int
+        /// Spare parity shards on the WORST frame this window (parity − data
+        /// deficit) - the early warning before a frame goes unrecoverable. On a
+        /// clean window (no recovery) this is the current frame's full parity count.
+        var parityMargin: Int
+    }
+
+    /// Publish the FEC-health gauge. Called once per ~2s window by the RTP receive
+    /// path (never the per-datagram hot path).
+    func setFecHealth(_ snapshot: FecHealthSnapshot) {
+        os_unfair_lock_lock(fecHealthLock); fecHealthValue = snapshot; os_unfair_lock_unlock(fecHealthLock)
+    }
+    /// Latest FEC-health gauge, or nil before the first window. Read by the
+    /// exporter on its 1Hz queue (never the hot path).
+    var fecHealth: FecHealthSnapshot? {
+        os_unfair_lock_lock(fecHealthLock); defer { os_unfair_lock_unlock(fecHealthLock) }
+        return fecHealthValue
+    }
+
     func setRecvJitterMs(_ ms: Double) {
         os_unfair_lock_lock(jitterLock); recvJitterMsValue = ms; os_unfair_lock_unlock(jitterLock)
     }

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -395,6 +395,12 @@ final class TelemetryCounters: @unchecked Sendable {
     let decodeStateLock = os_unfair_lock_t.allocate(capacity: 1)
     var decodeStateValue: DecodeState?
 
+    // Live FEC-HEALTH gauge storage (reorder-hold + headroom axes + per-frame
+    // parity headroom); the `FecHealthSnapshot` value type + accessors live in
+    // TelemetryCounters+Gauges.swift. Module-internal so those accessors reach it.
+    let fecHealthLock = os_unfair_lock_t.allocate(capacity: 1)
+    var fecHealthValue: FecHealthSnapshot?
+
     /// Host-RUMBLE receipt stamp (the last 0x010b receipt instant) - the detach-
     /// context breadcrumb's rumble-age source (ControllerForwarder.detach).
     /// Self-locked holder (the `P2State` idiom), defined in
@@ -512,6 +518,7 @@ final class TelemetryCounters: @unchecked Sendable {
         rttLock.initialize(to: os_unfair_lock_s())
         gapLock.initialize(to: os_unfair_lock_s())
         decodeStateLock.initialize(to: os_unfair_lock_s())
+        fecHealthLock.initialize(to: os_unfair_lock_s())
         audioStateLock.initialize(to: os_unfair_lock_s())
         audioFirstPacketLock.initialize(to: os_unfair_lock_s())
         presentSuppressedLock.initialize(to: os_unfair_lock_s())
@@ -520,7 +527,7 @@ final class TelemetryCounters: @unchecked Sendable {
     deinit {
         jitterLock.deallocate(); inputLock.deallocate()
         rttLock.deallocate(); gapLock.deallocate()
-        decodeStateLock.deallocate()
+        decodeStateLock.deallocate(); fecHealthLock.deallocate()
         audioStateLock.deallocate(); audioFirstPacketLock.deallocate()
         presentSuppressedLock.deallocate(); decodeGatedLock.deallocate()
     }
@@ -583,6 +590,7 @@ final class TelemetryCounters: @unchecked Sendable {
         rumbleActivity.reset()
         os_unfair_lock_lock(gapLock); packetGapValue = nil; os_unfair_lock_unlock(gapLock)
         os_unfair_lock_lock(decodeStateLock); decodeStateValue = nil; os_unfair_lock_unlock(decodeStateLock)
+        os_unfair_lock_lock(fecHealthLock); fecHealthValue = nil; os_unfair_lock_unlock(fecHealthLock)
         os_unfair_lock_lock(audioStateLock)
         audioStateValue = nil; audioBufferFillMinMsValue = .infinity
         os_unfair_lock_unlock(audioStateLock)

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -238,6 +238,13 @@ extension TelemetryExporter {
             snap.packetGapP95Us = gap.p95Us
             snap.packetGapMaxUs = gap.maxUs
         }
+        if let fec = counters.fecHealth {
+            snap.fecReorderHoldMs = fec.reorderHoldMs
+            snap.fecHeadroomLevel = fec.headroomLevel
+            snap.fecLossLevel = fec.lossLevel
+            snap.fecPercentage = fec.fecPercentage
+            snap.fecParityMargin = fec.parityMargin
+        }
         // Refresh the live RTT gauge the per-frame glass-to-glass computation
         // reads at present (~RTT/2 for the transit leg). Done here on the 1Hz
         // queue, never the hot path; the present-side read is the only hot-path

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -99,6 +99,13 @@ extension TelemetryRenderer {
                      "Learned audio cushion LOSS FLOOR, ms (EWMA of the target at each under-run; "
                      + "decay never steps below floor + one step). Absent until learned.",
                      cushionFloorMs > 0 ? cushionFloorMs : nil)
+        let cushionSeedMs = AudioCushionTelemetry.shared.seedMs
+        builder.emit("glimmer_audio_cushion_seed_ms",
+                     "Audio cushion COLD-START seed target, ms (the t=0 playout cushion chosen "
+                     + "before the grow ratchet runs). Jitter-aware on a fresh no-memory link: "
+                     + "max(base, ceil(2*smoothedJitter)+10) clamped to cap; a clean/wired link "
+                     + "reads the 30ms base. Per-host memory, when present, seeds this directly.",
+                     cushionSeedMs > 0 ? cushionSeedMs : nil)
         builder.emit("glimmer_audio_first_packet_ms",
                      "Time from stream start to first decoded audio, ms (cold-start metric).",
                      audio.firstPacketMs)

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -212,6 +212,11 @@ extension TelemetryRenderer {
     ) {
         builder.add("recv_jitter_ms", snap.recvJitterMs)
         builder.add("fec_recovery_rate", snap.fecRecoveryRate)
+        builder.add("fec_reorder_hold_ms", snap.fecReorderHoldMs)
+        builder.add("fec_headroom_level", snap.fecHeadroomLevel.map(Double.init))
+        builder.add("fec_loss_level", snap.fecLossLevel.map(Double.init))
+        builder.add("fec_percentage", snap.fecPercentage.map(Double.init))
+        builder.add("fec_parity_margin", snap.fecParityMargin.map(Double.init))
         builder.add("pkts_per_s", snap.packetsPerSecond)
         // FRACTIONAL ms (high-res local clock): emit the Double with decimals via
         // `add` (jsonNumber → %.3f) instead of truncating to Int, so a sub-ms RTT

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -158,6 +158,8 @@ extension TelemetryRenderer {
         // target is legible against the evidence holding it.
         let cushionFloorMs = AudioCushionTelemetry.shared.floorMs
         builder.add("audio_cushion_floor_ms", cushionFloorMs > 0 ? cushionFloorMs : nil)
+        let cushionSeedMs = AudioCushionTelemetry.shared.seedMs
+        builder.add("audio_cushion_seed_ms", cushionSeedMs > 0 ? cushionSeedMs : nil)
         builder.add("audio_first_packet_ms", audio.firstPacketMs)
     }
 

--- a/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
@@ -22,6 +22,26 @@ extension TelemetryRenderer {
         builder.emit("glimmer_net_recv_jitter_ms", "RFC3550 smoothed receive jitter, ms.", snap.recvJitterMs)
         builder.emit("glimmer_net_fec_recovery_rate",
                      "Fraction of frames needing Reed-Solomon recovery this window.", snap.fecRecoveryRate)
+        // FEC HEALTH (read-only observability): the FecHeadroomController's response
+        // (reorder-hold + both headroom axes) and the per-frame parity headroom, so a
+        // degrading link's escalation is visible, not only in the diag log. Clean-link
+        // baseline: hold ≈ 24ms, both levels 0, a comfortable positive parity margin.
+        builder.emit("glimmer_fec_reorder_hold_ms",
+                     "Live FEC reorder-hold window the receiver applies, ms (base 24, cap 48).",
+                     snap.fecReorderHoldMs)
+        builder.emit("glimmer_fec_headroom_level",
+                     "FEC headroom jitter/out-of-order/retransmit axis level (0 = clean link).",
+                     snap.fecHeadroomLevel.map(Double.init))
+        builder.emit("glimmer_fec_loss_level",
+                     "FEC headroom direct-loss axis level (0 = clean link).",
+                     snap.fecLossLevel.map(Double.init))
+        builder.emit("glimmer_fec_percentage",
+                     "Host-driven per-frame FEC percentage (latest frame).",
+                     snap.fecPercentage.map(Double.init))
+        builder.emit("glimmer_fec_parity_margin",
+                     "Spare parity shards on the worst frame this window (parity - data deficit); "
+                     + "trends toward 0 before a frame goes unrecoverable.",
+                     snap.fecParityMargin.map(Double.init))
         builder.emit("glimmer_net_packets_per_second", "Video packets received per second.", snap.packetsPerSecond)
         builder.emit("glimmer_net_rtt_ms", "ENet RTT estimate (high-res local clock), ms.", snap.rttMs)
         builder.emit("glimmer_net_rtt_variance_ms", "ENet RTT variance, ms.", snap.rttVarianceMs)

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -104,6 +104,21 @@ struct TelemetrySnapshot: Sendable {
     var packetGapP95Us: Double?
     var packetGapMaxUs: Double?
 
+    // network - FEC health (the FecHeadroomController response + per-frame parity
+    // headroom). READ-ONLY observability: surfaces a degrading link's reorder-hold
+    // escalation and how close frames ran to unrecoverable. nil until the first ~2s
+    // receive window flushes.
+    /// Live reorder-hold window (ms): base 24, cap 48.
+    var fecReorderHoldMs: Double?
+    /// Jitter / out-of-order / retransmit headroom level (0 = clean).
+    var fecHeadroomLevel: Int?
+    /// Direct-loss headroom level (0 = clean).
+    var fecLossLevel: Int?
+    /// Host per-frame FEC percentage (latest frame).
+    var fecPercentage: Int?
+    /// Spare parity shards on the worst frame this window (parity − deficit).
+    var fecParityMargin: Int?
+
     // ENet reliable-stream health
     var enetSentReliable: Int?
     var enetOldestUnackedMs: UInt32?

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.17
-CURRENT_PROJECT_VERSION = 20260628
+MARKETING_VERSION = 2026.6.18
+CURRENT_PROJECT_VERSION = 20260629


### PR DESCRIPTION
Controller input now heals on focus-regain after recording a custom quit chord (previously dead until a stream restart). Plus: macOS mouse acceleration is turned off while streaming so only the game's sensitivity shapes aim (default on, toggle in Settings > General > Mouse, mice only); a jitter-aware cold-start seed for the audio playout cushion on fresh/remote links; and FEC loss-recovery headroom + parity-margin telemetry gauges. See CHANGELOG.md.