### PR TITLE
Release 2026.6.19: Quality preset rework, settings reorg, DualSense player LEDs, hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2026.6.19 - 2026-06-21
+
+A polish pass across Settings, the controller, and stream robustness.
+
+The Quality presets are simpler and truer to these displays: "Match my display"
+is now "Native Retina" (every pixel of the Mac's panel), the rarely-right Smooth
+and Maximum presets are gone, and a new HiDPI preset streams at the Mac's
+default Retina scale - a crisp picture at roughly a quarter of the bandwidth.
+Notch coverage is now a single-line toggle right under the resolution picker,
+and the in-stream stats overlay can sit top-center (clear of the camera notch)
+or bottom-center.
+
+Settings are also reorganized: the raw-mouse aim toggle moved to Input, Wi-Fi
+stutter-smoothing moved to Quality, and the Troubleshooting and Diagnostics
+panes merged into one - the controller test and logs stay in plain sight, while
+the telemetry wires reveal with the usual option-click on the version line.
+
+On the controller, the DualSense player-number LEDs now light to match its slot,
+and the unreliable Home / Guide quit chord - macOS reserves that button - was
+removed (the Options + Create + L1 + R1 chord remains).
+
+Under the hood: a SwiftUI layout-engine crash is hardened by making the
+display-change recompute idempotent; the video receive path falls back
+gracefully if a future macOS ever drops its private batched-receive syscall; and
+a handful of defensive guards round it out.
+
 ## 2026.6.18 - 2026-06-20
 
 Fixes controller input dying after you record a custom quit chord. Recording a

--- a/Glimmer/AboutPane.swift
+++ b/Glimmer/AboutPane.swift
@@ -62,14 +62,16 @@ struct AboutPane: View {
                         Text("Version \(versionString)")
                             .font(.footnote)
                             .foregroundStyle(.tertiary)
-                            // Hidden reveal for the Diagnostics pane. Option-
-                            // clicking the version line toggles the
-                            // `showDiagnostics` UserDefault - a deliberate,
-                            // undiscoverable gesture so normal users never trip
-                            // it, but a power user (or a bug report) can surface
-                            // the debug/tuning wires. The Telemetry toggle lives
-                            // INSIDE Diagnostics, so it can't gate its own
-                            // reveal - hence this separate gesture-driven flag.
+                            // Hidden reveal for the telemetry/tuning sections
+                            // inside Settings → Diagnostics (the pane itself is
+                            // always visible for the input test + logs; only the
+                            // debug wires hide). Option-clicking the version line
+                            // toggles the `showDiagnostics` UserDefault - a
+                            // deliberate, undiscoverable gesture so normal users
+                            // never trip it, but a power user (or a bug report)
+                            // can surface them. The Telemetry toggle lives inside
+                            // those sections, so it can't gate its own reveal -
+                            // hence this separate gesture-driven flag.
                             .gesture(
                                 TapGesture()
                                     .modifiers(.option)
@@ -78,7 +80,7 @@ struct AboutPane: View {
                             // Option-cursor hint that something lives here,
                             // without spelling it out.
                             .help(moonlight.showDiagnostics
-                                  ? "Option-click to hide Diagnostics"
+                                  ? "Option-click to hide the developer tools"
                                   : "")
                     }
                     Spacer()

--- a/Glimmer/AboutPane.swift
+++ b/Glimmer/AboutPane.swift
@@ -85,7 +85,26 @@ struct AboutPane: View {
                 }
                 .padding(.vertical, 6)
             }
-            Section("Acknowledgements") {
+            // Order: Support up top (the one ask), License in the middle (the
+            // legal fact), and the projects we lean on at the bottom as a
+            // closing note of appreciation.
+            Section("Support") {
+                if let url = URL(string: AboutLink.donate) {
+                    Link("Support Glimmer's development", destination: url)
+                        .font(.footnote)
+                }
+            }
+            Section("License") {
+                Text("Glimmer is free software under the GNU General Public License v3. "
+                    + "You may run, study, share, and modify it; there is no warranty.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                if let url = URL(string: AboutLink.license) {
+                    Link("GNU GPL v3", destination: url)
+                        .font(.footnote)
+                }
+            }
+            Section("Projects we like") {
                 Text("Built for Sunshine, the open-source game-streaming host. Glimmer "
                     + "speaks the Moonlight protocol - itself carrying NVIDIA GameStream "
                     + "forward - and the transport is ported from moonlight-common-c, "
@@ -102,22 +121,6 @@ struct AboutPane: View {
                 }
                 if let url = URL(string: AboutLink.credits) {
                     Link("Credits", destination: url)
-                        .font(.footnote)
-                }
-            }
-            Section("License") {
-                Text("Glimmer is free software under the GNU General Public License v3. "
-                    + "You may run, study, share, and modify it; there is no warranty.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                if let url = URL(string: AboutLink.license) {
-                    Link("GNU GPL v3", destination: url)
-                        .font(.footnote)
-                }
-            }
-            Section("Support") {
-                if let url = URL(string: AboutLink.donate) {
-                    Link("Support Glimmer's development", destination: url)
                         .font(.footnote)
                 }
             }

--- a/Glimmer/DiagnosticsPane.swift
+++ b/Glimmer/DiagnosticsPane.swift
@@ -42,76 +42,107 @@ struct DiagnosticsPane: View {
         // environment value (matches the other Settings panes).
         @Bindable var moonlight = moonlight
         Form {
+            // Always-visible support surface (formerly the Troubleshooting pane):
+            // a live controller input test + the in-app log viewer. These need to
+            // stay reachable by normal users - they're how you debug "my
+            // controller stopped" or grab logs for a bug report - so they are NOT
+            // behind the option-click reveal below.
             Section {
-                Toggle(isOn: $moonlight.telemetryEnabled) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Performance telemetry").fontWeight(.medium)
-                        Text("Exposes per-second stream metrics over a local "
-                            + "Prometheus endpoint and an NDJSON log, plus a "
-                            + "richer per-session diagnostic log. Off by default; "
-                            + "carries only performance numbers, never secrets.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Toggle(isOn: $fileLogDebug) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Verbose session log file").fontWeight(.medium)
-                        Text("Mirrors debug-level lines into the per-session "
-                            + "diagnostic log file too (info and above by "
-                            + "default). The in-app log and Console always "
-                            + "carry everything.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                // The exporter (and the file sink's level) snapshot their gates
-                // when a session starts, so a mid-session flip does nothing
-                // until the next stream.
-                Text("Applies on the next stream.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                ControllerInputTest()
             } header: {
-                Text("Telemetry")
+                Text("Controller input test")
+            } footer: {
+                Text("Reads the controller directly through macOS. If a signal "
+                    + "lights up here but not in a stream, the issue is in how "
+                    + "the stream forwards it - try this view right after a "
+                    + "Cmd-Tab to confirm input is still live.")
             }
 
             Section {
-                HStack {
-                    Text("Bookmark a rough moment")
-                    Spacer()
-                    StaticChordBadge(chord: .defaultBookmark)
-                }
-                Text("Press \(HotkeyChord.defaultBookmark.displayString) during a "
-                    + "stream when it \u{201C}feels bad\u{201D} to drop a "
-                    + "timestamped marker into the telemetry. Client-only - never "
-                    + "sent to the host - and intercepted only while telemetry is "
-                    + "on; otherwise the keystroke passes straight through.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                LogViewer()
             } header: {
-                Text("In-stream marker")
+                Text("Logs")
+            } footer: {
+                Text("Recent entries from Glimmer's unified log. Copy them when "
+                    + "filing an issue.")
             }
 
-            Section {
-                LabeledContent("Telemetry logs") {
-                    HStack(spacing: 8) {
-                        Text(abbreviatedLogPath)
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Button {
-                            revealLogDir()
-                        } label: {
-                            Image(systemName: "folder")
+            // Power-user wires - revealed ONLY by the option-click gesture on the
+            // About version line (showDiagnostics). Telemetry + tuning live behind
+            // it so normal users never trip the opt-in toggles; the support
+            // surface above is always available either way.
+            if moonlight.showDiagnostics {
+                Section {
+                    Toggle(isOn: $moonlight.telemetryEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Performance telemetry").fontWeight(.medium)
+                            Text("Exposes per-second stream metrics over a local "
+                                + "Prometheus endpoint and an NDJSON log, plus a "
+                                + "richer per-session diagnostic log. Off by default; "
+                                + "carries only performance numbers, never secrets.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
                         }
-                        .buttonStyle(.borderless)
-                        .help("Reveal in Finder")
                     }
+                    Toggle(isOn: $fileLogDebug) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Verbose session log file").fontWeight(.medium)
+                            Text("Mirrors debug-level lines into the per-session "
+                                + "diagnostic log file too (info and above by "
+                                + "default). The in-app log and Console always "
+                                + "carry everything.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    // The exporter (and the file sink's level) snapshot their gates
+                    // when a session starts, so a mid-session flip does nothing
+                    // until the next stream.
+                    Text("Applies on the next stream.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Telemetry")
                 }
-            } header: {
-                Text("Where the data goes")
+
+                Section {
+                    HStack {
+                        Text("Bookmark a rough moment")
+                        Spacer()
+                        StaticChordBadge(chord: .defaultBookmark)
+                    }
+                    Text("Press \(HotkeyChord.defaultBookmark.displayString) during a "
+                        + "stream when it \u{201C}feels bad\u{201D} to drop a "
+                        + "timestamped marker into the telemetry. Client-only - never "
+                        + "sent to the host - and intercepted only while telemetry is "
+                        + "on; otherwise the keystroke passes straight through.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("In-stream marker")
+                }
+
+                Section {
+                    LabeledContent("Telemetry logs") {
+                        HStack(spacing: 8) {
+                            Text(abbreviatedLogPath)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Button {
+                                revealLogDir()
+                            } label: {
+                                Image(systemName: "folder")
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Reveal in Finder")
+                        }
+                    }
+                } header: {
+                    Text("Where the data goes")
+                }
             }
         }
         .formStyle(.grouped)

--- a/Glimmer/Models/Host.swift
+++ b/Glimmer/Models/Host.swift
@@ -69,19 +69,23 @@ struct MoonlightApp: Identifiable, Hashable {
 
 enum QualityPreset: String, CaseIterable, Identifiable {
     // Declaration order drives `allCases`, which drives the picker order.
-    // Match-my-display is the default and sits at the top.
-    case matchDisplay  // host-native fps + display res, balanced
-    case smooth      // 60 fps, conservative bitrate
-    case maximum     // host-native fps, peak bitrate
-    case custom      // user-defined width/height/fps/bitrate
+    // Native Retina is the default and sits at the top.
+    //
+    // Smooth/Maximum were dropped: their 16:9 caps looked poor on the 16:10
+    // Retina panels these run on, and the bitrate-multiplier axis they rode
+    // was redundant once presets differ by RESOLUTION instead. The two that
+    // remain are the two real choices - full native, or the Mac's own default
+    // Retina scale at a quarter of the pixels - plus Custom.
+    case matchDisplay  // panel-native pixel grid + host-native fps (sharpest)
+    case hidpi         // default "looks like" scale (native ÷ 2), 2x-crisp, ~¼ the bitrate
+    case custom        // user-defined width/height/fps/bitrate
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .smooth: return "Smooth"
-        case .matchDisplay: return "Match my display"
-        case .maximum: return "Maximum"
+        case .matchDisplay: return "Native Retina"
+        case .hidpi: return "HiDPI"
         case .custom: return "Custom"
         }
     }
@@ -91,9 +95,8 @@ enum QualityPreset: String, CaseIterable, Identifiable {
     // pane's "Your next stream" summary.
     var subtitle: String {
         switch self {
-        case .smooth: return "Always fluid, even on Wi-Fi (caps sharpness at 1440p 60)"
-        case .matchDisplay: return "Looks like this Mac's own display (wants a solid network)"
-        case .maximum: return "Sharpest picture in heavy scenes (uses the most bandwidth)"
+        case .matchDisplay: return "Every pixel of this Mac's panel (sharpest; wants a solid network)"
+        case .hidpi: return "This Mac's default Retina scale - a touch softer, far less bandwidth"
         case .custom: return "Pick your own resolution, refresh, and bitrate"
         }
     }
@@ -234,8 +237,12 @@ public enum ControllerQuitChord: String, CaseIterable, Codable, Sendable {
     case l1r1
     case l1r1l2r2
     case l3r3
-    case home
     case custom
+    // NOTE: `.home` (the PS / Guide / "menu" button) was removed - macOS
+    // gamecontrollerd reserves that button for system gestures, so it never
+    // reliably reached the app as a quit chord. A persisted `.home` decodes to
+    // nil and falls back to the default (see MoonlightManager load), so this is
+    // a clean removal with no migration step.
 
     public var displayName: String {
         switch self {
@@ -244,7 +251,6 @@ public enum ControllerQuitChord: String, CaseIterable, Codable, Sendable {
         case .l1r1: return "L1 + R1"
         case .l1r1l2r2: return "L1 + R1 + L2 + R2"
         case .l3r3: return "L3 + R3 (stick clicks)"
-        case .home: return "Home / Guide"
         case .custom: return "Custom (recorded)"
         }
     }

--- a/Glimmer/MoonlightManager+Lifecycle.swift
+++ b/Glimmer/MoonlightManager+Lifecycle.swift
@@ -65,11 +65,18 @@ extension MoonlightManager {
             // yanking the resolution mid-stream would be disruptive.
             Task { @MainActor in
                 guard let self, !self.isStreaming else { return }
-                self.persistQualitySettings()
-                // Bump the sentinel so any view that read
-                // `currentDisplayDescription` rebuilds. @Observable can't
-                // see through NSScreen.main on its own.
-                self.displayInfoRevision &+= 1
+                // persistQualitySettings is idempotent and reports whether the
+                // effective config actually moved. A no-op screen-parameter
+                // notification (common on the launcher - EDR/brightness/refresh
+                // changes that don't touch the resolution) then mutates zero
+                // @Observable state and invalidates nothing, instead of churning
+                // the view graph on every display tick.
+                if self.persistQualitySettings() {
+                    // Bump the sentinel so any view that read
+                    // `currentDisplayDescription` rebuilds. @Observable can't
+                    // see through NSScreen.main on its own.
+                    self.displayInfoRevision &+= 1
+                }
             }
         })
         notificationTokens.append(nc.addObserver(

--- a/Glimmer/QualityCalculator.swift
+++ b/Glimmer/QualityCalculator.swift
@@ -263,8 +263,11 @@ extension MoonlightManager {
     // MARK: - Effective config + persistence
 
     /// Recompute the effective stream config from the current preset + custom
-    /// overrides and stash it for the UI to read.
-    func persistQualitySettings() {
+    /// overrides and stash it for the UI to read. Returns true iff any effective
+    /// value actually moved, so callers on the hot display-change path can skip
+    /// invalidating views when nothing changed.
+    @discardableResult
+    func persistQualitySettings() -> Bool {
         let display = smartDefaultsForCurrentDisplay()
 
         let width: Int, height: Int, fps: Int, bitrate: Int, hdr: Bool
@@ -289,15 +292,22 @@ extension MoonlightManager {
             bitrate = customBitrateMbps * 1000
             hdr = customHDR
         }
-        effectiveWidth = width
-        effectiveHeight = height
-        effectiveFPS = fps
-        effectiveBitrateKbps = bitrate
-        effectiveHDR = hdr
+        // Idempotent writes: assign each @Observable property only when it
+        // actually moves. A spurious didChangeScreenParameters notification (the
+        // launcher gets these on EDR / brightness / refresh changes that don't
+        // touch the resolution) would otherwise re-stamp identical values and
+        // schedule a needless SwiftUI invalidation every time - exactly the kind
+        // of display-cycle layout churn that feeds AttributeGraph instability.
+        // Writing an @Observable property always invalidates its readers, even
+        // when the value is unchanged, so the guards are load-bearing.
+        var changed = false
+        if effectiveWidth != width { effectiveWidth = width; changed = true }
+        if effectiveHeight != height { effectiveHeight = height; changed = true }
+        if effectiveFPS != fps { effectiveFPS = fps; changed = true }
+        if effectiveBitrateKbps != bitrate { effectiveBitrateKbps = bitrate; changed = true }
+        if effectiveHDR != hdr { effectiveHDR = hdr; changed = true }
         UserDefaults.standard.set(qualityPreset.rawValue, forKey: "qualityPreset")
-        // Writing the @Observable-tracked properties above schedules the
-        // necessary view updates; no explicit objectWillChange.send()
-        // needed.
+        return changed
     }
 
     /// Snap custom values to the display's native dimensions.

--- a/Glimmer/QualityCalculator.swift
+++ b/Glimmer/QualityCalculator.swift
@@ -143,13 +143,13 @@ extension MoonlightManager {
         let fpsValue = Double(fps)
         let frameRateFactor = (fpsValue <= 60 ? fpsValue : (sqrt(fpsValue / 60.0) * 60.0)) / 30.0
 
-        // Preset multiplier: smooth = 0.75x, match = 1.0x, max = 1.5x.
+        // Preset multiplier: the surviving presets all stream at the formula's
+        // reference bits-per-pixel and differ by RESOLUTION instead (HiDPI sends
+        // a quarter of the pixels, so the resolution factor already discounts it).
+        // Kept as an explicit switch so a future preset has to make a choice.
         let presetMultiplier: Double
         switch preset {
-        case .smooth: presetMultiplier = 0.75
-        case .matchDisplay: presetMultiplier = 1.0
-        case .maximum: presetMultiplier = 1.5
-        case .custom: presetMultiplier = 1.0
+        case .matchDisplay, .hidpi, .custom: presetMultiplier = 1.0
         }
 
         let kbps = Int((resolutionFactor * frameRateFactor * presetMultiplier).rounded() * 1000)
@@ -269,17 +269,18 @@ extension MoonlightManager {
 
         let width: Int, height: Int, fps: Int, bitrate: Int, hdr: Bool
         switch qualityPreset {
-        case .smooth:
-            width = min(display.width, 2560)
-            height = min(display.height, 1440)
-            fps = 60
-            bitrate = bitrateKbps(width: width, height: height, fps: fps, preset: .smooth)
-            hdr = true
-        case .matchDisplay, .maximum:
+        case .matchDisplay:
             width = display.width
             height = display.height
             fps = display.fps
-            bitrate = bitrateKbps(width: width, height: height, fps: fps, preset: qualityPreset)
+            bitrate = bitrateKbps(width: width, height: height, fps: fps, preset: .matchDisplay)
+            hdr = true
+        case .hidpi:
+            let hd = hidpiDefaultsForCurrentDisplay()
+            width = hd.width
+            height = hd.height
+            fps = hd.fps
+            bitrate = bitrateKbps(width: width, height: height, fps: fps, preset: .hidpi)
             hdr = true
         case .custom:
             width = customWidth
@@ -321,20 +322,32 @@ extension MoonlightManager {
     func effectiveValuesForPreset(_ preset: QualityPreset) -> PresetSnapshot {
         let display = smartDefaultsForCurrentDisplay()
         switch preset {
-        case .smooth:
-            let width = min(display.width, 2560)
-            let height = min(display.height, 1440)
-            let kbps = bitrateKbps(width: width, height: height, fps: 60, preset: .smooth)
-            return PresetSnapshot(width: width, height: height, fps: 60, bitrateKbps: kbps)
         case .matchDisplay:
             let kbps = bitrateKbps(width: display.width, height: display.height, fps: display.fps, preset: .matchDisplay)
             return PresetSnapshot(width: display.width, height: display.height, fps: display.fps, bitrateKbps: kbps)
-        case .maximum:
-            let kbps = bitrateKbps(width: display.width, height: display.height, fps: display.fps, preset: .maximum)
-            return PresetSnapshot(width: display.width, height: display.height, fps: display.fps, bitrateKbps: kbps)
+        case .hidpi:
+            let hd = hidpiDefaultsForCurrentDisplay()
+            let kbps = bitrateKbps(width: hd.width, height: hd.height, fps: hd.fps, preset: .hidpi)
+            return PresetSnapshot(width: hd.width, height: hd.height, fps: hd.fps, bitrateKbps: kbps)
         case .custom:
             return PresetSnapshot(width: customWidth, height: customHeight, fps: customFPS, bitrateKbps: customBitrateMbps * 1000)
         }
+    }
+
+    /// HiDPI preset target: the display's DEFAULT "looks like" logical
+    /// resolution. Apple ships every built-in Retina panel at a default scale
+    /// of exactly 2x, so the panel-native pixel grid halved IS the point grid
+    /// the macOS UI is laid out in (3024x1964 -> 1512x982 on a 14" MBP, etc.).
+    /// Streaming at this size and letting the panel integer-upscale 2x stays
+    /// crisp while carrying ~1/4 the pixels of native - the bandwidth win. fps
+    /// tracks the panel max, same as matchDisplay. Falls back to native for a
+    /// degenerately small panel where halving would drop below 720p-ish.
+    func hidpiDefaultsForCurrentDisplay() -> (width: Int, height: Int, fps: Int) {
+        let native = smartDefaultsForCurrentDisplay()
+        let w = native.width / 2
+        let h = native.height / 2
+        guard w >= 1280, h >= 720 else { return native }
+        return (w, h, native.fps)
     }
 
     /// Friendly label for common Mac and external panel native resolutions.

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -298,9 +298,8 @@ struct QualityPane: View {
                 Toggle("Fill the notch", isOn: $moonlight.streamCoversNotch)
                     .toggleStyle(.button)
                     .help("Covers the whole panel on notched MacBooks; a sliver of the image hides behind the camera notch.")
-                Text("On notched MacBooks the stream fills the entire panel - a thin strip of "
-                    + "the picture sits behind the notch. Turn off to keep the image clear of it "
-                    + "(macOS safe-area framing). Applies on your next stream.")
+                Text("Fills the whole panel on notched MacBooks - a thin strip of the picture "
+                    + "hides behind the notch. Off keeps it clear. Applies next stream.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -96,20 +96,11 @@ struct GeneralPane: View {
     @Environment(MoonlightManager.self) private var moonlight
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = false
     @AppStorage("launchMinimized") private var launchMinimized: Bool = false
-    // Default-ON: linearize the Mac's mouse acceleration while a stream is
-    // focused so only the game's own sensitivity shapes aim. Key mirrors
-    // MouseAccelerationControl.enabledDefaultsKey (registered true in GlimmerApp,
-    // which is what makes the non-UI UserDefaults.bool read default to on too).
-    @AppStorage("disableMouseAccelWhileStreaming") private var rawMouseWhileStreaming: Bool = true
 
     /// True when macOS has the login item but it's pending the user's approval
     /// in System Settings ▸ Login Items - surfaced inline so the user isn't left
     /// with a toggle that silently does nothing at the next reboot.
     @State private var loginItemNeedsApproval = false
-
-    /// The privileged AWDL network helper (parks awdl0 during streams). Shared
-    /// singleton so this toggle and the stream lifecycle drive one instance.
-    @ObservedObject private var awdl = AWDLHelperManager.shared
 
     /// Defer the SMAppService register/unregister off the SwiftUI `.onChange`
     /// transaction - running it inline (synchronous, XPC-backed) mid-update
@@ -119,15 +110,6 @@ struct GeneralPane: View {
         DispatchQueue.main.async {
             let status = LoginItemManager.apply(launchAtLogin: launchAtLogin, minimized: minimized)
             loginItemNeedsApproval = (status == .requiresApproval)
-        }
-    }
-
-    /// Defer the helper register/unregister off the SwiftUI transaction - same
-    /// reason as the login item: an inline XPC-backed SMAppService call mid-
-    /// update dismisses the Settings window.
-    private func scheduleHelperToggle(_ enable: Bool) {
-        Task { @MainActor in
-            if enable { AWDLHelperManager.shared.enable() } else { AWDLHelperManager.shared.disable() }
         }
     }
 
@@ -183,46 +165,6 @@ struct GeneralPane: View {
                 }
                 Toggle("Silence this Mac while streaming (when sound plays on the gaming PC)", isOn: $moonlight.muteMacWhileStreaming)
             }
-            Section("Network") {
-                Toggle(isOn: Binding(get: { awdl.isRegistered }, set: { scheduleHelperToggle($0) })) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Smooth out Wi-Fi stutter while streaming").fontWeight(.medium)
-                        Text("Parks AirDrop's radio (AWDL) for the length of a stream so it can't "
-                            + "grab the Wi-Fi channel and cause multi-second freezes. Restored the "
-                            + "instant you stop. Installs a small helper that needs a one-time approval.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .help("Holds awdl0 down for the duration of each stream via a privileged helper.")
-                if case .requiresApproval = awdl.state {
-                    HStack(spacing: 8) {
-                        Label("macOS needs you to approve the Glimmer network helper in Login Items.",
-                              systemImage: "exclamationmark.triangle.fill")
-                            .font(.footnote).foregroundStyle(.orange)
-                        Spacer()
-                        Button("Open Login Items") { awdl.openSystemSettings() }
-                    }
-                }
-                if case .unavailable(let why) = awdl.state {
-                    Label("Network helper unavailable: \(why)", systemImage: "xmark.octagon")
-                        .font(.footnote).foregroundStyle(.red)
-                }
-            }
-            Section("Mouse") {
-                Toggle(isOn: $rawMouseWhileStreaming) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Aim with raw mouse motion while streaming").fontWeight(.medium)
-                        Text("Turns off the Mac's own mouse acceleration while the stream window "
-                            + "is focused, so only the game's sensitivity shapes your aim instead of "
-                            + "the Mac's pointer curve stacking on top of it. Restored the instant "
-                            + "you leave the stream. Affects mice only - the trackpad is untouched.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .help("Linearizes the system mouse acceleration (like `com.apple.mouse.scaling -1`) for the duration of each focused stream.")
-            }
             Section("Default action") {
                 // Picker sourced from the selected host's announced app
                 // list (Sunshine's `applist`). "Desktop" is always
@@ -241,7 +183,6 @@ struct GeneralPane: View {
         }
         .formStyle(.grouped)
         .onAppear {
-            awdl.refresh()
             guard launchAtLogin else { loginItemNeedsApproval = false; return }
             let service = launchMinimized
                 ? SMAppService.loginItem(identifier: LoginItemManager.helperBundleID)
@@ -289,6 +230,21 @@ enum CommonResolution: CaseIterable {
 struct QualityPane: View {
     @Environment(MoonlightManager.self) private var moonlight
 
+    /// The privileged AWDL network helper (parks awdl0 during streams). Shared
+    /// singleton so this toggle and the stream lifecycle drive one instance.
+    /// Lives in Quality because parking AirDrop's radio is a stream-smoothness
+    /// lever, not a general app setting.
+    @ObservedObject private var awdl = AWDLHelperManager.shared
+
+    /// Defer the helper register/unregister off the SwiftUI transaction - an
+    /// inline XPC-backed SMAppService call mid-update dismisses the Settings
+    /// window.
+    private func scheduleHelperToggle(_ enable: Bool) {
+        Task { @MainActor in
+            if enable { AWDLHelperManager.shared.enable() } else { AWDLHelperManager.shared.disable() }
+        }
+    }
+
     /// Width clamp: 640..7680 (480p min, 8K max). Matches Moonlight's
     /// upstream bounds. Wired to .onChange so it runs on EVERY commit:
     /// TextField(value:format:) writes the binding whenever editing ends -
@@ -332,6 +288,21 @@ struct QualityPane: View {
                 }
                 .pickerStyle(.inline)
                 .labelsHidden()
+
+                // Notch coverage as a compact pill right under the resolution
+                // choice - it shapes the same picture. DEFAULT ON: full-panel
+                // coverage is the product stance on notched MacBooks. Only
+                // meaningful on built-in notched panels; elsewhere the safe-area
+                // inset is zero and the toggle is a no-op. Snapshotted at session
+                // start, so the next-stream caveat lives in the description.
+                Toggle("Fill the notch", isOn: $moonlight.streamCoversNotch)
+                    .toggleStyle(.button)
+                    .help("Covers the whole panel on notched MacBooks; a sliver of the image hides behind the camera notch.")
+                Text("On notched MacBooks the stream fills the entire panel - a thin strip of "
+                    + "the picture sits behind the notch. Turn off to keep the image clear of it "
+                    + "(macOS safe-area framing). Applies on your next stream.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
 
             if moonlight.qualityPreset == .custom {
@@ -457,25 +428,30 @@ struct QualityPane: View {
                 }
             }
 
-            Section("Display") {
-                // DEFAULT ON: full-panel coverage is the product stance on
-                // notched MacBooks; this is the opt-out.
-                // Only meaningful on built-in panels with a notch; elsewhere
-                // the safe-area inset is zero and the toggle has no effect.
-                // The value is snapshotted into the stream window once at
-                // session start (no live provider, unlike stats/hotkeys), so
-                // the footnote carries the next-stream caveat - same copy as
-                // the equally session-snapshotted captureSysKeys toggle.
-                Toggle(isOn: $moonlight.streamCoversNotch) {
+            Section("Wi-Fi") {
+                Toggle(isOn: Binding(get: { awdl.isRegistered }, set: { scheduleHelperToggle($0) })) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Use every pixel of the display (a sliver hides behind the notch)")
-                            .fontWeight(.medium)
-                        Text("On notched MacBooks the stream covers the entire physical panel. "
-                            + "Turn off to match macOS's safe-area framing instead. "
-                            + "Takes effect on the next stream.")
+                        Text("Smooth out Wi-Fi stutter while streaming").fontWeight(.medium)
+                        Text("Parks AirDrop's radio (AWDL) for the length of a stream so it can't "
+                            + "grab the Wi-Fi channel and cause multi-second freezes. Restored the "
+                            + "instant you stop. Installs a small helper that needs a one-time approval.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }
+                }
+                .help("Holds awdl0 down for the duration of each stream via a privileged helper.")
+                if case .requiresApproval = awdl.state {
+                    HStack(spacing: 8) {
+                        Label("macOS needs you to approve the Glimmer network helper in Login Items.",
+                              systemImage: "exclamationmark.triangle.fill")
+                            .font(.footnote).foregroundStyle(.orange)
+                        Spacer()
+                        Button("Open Login Items") { awdl.openSystemSettings() }
+                    }
+                }
+                if case .unavailable(let why) = awdl.state {
+                    Label("Network helper unavailable: \(why)", systemImage: "xmark.octagon")
+                        .font(.footnote).foregroundStyle(.red)
                 }
             }
 
@@ -489,8 +465,8 @@ struct QualityPane: View {
             // they never scatter across panes. Anything here must be safe to
             // flip blind and safe to ignore. A dial that proves itself moves
             // up into a real section; one that doesn't gets deleted, not
-            // hidden. (The notch toggle graduated to Display above -
-            // full-panel coverage is the product default, not an
+            // hidden. (The notch toggle graduated to a pill under the Preset
+            // picker - full-panel coverage is the product default, not an
             // experiment.) The fence is currently EMPTY, so no Section
             // is emitted at all: SwiftUI's grouped Form renders a Section
             // HEADER even over an EmptyView body, leaving a dangling flask
@@ -498,6 +474,7 @@ struct QualityPane: View {
             // systemImage: "flask") }` with the first new dial.
         }
         .formStyle(.grouped)
+        .onAppear { awdl.refresh() }
     }
 
     /// Two-tier bitrate guidance under the slider. Tier 1 is the baked-in

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -296,7 +296,7 @@ struct QualityPane: View {
                 // inset is zero and the toggle is a no-op. Snapshotted at session
                 // start, so the next-stream caveat lives in the description.
                 Toggle("Fill the notch", isOn: $moonlight.streamCoversNotch)
-                    .toggleStyle(.button)
+                    .toggleStyle(.switch)
                     .help("Covers the whole panel on notched MacBooks; a sliver of the image hides behind the camera notch.")
                 Text("Fills the whole panel on notched MacBooks - a thin strip of the picture "
                     + "hides behind the notch. Off keeps it clear. Applies next stream.")

--- a/Glimmer/SettingsPCsShortcutsPanes.swift
+++ b/Glimmer/SettingsPCsShortcutsPanes.swift
@@ -278,10 +278,9 @@ struct ShortcutsPane: View {
                 Toggle(isOn: $rawMouseWhileStreaming) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Aim with raw mouse motion while streaming").fontWeight(.medium)
-                        Text("Turns off the Mac's own mouse acceleration while the stream window "
-                            + "is focused, so only the game's sensitivity shapes your aim instead of "
-                            + "the Mac's pointer curve stacking on top of it. Restored the instant "
-                            + "you leave the stream. Affects mice only - the trackpad is untouched.")
+                        Text("Only the game's own sensitivity shapes your aim - the Mac's pointer "
+                            + "acceleration stops stacking on top while the stream is focused, and is "
+                            + "restored the instant you leave. Mice only; the trackpad is untouched.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }

--- a/Glimmer/SettingsPCsShortcutsPanes.swift
+++ b/Glimmer/SettingsPCsShortcutsPanes.swift
@@ -188,6 +188,11 @@ struct PCTile: View {
 struct ShortcutsPane: View {
     @Environment(MoonlightManager.self) private var moonlight
     @State private var showChordCapture = false
+    // Default-ON: linearize the Mac's mouse acceleration while a stream is
+    // focused so only the game's own sensitivity shapes aim. Key mirrors
+    // MouseAccelerationControl.enabledDefaultsKey (registered true in GlimmerApp,
+    // which is what makes the non-UI UserDefaults.bool read default to on too).
+    @AppStorage("disableMouseAccelWhileStreaming") private var rawMouseWhileStreaming: Bool = true
 
     var body: some View {
         // @Bindable shim - surfaces $moonlight.x bindings from an @Observable
@@ -269,9 +274,20 @@ struct ShortcutsPane: View {
                     .foregroundStyle(.secondary)
             }
 
-            // (Raw/accel-free mouse was explored here but shelved: CGEventTap
-            // deltas are accelerated and the system accel-disable is intrusive.
-            // See issue #22, closed not-planned. Mouse motion uses macOS's deltas.)
+            Section("Mouse") {
+                Toggle(isOn: $rawMouseWhileStreaming) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Aim with raw mouse motion while streaming").fontWeight(.medium)
+                        Text("Turns off the Mac's own mouse acceleration while the stream window "
+                            + "is focused, so only the game's sensitivity shapes your aim instead of "
+                            + "the Mac's pointer curve stacking on top of it. Restored the instant "
+                            + "you leave the stream. Affects mice only - the trackpad is untouched.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .help("Linearizes the system mouse acceleration (like `com.apple.mouse.scaling -1`) for the duration of each focused stream.")
+            }
         }
         .formStyle(.grouped)
         .sheet(isPresented: $showChordCapture) {

--- a/Glimmer/SettingsView.swift
+++ b/Glimmer/SettingsView.swift
@@ -6,7 +6,11 @@ import SwiftUI
 // MARK: - Settings Root
 
 enum SettingsPane: String, CaseIterable, Identifiable {
-    case general, streaming, pcs, shortcuts, troubleshooting, diagnostics, about
+    // `.diagnostics` is the merged home for what used to be two panes:
+    // the always-visible troubleshooting surface (controller input test + logs)
+    // plus the option-click-revealed telemetry/tuning wires. The old
+    // `.troubleshooting` case folded into it.
+    case general, streaming, pcs, shortcuts, diagnostics, about
 
     var id: String { rawValue }
     var title: String {
@@ -23,7 +27,6 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         // keys, controller raw-HID + quit chord, mouse). Case/rawValue
         // "shortcuts" stays put so nothing persisted/deep-linked breaks.
         case .shortcuts: return "Input"
-        case .troubleshooting: return "Troubleshooting"
         case .diagnostics: return "Diagnostics"
         case .about: return "About"
         }
@@ -37,8 +40,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .streaming: return "dial.high.fill"
         case .pcs: return "display"
         case .shortcuts: return "keyboard.fill"
-        case .troubleshooting: return "stethoscope"
-        case .diagnostics: return "waveform.path.ecg"
+        case .diagnostics: return "stethoscope"
         // System Settings' About uses `info.circle.fill` - the bare "info"
         // symbol doesn't ship in SF Symbols 6 and falls back to a missing
         // glyph on macOS 26.
@@ -52,8 +54,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .streaming: return .red
         case .pcs: return .orange
         case .shortcuts: return .indigo
-        case .troubleshooting: return .teal
-        case .diagnostics: return .purple
+        case .diagnostics: return .teal
         case .about: return .gray
         }
     }
@@ -63,12 +64,11 @@ struct SettingsRoot: View {
     @Environment(MoonlightManager.self) private var moonlight
     @State private var selection: SettingsPane = .general
 
-    /// Panes shown in the sidebar. Diagnostics is HIDDEN until revealed by the
-    /// option-click gesture on the version line in About - normal users never
-    /// see it, so the debug/tuning wires stay out of the way.
-    private var visiblePanes: [SettingsPane] {
-        SettingsPane.allCases.filter { $0 != .diagnostics || moonlight.showDiagnostics }
-    }
+    /// Panes shown in the sidebar. All are always present now: Diagnostics holds
+    /// the always-visible troubleshooting surface (controller input test + logs),
+    /// and its debug/tuning sections stay hidden INSIDE the pane until the
+    /// option-click gesture on the About version line flips `showDiagnostics`.
+    private var visiblePanes: [SettingsPane] { SettingsPane.allCases }
 
     var body: some View {
         // NavigationSplitView's master column auto-adopts Liquid Glass
@@ -114,12 +114,6 @@ struct SettingsRoot: View {
             .scrollContentBackground(.hidden)
             .navigationSplitViewColumnWidth(min: 170, ideal: 190)
             .toolbar(removing: .sidebarToggle)
-            // If the user collapses the Diagnostics reveal while it's the
-            // selected pane, fall back to General so the detail view doesn't
-            // point at a now-hidden pane.
-            .onChange(of: moonlight.showDiagnostics) { _, shown in
-                if !shown, selection == .diagnostics { selection = .general }
-            }
         } detail: {
             Group {
                 switch selection {
@@ -127,7 +121,6 @@ struct SettingsRoot: View {
                 case .streaming: QualityPane()
                 case .pcs: PCsPane()
                 case .shortcuts: ShortcutsPane()
-                case .troubleshooting: TroubleshootingPane()
                 case .diagnostics: DiagnosticsPane()
                 case .about: AboutPane()
                 }

--- a/Glimmer/Stream/ControllerForwarder+QuitChord.swift
+++ b/Glimmer/Stream/ControllerForwarder+QuitChord.swift
@@ -42,8 +42,6 @@ extension InputForwarder {
         case .l3r3:
             return (pad.leftThumbstickButton?.isPressed ?? false)
                 && (pad.rightThumbstickButton?.isPressed ?? false)
-        case .home:
-            return pad.buttonHome?.isPressed ?? false
         case .custom:
             let custom = customControllerChordProvider()
             return !custom.isEmpty && custom.isSubset(of: heldControllerButtons(pad: pad))
@@ -66,7 +64,7 @@ extension InputForwarder {
             return true   // "select" maps to Create, which GameController drops on DualSense
         case .custom:
             return !customControllerChordProvider().isDisjoint(with: [.create, .mute])
-        case .none, .l1r1, .l1r1l2r2, .l3r3, .home:
+        case .none, .l1r1, .l1r1l2r2, .l3r3:
             return false
         }
     }

--- a/Glimmer/Stream/ControllerForwarder.swift
+++ b/Glimmer/Stream/ControllerForwarder.swift
@@ -109,6 +109,14 @@ extension InputForwarder {
         }
         gamepadMask |= UInt16(1) << slot
 
+        // Light the controller's player-number LEDs to match its slot - the one
+        // native touch the pad was missing. GameController owns this on macOS (it
+        // drives the DualSense's player dots, the Xbox quadrant, etc.), so we use
+        // the official playerIndex rather than poking raw-HID LED bytes and
+        // fighting gamecontrollerd. Only indices 1-4 exist; a 5th+ pad (slot >= 4,
+        // Sunshine-only territory) stays unset and keeps the system default.
+        gamepad.playerIndex = GCControllerPlayerIndex(rawValue: Int(slot)) ?? .indexUnset
+
         // Determine controller type from GameController metadata. macOS doesn't
         // expose a clean type enum, so we infer from product category strings.
         let kind = controllerType(for: gamepad)

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -466,6 +466,9 @@ enum MouseAccelerationControl {
     private static let pendingRestoreKey = "mouseAccelPendingRestore"
     /// The "disabled / linear" acceleration value (mirrors `com.apple.mouse.scaling -1`).
     static let linear = -1.0
+    /// One-time latch so a failing/absent IOKit acceleration API logs a single
+    /// NOTICE, not one per stream focus. Single-writer on the @MainActor capture path.
+    nonisolated(unsafe) private static var loggedAPIUnavailable = false
 
     /// Whether the linearize-while-focused feature is on (default true).
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }
@@ -476,8 +479,19 @@ enum MouseAccelerationControl {
     /// the crash-safety sentinel only when it actually overrides.
     static func engageLinear() -> Double? {
         let prior = gl_get_mouse_acceleration()
-        // -2.0 = read failure; < 0 (e.g. -1) = already disabled - either way
-        // there is no positive value of ours to restore later, so do nothing.
+        // < -1.5 = the (deprecated, private) IOKit acceleration API failed or is
+        // gone on this OS (the read sentinel is -2.0). Degrade silently - the
+        // stream is unaffected, the mouse just keeps the Mac's acceleration - but
+        // log ONCE so a future-macOS regression is visible in the log.
+        if prior < -1.5 {
+            if !loggedAPIUnavailable {
+                loggedAPIUnavailable = true
+                Diag.notice("Mouse: pointer-acceleration API unavailable - raw-aim "
+                    + "linearization disabled (stream unaffected)", "Input")
+            }
+            return nil
+        }
+        // prior in [-1, 0): the user already runs linear - nothing of ours to undo.
         guard prior >= 0 else { return nil }
         let defaults = UserDefaults.standard
         defaults.set(prior, forKey: pendingRestoreKey)

--- a/Glimmer/Stream/Native/RtpVideoQueue.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue.swift
@@ -538,6 +538,12 @@ final class RtpVideoQueue {
     // MARK: - little-endian read
 
     @inline(__always) func le32(_ b: [UInt8], _ off: Int) -> UInt32 {
-        UInt32(b[off]) | (UInt32(b[off + 1]) << 8) | (UInt32(b[off + 2]) << 16) | (UInt32(b[off + 3]) << 24)
+        // Defense-in-depth: every current caller (AddPacket / Reconstruct) already
+        // rejects packets shorter than the NV header before reading, so this guard
+        // never fires today. It's here so the bare helper can't trap on a future
+        // caller that forgets the length check - a short read degrades to 0, not a
+        // hard crash in a release build where array bounds checks are compiled out.
+        guard off >= 0, off + 3 < b.count else { return 0 }
+        return UInt32(b[off]) | (UInt32(b[off + 1]) << 8) | (UInt32(b[off + 2]) << 16) | (UInt32(b[off + 3]) << 24)
     }
 }

--- a/Glimmer/Stream/Native/VideoRtpReceiver.swift
+++ b/Glimmer/Stream/Native/VideoRtpReceiver.swift
@@ -296,28 +296,52 @@ final class VideoRtpReceiver: VideoDepacketizerDelegate, @unchecked Sendable {
             // Batched receive (issue #24): up to `cap` datagrams per recvmsg_x
             // syscall, cutting the ~14k recvfrom/s floor at 4K240 (measurably
             // smoother). Buffers allocated once and reused; handleDatagram
-            // copies each out - the win is the syscall COUNT. recvmsg_x is
-            // universally available on macOS; the plain recvfrom path it
-            // replaced is in git history if a fallback is ever needed.
+            // copies each out - the win is the syscall COUNT. recvmsg_x is a
+            // Darwin-PRIVATE syscall with no public contract; if a future kernel
+            // ever drops it the call returns ENOSYS and we fall back to one
+            // recvfrom per datagram (slower - the syscall-count win is gone - but
+            // correct) for the rest of the session. A removed SPI then degrades
+            // the stream, it doesn't kill it.
             let cap = 32
             let stride = bufSize
             let storage = UnsafeMutablePointer<UInt8>.allocate(capacity: cap * stride)
             let lengths = UnsafeMutablePointer<Int32>.allocate(capacity: cap)
             defer { storage.deallocate(); lengths.deallocate() }
+            var batched = true
             while let self, !self.interrupted.isSet {
-                let n = gl_recvmsg_x_batch(sock, storage, Int32(stride), Int32(cap), lengths)
-                if n > 0 {
-                    for i in 0..<Int(n) {
-                        // Clamp to stride: a bad length (never observed, but a
-                        // private-API misread would be) must not read OOB.
-                        let len = min(Int(lengths[i]), stride)
-                        guard len > 0 else { continue }
-                        self.handleDatagram(Array(UnsafeBufferPointer(start: storage + i * stride, count: len)))
+                if batched {
+                    let n = gl_recvmsg_x_batch(sock, storage, Int32(stride), Int32(cap), lengths)
+                    if n > 0 {
+                        for i in 0..<Int(n) {
+                            // Clamp to stride: a bad length (never observed, but a
+                            // private-API misread would be) must not read OOB.
+                            let len = min(Int(lengths[i]), stride)
+                            guard len > 0 else { continue }
+                            self.handleDatagram(Array(UnsafeBufferPointer(start: storage + i * stride, count: len)))
+                        }
+                    } else if n < 0 {
+                        let err = errno
+                        if err == EAGAIN || err == EWOULDBLOCK || err == EINTR { continue } // poll timeout
+                        if err == ENOSYS {
+                            // Batched receive not implemented on this kernel - drop
+                            // to the per-datagram path for the rest of the session.
+                            Diag.notice("recvmsg_x unavailable (ENOSYS) - falling back to recvfrom", Self.cat)
+                            batched = false
+                            continue
+                        }
+                        break // socket closed (stop) or fatal
                     }
-                } else if n < 0 {
-                    let err = errno
-                    if err == EAGAIN || err == EWOULDBLOCK || err == EINTR { continue } // poll timeout
-                    break // socket closed (stop) or fatal
+                } else {
+                    // Fallback: one recvfrom per datagram. Same SO_RCVTIMEO-driven
+                    // EAGAIN cancellation as the batched path; close(fd) unblocks it.
+                    let len = recvfrom(sock, storage, stride, 0, nil, nil)
+                    if len > 0 {
+                        self.handleDatagram(Array(UnsafeBufferPointer(start: storage, count: min(len, stride))))
+                    } else if len < 0 {
+                        let err = errno
+                        if err == EAGAIN || err == EWOULDBLOCK || err == EINTR { continue }
+                        break
+                    }
                 }
             }
         }

--- a/Glimmer/Stream/StatsOverlayLayer.swift
+++ b/Glimmer/Stream/StatsOverlayLayer.swift
@@ -175,17 +175,30 @@ public final class StatsOverlayLayer {
 
         let hostWidth = host.bounds.width
         let hostHeight = host.bounds.height
+        let centerX = (hostWidth - boxWidth) / 2
+        // Top-center clears the camera notch: on a notched panel the safe-area
+        // top inset is the notch band, so anchor below it (with a small gap);
+        // elsewhere safeAreaInsets.top is 0 and this collapses to the normal
+        // inset. CALayer origin is bottom-left, so "top" is the larger y.
+        let notchTop = NSScreen.main?.safeAreaInsets.top ?? 0
+        let topCenterY = hostHeight - max(inset, notchTop + 8) - boxHeight
         let x: CGFloat
         let y: CGFloat
         switch corner {
         case .topLeft:
             x = inset
             y = hostHeight - inset - boxHeight
+        case .topCenter:
+            x = centerX
+            y = topCenterY
         case .topRight:
             x = hostWidth - inset - boxWidth
             y = hostHeight - inset - boxHeight
         case .bottomLeft:
             x = inset
+            y = inset
+        case .bottomCenter:
+            x = centerX
             y = inset
         case .bottomRight:
             x = hostWidth - inset - boxWidth

--- a/Glimmer/Stream/Types+Stats.swift
+++ b/Glimmer/Stream/Types+Stats.swift
@@ -204,15 +204,20 @@ public struct StatsThresholds: Sendable, Equatable, Codable {
 /// cursor is hidden, right-click is a game input, not a launcher
 /// gesture), so the positional preference lives in Settings.
 public enum StatsOverlayCorner: String, CaseIterable, Sendable {
-    case topLeft, topRight, bottomLeft, bottomRight
+    // "Corner" by history; now also carries the two edge-centers. Top-center
+    // sits clear of the camera notch; bottom-center rides the bottom edge.
+    // rawValues are the case names, so adding cases mid-list is persistence-safe.
+    case topLeft, topCenter, topRight, bottomLeft, bottomCenter, bottomRight
 
     /// Human-readable label for the Settings picker.
     public var displayName: String {
         switch self {
-        case .topLeft:     return "Top left"
-        case .topRight:    return "Top right"
-        case .bottomLeft:  return "Bottom left"
-        case .bottomRight: return "Bottom right"
+        case .topLeft:      return "Top left"
+        case .topCenter:    return "Top center (under the notch)"
+        case .topRight:     return "Top right"
+        case .bottomLeft:   return "Bottom left"
+        case .bottomCenter: return "Bottom center"
+        case .bottomRight:  return "Bottom right"
         }
     }
 }

--- a/Glimmer/TroubleshootingPane.swift
+++ b/Glimmer/TroubleshootingPane.swift
@@ -1,53 +1,20 @@
 //
 //  TroubleshootingPane.swift
 //
-//  Settings → Troubleshooting. A live controller input test (the diagnostic
-//  for "controller input dies after Cmd-Tab" - it reads GameController
-//  directly, so if signals stay live here but not in-stream, the stream's
-//  forwarding is the culprit), a battery readout, and an in-app log viewer
-//  (Sunshine-style - read the app's own unified-log entries without leaving
-//  the app).
+//  Hosts the opt-in raw-HID DualSense control (RawHIDControl), used by
+//  Settings → Input. The Troubleshooting PANE that used to live here - the
+//  controller input test + the log viewer - folded into the always-visible part
+//  of Settings → Diagnostics (one pane instead of two thin ones; the input test
+//  and logs stay reachable by everyone, the telemetry/tuning sections reveal via
+//  the About option-click). Only this shared control remains here; the file name
+//  is kept to avoid an Xcode project-file edit.
 //
 
 import AppKit
-import GameController
 import SwiftUI
 
-struct TroubleshootingPane: View {
-    @Environment(MoonlightManager.self) private var moonlight
-
-    var body: some View {
-        Form {
-            // The "Extra DualSense buttons" raw-HID control now lives in
-            // Settings → Input (alongside the mouse + controller-quit settings),
-            // so all raw input shares one home. Troubleshooting keeps the live
-            // input TEST + logs - the diagnostics, not the settings.
-            Section {
-                ControllerInputTest()
-            } header: {
-                Text("Controller input test")
-            } footer: {
-                Text("Reads the controller directly through macOS. If a signal "
-                    + "lights up here but not in a stream, the issue is in how "
-                    + "the stream forwards it - try this view right after a "
-                    + "Cmd-Tab to confirm input is still live.")
-            }
-
-            Section {
-                LogViewer()
-            } header: {
-                Text("Logs")
-            } footer: {
-                Text("Recent entries from Glimmer's unified log. Copy them when "
-                    + "filing an issue.")
-            }
-        }
-        .formStyle(.grouped)
-    }
-}
-
 // Module-internal (was private) so Settings → Input can host it alongside the
-// mouse + controller-quit settings; the live input test below stays here.
+// mouse + controller-quit settings.
 /// Opt-in control for the raw-HID DualSense reader. Off by default; turning it
 /// on shows a plain-language explanation BEFORE macOS's "Input Monitoring"
 /// prompt, so that scary system dialog is never a surprise.

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.18
-CURRENT_PROJECT_VERSION = 20260629
+MARKETING_VERSION = 2026.6.19
+CURRENT_PROJECT_VERSION = 20260630

--- a/docs/vddsettings.xml
+++ b/docs/vddsettings.xml
@@ -56,6 +56,26 @@
     <resolution><width>3456</width><height>2234</height><refresh_rate>120</refresh_rate></resolution>
     <resolution><width>3456</width><height>2234</height><refresh_rate>240</refresh_rate></resolution>
 
+    <!-- Apple "default Retina scale" sizes (Glimmer's HiDPI preset = panel
+         native halved, the logical point grid macOS lays the UI out in). A
+         quarter of the pixels of the native entries above; the Mac integer-
+         upscales 2x on display, so they stay crisp at far lower bandwidth. -->
+    <resolution><width>1280</width><height>800</height><refresh_rate>60</refresh_rate></resolution>    <!-- 13" MBP HiDPI -->
+    <resolution><width>1280</width><height>800</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>1280</width><height>832</height><refresh_rate>60</refresh_rate></resolution>    <!-- 13" Air HiDPI -->
+    <resolution><width>1280</width><height>832</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>1440</width><height>932</height><refresh_rate>60</refresh_rate></resolution>    <!-- 15" Air HiDPI -->
+    <resolution><width>1440</width><height>932</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>1512</width><height>982</height><refresh_rate>60</refresh_rate></resolution>    <!-- 14" MBP HiDPI -->
+    <resolution><width>1512</width><height>982</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>1728</width><height>1117</height><refresh_rate>60</refresh_rate></resolution>   <!-- 16" MBP HiDPI -->
+    <resolution><width>1728</width><height>1117</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>2240</width><height>1260</height><refresh_rate>60</refresh_rate></resolution>   <!-- 24" iMac HiDPI -->
+    <resolution><width>2240</width><height>1260</height><refresh_rate>120</refresh_rate></resolution>
+    <resolution><width>3008</width><height>1692</height><refresh_rate>60</refresh_rate></resolution>   <!-- 6K Pro Display XDR HiDPI -->
+    <!-- (5K Studio Display HiDPI = 2560x1440 and 4K external HiDPI = 1920x1080
+         are already covered by the 16:9 standards above.) -->
+
     <!-- Ultrawide + high-res external (5K Studio Display, 6K Pro Display XDR, 8K) -->
     <resolution><width>3440</width><height>1440</height><refresh_rate>60</refresh_rate></resolution>
     <resolution><width>3440</width><height>1440</height><refresh_rate>120</refresh_rate></resolution>


### PR DESCRIPTION
Polish pass across Settings, the controller, and stream robustness.

**Quality / display**
- Reworked resolution presets: "Match my display" → "Native Retina"; dropped Smooth/Maximum; added a HiDPI preset (native ÷ 2, ~¼ the bandwidth) with VDD modes.
- Notch coverage is a single-line toggle under the resolution picker.
- Stats overlay gains top-center (under the notch) and bottom-center positions.

**Settings**
- Raw-mouse aim toggle → Input; Wi-Fi (AWDL) stutter-smoothing → Quality.
- Merged Troubleshooting into Diagnostics (input test + logs always visible; telemetry/tuning revealed via the About option-click).
- About reordered (Support / License / Projects we like) and a couple of long footers tightened.

**Controller**
- DualSense player-number LEDs light to match the controller's slot (GCController.playerIndex).
- Removed the unreliable Home/Guide quit chord (macOS reserves that button); Options+Create+L1+R1 remains.

**Robustness**
- Hardened a SwiftUI/AttributeGraph layout crash by making the display-change quality recompute idempotent.
- recvmsg_x → recvfrom fallback if a future macOS drops the private syscall; le32 bounds guard; mouse-accel API-failure logging.

Build + 146 tests green.