### PR TITLE
Audit cleanup + release 2026.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026.6.20 - 2026-06-22
+
+A maintenance pass. Fixes a couple of stale in-app pointers left by the
+Troubleshooting/Diagnostics merge - the DualSense chord tip and the quit-chord
+hint now send you to Settings > Input, where those controls actually live. The
+mute-while-streaming toggle reads outcome-first with a clearer footnote, the
+Custom resolution helper is now a "Use native resolution" button, and the
+empty-state copy settles on a single "Pair a PC."
+
+Everything else is under-the-hood housekeeping: stale comments and docs brought
+back in line with the code - notably the security notes, which now describe the
+current OpenSSL certificate-pinning path - and internal planning shorthand
+scrubbed out of the source.
+
 ## 2026.6.19 - 2026-06-21
 
 A polish pass across Settings, the controller, and stream robustness.

--- a/Glimmer/AboutPane.swift
+++ b/Glimmer/AboutPane.swift
@@ -88,7 +88,7 @@ struct AboutPane: View {
                 .padding(.vertical, 6)
             }
             // Order: Support up top (the one ask), License in the middle (the
-            // legal fact), and the projects we lean on at the bottom as a
+            // legal fact), and the third-party credits at the bottom as a
             // closing note of appreciation.
             Section("Support") {
                 if let url = URL(string: AboutLink.donate) {

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -163,7 +163,11 @@ struct GeneralPane: View {
                         Button("Open Login Items") { SMAppService.openSystemSettingsLoginItems() }
                     }
                 }
-                Toggle("Silence this Mac while streaming (when sound plays on the gaming PC)", isOn: $moonlight.muteMacWhileStreaming)
+                Toggle("Mute this Mac while streaming", isOn: $moonlight.muteMacWhileStreaming)
+                Text("Keeps game audio on the gaming PC's output only; this Mac stays silent "
+                    + "for the length of the stream.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
             Section("Default action") {
                 // Picker sourced from the selected host's announced app
@@ -376,7 +380,7 @@ struct QualityPane: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()
-                        Button("Match this Mac's display") {
+                        Button("Use native resolution") {
                             moonlight.snapCustomToDisplay()
                         }
                         .buttonStyle(.borderless)
@@ -460,17 +464,7 @@ struct QualityPane: View {
                     .foregroundStyle(.secondary)
             }
 
-            // EXPERIMENTS FENCE - the single home for try-it-and-see dials so
-            // they never scatter across panes. Anything here must be safe to
-            // flip blind and safe to ignore. A dial that proves itself moves
-            // up into a real section; one that doesn't gets deleted, not
-            // hidden. (The notch toggle graduated to a pill under the Preset
-            // picker - full-panel coverage is the product default, not an
-            // experiment.) The fence is currently EMPTY, so no Section
-            // is emitted at all: SwiftUI's grouped Form renders a Section
-            // HEADER even over an EmptyView body, leaving a dangling flask
-            // card. Re-add `Section { ... } header: { Label("Experiments",
-            // systemImage: "flask") }` with the first new dial.
+            // No Experiments section yet. Don't emit an empty `Section { } header: { Label("Experiments", systemImage: "flask") }` — SwiftUI's grouped Form renders the Section header even over an EmptyView body, leaving a dangling flask card. Add the Section back together with the first real dial.
         }
         .formStyle(.grouped)
         .onAppear { awdl.refresh() }

--- a/Glimmer/SettingsPCsShortcutsPanes.swift
+++ b/Glimmer/SettingsPCsShortcutsPanes.swift
@@ -35,7 +35,7 @@ struct PCsPane: View {
                             .foregroundStyle(.tint)
                         Text("No PCs paired")
                             .font(.headline)
-                        Text("Add a PC to stream from your Mac.")
+                        Text("Pair a PC to stream games to this Mac.")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
@@ -55,7 +55,7 @@ struct PCsPane: View {
                         initialPairAddress = ""
                         showPairSheet = true
                     } label: {
-                        Label("Pair a new PC", systemImage: "plus.circle.fill")
+                        Label("Pair a PC", systemImage: "plus.circle.fill")
                     }
                     .buttonStyle(StreamButtonStyle())
                     Button("Refresh paired PCs") {
@@ -336,7 +336,7 @@ private struct ChordCaptureSheet: View {
             }
 
             if DualSenseHID.isEnabled == false {
-                Text("Tip: turn on Extra DualSense buttons (Troubleshooting) to record "
+                Text("Tip: turn on Extra DualSense buttons (Settings → Input) to record "
                     + "the Options / Create / Mute buttons.")
                     .font(.caption2).foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -406,7 +406,7 @@ extension AudioDecoder {
         }
     }
 
-    // MARK: - Drift micro-stretch (deterministic clock-skew repayment)
+    // MARK: - Drift-tracking resampler (deterministic clock-skew repayment)
     //
     //  MEASURED FAULT (a long wired 4K240 test): the audio clock
     //  drift gauge ramped at a rock-constant −39..−40.4µs/s in every quiet
@@ -415,28 +415,12 @@ extension AudioDecoder {
     //  drain math for a 40-80ms reservoir at 40ppm.
     //  A deterministic drain, not link noise - the cushion ladder can only
     //  stretch the period (deeper target → longer walk to empty), never fix
-    //  it. The repayment: once the LONG-WINDOW accumulated drift proves a
-    //  standing skew, insert one 5ms silence packet per 5ms of accrued skew
-    //  (~40µs/s at the measured 40ppm - one packet per ~2min, inaudible) so
-    //  the cushion holds its depth instead of walking to empty. Discrete
-    //  packet quanta in the trim machinery's idiom - threshold-armed,
-    //  rate-limited, standing down in distress windows - NOT a resampler:
-    //  no signal-path rework, no decoder state touched, and the cadence the
-    //  steady-state trim already proved inaudible bounds this too.
-    //
-    //  JITTERY-LINK ARGUMENT (why this can't oscillate on a bursty link): the
-    //  key is the CUMULATIVE per-segment drift - an integral needing many
-    //  minutes of one-sided ppm-scale accrual to reach the arm point - never
-    //  a short-window slope. Delivery jitter can only push that gauge
-    //  POSITIVE (a late clump stalls `framesScheduled` while wall time runs;
-    //  media the host hasn't sent cannot arrive early), so burst wobble moves
-    //  the residual AWAY from the arm point - and the threshold is 6× the
-    //  5ms single-packet granularity besides. Corroboration gate: a stretch
-    //  also requires the fill to actually sit a full step short of target, so
-    //  a gauge gone haywire against a healthy cushion does nothing. And every
-    //  distress window disarms it outright - un-primed, drained, and the
-    //  post-(re)prime grace belong to the under-run/rebuild machinery, which
-    //  keeps sole custody of recovery there.
+    //  it. The varispeed PI loop below
+    //  (`driveResampler`) repays it: it steers the playout rate by ppm to absorb
+    //  the standing host↔Mac clock offset so the cushion holds its depth instead
+    //  of walking to empty. This replaced an earlier decode-path "5ms silence
+    //  packet per 5ms of accrued skew" micro-stretch (AudioDecoder.swift notes
+    //  the swap).
 
     /// Drift-tracking resampler PI loop. Called ~per decoded packet from
     /// `publishAudioState`; self-rate-limits to ~4Hz (drift is ppm-slow). When

--- a/Glimmer/Stream/ControllerForwarder+QuitChord.swift
+++ b/Glimmer/Stream/ControllerForwarder+QuitChord.swift
@@ -123,7 +123,7 @@ extension InputForwarder {
 
 /// The set of buttons currently held on a gamepad, used both to match a
 /// recorded `.custom` chord (ControllerForwarder) and to drive the Settings
-/// capture sheet (issue #9). Reads GameController plus the DualSense raw-HID
+/// capture sheet. Reads GameController plus the DualSense raw-HID
 /// center buttons - the same sources `sendGamepadUpdate` forwards. Free
 /// function (not an InputForwarder method) so the Settings capture sheet, which
 /// has no live stream, can call it too.

--- a/Glimmer/Stream/ControllerForwarder.swift
+++ b/Glimmer/Stream/ControllerForwarder.swift
@@ -168,7 +168,7 @@ extension InputForwarder {
             Self.warnedQuitChordNeedsRawHID = true
             Diag.notice("Quit chord needs DualSense centre buttons (Create/Mute) that require "
                 + "raw-HID, but raw-HID controller support is OFF - the chord will NOT fire on "
-                + "this DualSense. Enable raw-HID in Settings → Troubleshooting (and grant Input "
+                + "this DualSense. Enable 'Extra DualSense buttons' in Settings → Input (and grant Input "
                 + "Monitoring), or pick a chord that uses GameController-native buttons.",
                 "Controller")
         }
@@ -520,7 +520,7 @@ extension InputForwarder {
         return buttons
     }
 
-    // MARK: - Touchpad surface forwarding (#6)
+    // MARK: - Touchpad surface forwarding
 
     /// One tracked finger contact on a controller touchpad.
     struct TouchpadFinger {
@@ -629,7 +629,7 @@ extension InputForwarder {
         }
     }
 
-    // MARK: - Focus resync (#8)
+    // MARK: - Focus resync
 
     /// Re-send every attached controller's current state to the host. Called
     /// when the stream window regains key focus, so a stick held across a focus

--- a/Glimmer/Stream/Discovery.swift
+++ b/Glimmer/Stream/Discovery.swift
@@ -162,7 +162,7 @@ public actor HostDiscovery {
     /// Drop the interface-zone suffix Network appends to a resolved address
     /// (e.g. `192.0.2.10%en0`). The zone is an interface hint that's noise
     /// for a routable address and breaks the HTTP/TLS host parsing downstream
-    /// (pairing dialed the literal `...%en0` and failed - issue #21). It is
+    /// (pairing dialed the literal `...%en0` and failed). It is
     /// REQUIRED for IPv6 link-local (fe80::/10) to connect at all, so keep it
     /// there; strip it everywhere else.
     static func canonicalHost(_ raw: String, ipv6: Bool) -> String {

--- a/Glimmer/Stream/EnvSignalController.swift
+++ b/Glimmer/Stream/EnvSignalController.swift
@@ -74,7 +74,7 @@ final class EnvSignalController: @unchecked Sendable {
     static let shared = EnvSignalController()
     private static let cat = "EnvSignal"
 
-    // MARK: - Reconciler kill-switch (INCREMENT 1 - the A/B flag)
+    // MARK: - Reconciler kill-switch (the A/B flag)
 
     /// When TRUE (the default) the unified LINK RECONCILER is live: this
     /// controller publishes ONE jitter→headroom decision (`headroomLevel` +
@@ -147,7 +147,7 @@ final class EnvSignalController: @unchecked Sendable {
     /// session can never escalate off an unwarmed percentile.
     static let radioBaselineMinSamples = 60
 
-    // MARK: - Reconciler decision tunables (INCREMENT 1)
+    // MARK: - Reconciler decision tunables
 
     /// Maximum published headroom level. Matches FecHeadroomController.maxLevel
     /// (3 = (48ms − 24ms) / 8ms) so a clean link→0 and full escalation→3 maps
@@ -212,7 +212,7 @@ final class EnvSignalController: @unchecked Sendable {
     /// only trusts the route within `routeTrustHorizonNanos` of this.
     private var lastFedNanos: UInt64 = 0
 
-    // MARK: - Published reconciler decision (INCREMENT 1, lock-guarded)
+    // MARK: - Published reconciler decision (lock-guarded)
     //
     // The single jitter→headroom decision both actuators PULL on their own
     // ticks. Computed in the reconcile phase at window close (`reconcileLocked`)
@@ -413,7 +413,7 @@ final class EnvSignalController: @unchecked Sendable {
         var rssiP50: Int?
         var txP95: Double?
         var radioArmed = false
-        // JITTER evidence (INCREMENT 1): the worst recv-jitter (ms) seen across
+        // JITTER evidence: the worst recv-jitter (ms) seen across
         // the window's ticks (live gauge, max-folded), plus the window-summed
         // out-of-order + ENet-retransmit deltas. Folded delta-snapshotted like
         // the gap counters so the state classifier captures the jitter racer the
@@ -553,7 +553,7 @@ final class EnvSignalController: @unchecked Sendable {
             }
         }
 
-        // INCREMENT 1: jitter/loss is now a first-class degradation input
+        // Jitter/loss is now a first-class degradation input
         // alongside co-gap + radio, using FecHeadroomController's already-tuned
         // thresholds (window predicates above). The classifier captures the
         // jitter racer, so the published headroom tracks it instead of two

--- a/Glimmer/Stream/FramePacer+AdaptiveDepth.swift
+++ b/Glimmer/Stream/FramePacer+AdaptiveDepth.swift
@@ -61,7 +61,7 @@ extension FramePacer {
         os_unfair_lock_unlock(&lock)
     }
 
-    // MARK: - Adaptive target depth (Issue 2a). All run under `lock`.
+    // MARK: - Adaptive target depth. All run under `lock`.
 
     /// The depth the CURRENT desired target justifies - the value the rate-limited
     /// grow/decay actuator walks `adaptiveTargetDepth` toward. Clamped to

--- a/Glimmer/Stream/FramePacer+DueGate.swift
+++ b/Glimmer/Stream/FramePacer+DueGate.swift
@@ -276,7 +276,7 @@ extension FramePacer {
         var trimmed: [CMSampleBuffer] = []
         var sampledDepth = 0
 
-        // INCREMENT 1: refresh the reconciler's desired target BEFORE taking the
+        // Refresh the reconciler's desired target BEFORE taking the
         // pacer lock (the refresh briefly takes the controller's lock; doing it
         // here keeps the pacer from ever holding two locks). The grow/decay math
         // below - under the pacer lock - then reads only the pulled snapshot.

--- a/Glimmer/Stream/FramePacer+FrameRateRange.swift
+++ b/Glimmer/Stream/FramePacer+FrameRateRange.swift
@@ -1,7 +1,7 @@
 //
 //  FramePacer+FrameRateRange.swift
 //
-//  The present-callback throttle floor (FIX #1). Split out of FramePacer.swift
+//  The present-callback throttle floor. Split out of FramePacer.swift
 //  to keep that file under the length limit; these are the pure / view-reading
 //  static helpers that build the CADisplayLink `preferredFrameRateRange` so
 //  macOS cannot throttle the present callback below stream cadence on a static
@@ -111,7 +111,7 @@ extension FramePacer {
     }
 
     /// Build the CADisplayLink frame-rate range that forbids throttling the
-    /// present callback below the stream cadence on a static layer (FIX #1).
+    /// present callback below the stream cadence on a static layer.
     /// `minimum` is pinned to the stream Hz so macOS keeps the callback firing
     /// at stream cadence even on a flat scene; `maximum` is the panel max. The
     /// floor is CLAMPED to `min(streamHz, panelMaxHz)` so a sub-stream-fps

--- a/Glimmer/Stream/FramePacer+Recovery.swift
+++ b/Glimmer/Stream/FramePacer+Recovery.swift
@@ -115,7 +115,7 @@ extension FramePacer {
             self?.handleTick(link)
         }
         let link = view.displayLink(target: proxy, selector: #selector(DisplayLinkProxy.tick(_:)))
-        // FIX #1 - FORBID macOS from throttling the PRESENT CALLBACK below stream
+        // FORBID macOS from throttling the PRESENT CALLBACK below stream
         // cadence on a static/AFK layer. Without a floor, macOS slows the
         // CADisplayLink callback on a flat layer (NOT a ProMotion display
         // ramp-down - the panel stayed 120Hz; it is the CALLBACK being
@@ -140,7 +140,7 @@ extension FramePacer {
             forStreamIntervalSeconds: self.configuredFrameIntervalSeconds,
             panelMaxHz: panelMax)
         link.preferredFrameRateRange = range
-        // Record the floor we just pinned so the per-tick re-apply (FIX #1) only
+        // Record the floor we just pinned so the per-tick re-apply only
         // re-pins on a real cadence drift past the hysteresis, not on every tick.
         // Re-seeded on every (re)bind / screen change because installLink is the
         // single bind path, so a rebuild onto a different panel re-clamps cleanly.

--- a/Glimmer/Stream/FramePacer+Tick.swift
+++ b/Glimmer/Stream/FramePacer+Tick.swift
@@ -86,7 +86,7 @@ extension FramePacer {
         lastTickHostTime = hostNow
         tickCount &+= 1
         // Snapshot the PTS-refined stream interval under the lock so the
-        // main-actor floor re-apply (FIX #1) reads a consistent value without a
+        // main-actor floor re-apply reads a consistent value without a
         // second lock acquisition. `streamFrameIntervalSeconds` is written on the
         // decode/pacing queue (submit's median refine); this is the only place we
         // read it main-side.
@@ -136,7 +136,7 @@ extension FramePacer {
                 "fromHz=\(changedFromHz, privacy: .public) toHz=\(changedToHz, privacy: .public)")
         }
 
-        // FIX #1 (re-apply): the present-callback floor is seeded at install from
+        // Floor re-apply: the present-callback floor is seeded at install from
         // the CONFIGURED fps, but the true cadence is learned from PTS deltas once
         // frames flow (a configured-vs-actual mismatch, or a mid-stream fps change
         // like 60→120). Re-pin the floor from the refined cadence here - on the
@@ -149,7 +149,7 @@ extension FramePacer {
         }
     }
 
-    // The FIX #1 floor re-apply (`reapplyPreferredRangeIfNeeded`) lives in
+    // The floor re-apply (`reapplyPreferredRangeIfNeeded`) lives in
     // FramePacer+FrameRateRange.swift alongside the range builders it calls.
 }
 

--- a/Glimmer/Stream/FramePacer+TickDeficit.swift
+++ b/Glimmer/Stream/FramePacer+TickDeficit.swift
@@ -102,7 +102,7 @@ extension FramePacer {
     /// watchdog's own 1.75s sustained-trip requirement; measurement (window
     /// rolls) continues throughout, only the verdicts wait.
     static let resumeVerdictHoldSeconds = 0.5
-    /// Warm re-enable floor seed (digest D3): the refined content cadence the
+    /// Warm re-enable floor seed: the refined content cadence the
     /// last STOPPED pacer learned, stashed so a re-enabled pacer can seed from
     /// the truth (a wired-link warm re-enable installed floor=240.0Hz from
     /// the configured fps while content actually ran ~174.4Hz). Statics
@@ -376,7 +376,7 @@ extension FramePacer {
         pinnedFloorHz = .nan
     }
 
-    // MARK: - Warm re-enable cadence stash (digest D3)
+    // MARK: - Warm re-enable cadence stash
 
     /// Stash this pacer's refined content cadence at stop() so the NEXT pacer
     /// - if it is a warm re-enable - seeds its floor from the truth. Only
@@ -395,7 +395,7 @@ extension FramePacer {
 
     /// Adopt the stashed refined cadence into a WARM-HANDOVER pacer before its
     /// link installs (called from start() under `lock`; armWarmHandover ran
-    /// first on the re-enable path, so `warmingUp` distinguishes it). The D3
+    /// first on the re-enable path, so `warmingUp` distinguishes it). This
     /// fix: without this, installLink pinned floor = configured fps (240.0Hz)
     /// while content ran ~174.4 - a dishonest floor for the rebuilt link's
     /// first beats and a wrong `expectedHz` bar for the handover verdict. A

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -100,7 +100,7 @@ import os
 /// (lifecycle) all touch it, mirroring `StatsCollector`'s contract.
 final class FramePacer: @unchecked Sendable {
 
-    // Module-internal (not private) so the FIX #1 floor re-apply in
+    // Module-internal (not private) so the floor re-apply in
     // FramePacer+FrameRateRange.swift can log through the same category.
     let log = Logger(subsystem: "io.ugfugl.Glimmer", category: "Stream.Pacer")
 
@@ -146,7 +146,7 @@ final class FramePacer: @unchecked Sendable {
     /// Recent hostPTS deltas (seconds) for the median estimate. Bounded.
     var ptsDeltas: [Double] = []
 
-    // MARK: - Adaptive jitter buffer state (Issue 2a)
+    // MARK: - Adaptive jitter buffer state
 
     /// The most recent SMOOTHED RFC-3550 reorder jitter (ms) measured by the RTP
     /// receive path (`RtpVideoQueue` → `TelemetryCounters.recvJitterMs`), refreshed
@@ -165,7 +165,7 @@ final class FramePacer: @unchecked Sendable {
     /// frame, so the decay is rate-limited to one frame per `targetShrinkInterval`.
     var lastTargetShrinkTime: CFTimeInterval = .nan
 
-    // MARK: - Reconciler desired-target snapshot (INCREMENT 1)
+    // MARK: - Reconciler desired-target snapshot
     //
     // THREAD ISOLATION: the reconciler's desired depth comes from
     // EnvSignalController's published `headroomLevel`. To honor never-hold-two-
@@ -390,7 +390,7 @@ final class FramePacer: @unchecked Sendable {
     /// The CADisplayLink bound to the stream window's screen. macOS 14+
     /// `NSView.displayLink(target:selector:)`. Stored so we can invalidate on
     /// teardown / rebind on a screen change. Touched on the main actor only.
-    /// Module-internal (not private) so the FIX #1 floor re-apply in
+    /// Module-internal (not private) so the floor re-apply in
     /// FramePacer+FrameRateRange.swift can re-pin `preferredFrameRateRange`.
     @MainActor var displayLink: CADisplayLink?
     /// The view we bound the link to, kept so a screen change can rebind.
@@ -409,7 +409,7 @@ final class FramePacer: @unchecked Sendable {
     /// VideoDecoder and so the selector signature stays clean.
     @MainActor private var tickProxy: DisplayLinkProxy?
 
-    /// The Hz (floor) we last pinned `preferredFrameRateRange` to (FIX #1).
+    /// The Hz (floor) we last pinned `preferredFrameRateRange` to.
     /// Pinned to the FIXED configured fps at install and held there; the
     /// main-actor re-apply only touches it again if the panel max changes under
     /// us (deadband `frameRateReapplyHysteresisHz`). `.nan` until first applied.
@@ -473,7 +473,7 @@ final class FramePacer: @unchecked Sendable {
         rateWindowStartHostTime = now
         rateWindowStartTicks = tickCount
         rateWindowStartReleases = releaseCount
-        // D3 (warm re-enable cadence seed): a re-enabled pacer is freshly built
+        // Warm re-enable cadence seed: a re-enabled pacer is freshly built
         // from the CONFIGURED fps, but its predecessor had already refined the
         // true content cadence - adopt it to warm-start the DUE GATE's pacing
         // cadence. The present-callback floor is unaffected: it always pins the
@@ -501,7 +501,7 @@ final class FramePacer: @unchecked Sendable {
     func stop() {
         // Stash the refined content cadence FIRST (helper takes the lock) so a
         // warm re-enable after a give-up can seed its fresh pacer's floor from
-        // the truth (~174Hz) instead of the configured fps (the D3 240.0Hz
+        // the truth (~174Hz) instead of the configured fps (the 240.0Hz
         // warm-re-enable seed bug) - see adoptStashedRefinedCadenceLocked.
         stashRefinedCadenceForWarmReenable()
         os_unfair_lock_lock(&lock)
@@ -569,7 +569,7 @@ final class FramePacer: @unchecked Sendable {
         tickProxy = proxy
     }
 
-    // Per the code map in the file header: the throttle floor (FIX #1) lives in
+    // Per the code map in the file header: the throttle floor lives in
     // FramePacer+FrameRateRange.swift; the decode-queue submit path in
     // FramePacer+Submit.swift; the vsync tick in FramePacer+Tick.swift; the
     // trim → backoff → due-gate → release core (+ `BackoffBeat` /

--- a/Glimmer/Stream/Identity+Loading.swift
+++ b/Glimmer/Stream/Identity+Loading.swift
@@ -110,7 +110,7 @@ extension IdentityManager {
             let identity = Identity(uniqueID: uid, certPEM: certPEM, keyPEM: keyPEM)
             try writeIdentityToFileStore(identity)
             wipeUserDefaultsPlaintext()
-            // SECURITY (#5): once the file store has the canonical copy,
+            // SECURITY: once the file store has the canonical copy,
             // remove the PEM material from moonlight-qt's plist so the
             // long-lived private key isn't left readable at its world-
             // accessible source path forever. Conditioned on having
@@ -368,7 +368,7 @@ extension IdentityManager {
                                   forKey: Self.mqtPlistSweepKey)
     }
 
-    /// Best-effort cleanup for users who migrated before #5 shipped: the
+    /// Best-effort cleanup for users who migrated before the file store shipped: the
     /// file store has the canonical PEMs and we've not touched the source
     /// plist. Run on every preflight, gated by a UserDefaults version flag
     /// so it's effectively one-shot.

--- a/Glimmer/Stream/Identity.swift
+++ b/Glimmer/Stream/Identity.swift
@@ -219,8 +219,8 @@ public actor IdentityManager {
         // builds imported into the login keychain - the control channel no longer
         // uses a SecIdentity, so nothing of ours should linger there.
         deleteLabelledIdentity()
-        // SECURITY (#5): for users whose moonlight-qt migration already ran
-        // in a pre-#5 build, the source plist still has the PEM material
+        // SECURITY: for users whose moonlight-qt migration already ran
+        // in an earlier build, the source plist still has the PEM material
         // even though we've long since stopped reading from it. Do a
         // version-gated best-effort wipe so those installs catch up.
         sweepStaleMoonlightQtPEMs()

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -17,7 +17,7 @@ extension InputForwarder {
 
     // MARK: - Mouse capture & gesture suppression
     //
-    // SDL ASSOCIATE-FALSE CURSOR MODEL (issue #14, P0 mouse-snap fix). This is
+    // SDL ASSOCIATE-FALSE CURSOR MODEL (P0 mouse-snap fix). This is
     // the SDL_SetRelativeMouseMode(true) recipe on macOS and is the airtight
     // root-cause fix for the in-game aim snapping to a screen edge/corner.
     //
@@ -238,8 +238,8 @@ extension InputForwarder {
 
     // MARK: - Diagnostic event tap (stage 1: identify the zoom trigger)
     //
-    // The bug we're chasing: macOS zooms into the stream during intense D4
-    // input. Ctrl+scroll has been ruled out. We don't yet know which event
+    // The bug we're chasing: macOS zooms into the stream during intense
+    // gameplay input. Ctrl+scroll has been ruled out. We don't yet know which event
     // type fires immediately before zoom - could be a gesture phase event,
     // a systemDefined media-key subtype, a hover-text trigger, the
     // accessibility-zoom chord (⌥⌘8 / ⌥⌘= / ⌥⌘-), or pointer-shake.
@@ -280,7 +280,7 @@ extension InputForwarder {
         // mask, raw subtype-or-zero. Type-specific accessors
         // (`event.window`, `event.chars`, `scrollingDeltaX`,
         // `magnification`, etc.) throw on the wrong event type, and at
-        // high event rates (e.g. click + 1-4 key spam in D4) the OSLog
+        // high event rates (e.g. click + 1-4 key spam under intense input) the OSLog
         // formatter dies mid-interpolation and takes keyboard delivery
         // with it. The body of `logDiagnosticEvent` below enforces this;
         // do not add an accessor that's documented as "returns valid

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -42,8 +42,8 @@
 //     only emit modifier transitions, not modifier state on every key. This
 //     matches moonlight-qt's `m_KeysDown` QSet semantics.
 //
-//   * Mouse motion is *relative* via the SDL associate-false model (issue #14;
-//     P0 mouse-snap fix). When relative aim is engaged we call
+//   * Mouse motion is *relative* via the SDL associate-false model
+//     (P0 mouse-snap fix). When relative aim is engaged we call
 //     `CGAssociateMouseAndMouseCursorPosition(false)` (enterCapturedMode) so the
 //     OS STOPS physically moving the on-screen cursor - exactly
 //     SDL_SetRelativeMouseMode(true) on macOS. This is the airtight fix for the
@@ -170,7 +170,7 @@ public final class InputForwarder {
     /// edits in Settings take effect on the next gamepad event.
     public var controllerQuitChordProvider: (@MainActor () -> ControllerQuitChord) = { .none }
 
-    /// The user-recorded button set for the `.custom` quit chord (issue #9).
+    /// The user-recorded button set for the `.custom` quit chord.
     /// Consulted only when `controllerQuitChordProvider()` returns `.custom`.
     public var customControllerChordProvider: (@MainActor () -> Set<ControllerButton>) = { [] }
 
@@ -277,8 +277,8 @@ public final class InputForwarder {
     /// back to NSEvent.deltaX/Y only for a synthetic event with no CGEvent
     /// backing. NOTE: these deltas carry macOS's pointer-acceleration curve -
     /// no accel-free path was adopted for the mouse (CGEventTap is also
-    /// accelerated; the system accel-disable is intrusive - see issue #22,
-    /// closed not-planned).
+    /// accelerated; the system accel-disable is intrusive and was
+    /// deliberately not adopted).
     /// Returned in the same down-positive Y convention macOS uses so the
     /// LiSendMouseMoveEvent call site needs no sign flip.
     func mouseDelta(from event: NSEvent) -> (dx: Double, dy: Double) {
@@ -295,7 +295,7 @@ public final class InputForwarder {
     /// / `exitCapturedMode()` from the window's becomeKey/resignKey hooks.
     /// Re-entrant: enter while already-captured is a no-op.
     ///
-    /// Under the SDL associate-false model (issue #14; P0 mouse-snap fix) this
+    /// Under the SDL associate-false model (P0 mouse-snap fix) this
     /// flag ALSO gates the cursor-association latch:
     /// `enterCapturedMode` calls `CGAssociateMouseAndMouseCursorPosition(false)`
     /// when flipping it true, and `exitCapturedMode` re-associates (true) when

--- a/Glimmer/Stream/Native/FecHeadroomController.swift
+++ b/Glimmer/Stream/Native/FecHeadroomController.swift
@@ -1,7 +1,7 @@
 //
 //  FecHeadroomController.swift
 //
-//  PROACTIVE FEC headroom (#3): the OURS-OWNED slice of a wifi loss burst -
+//  PROACTIVE FEC headroom: the OURS-OWNED slice of a wifi loss burst -
 //  prevent, don't react. Today FEC/recovery is REACTIVE: only once loss has
 //  become unrecoverable do we flood RFI + post-invalidation IDR (a long loss
 //  burst can overwhelm the host's fixed FEC parity before that ever fires). This
@@ -11,7 +11,7 @@
 //  marginal frames complete from the parity the host ALREADY sends BEFORE they
 //  tip into unrecoverable - then relaxes back to baseline when the link clears.
 //
-//  LOSS AXIS (#25): the jitter/ooo/retransmit signals above miss a LOW-jitter but
+//  LOSS AXIS: the jitter/ooo/retransmit signals above miss a LOW-jitter but
 //  LOSSY link (bursty 5GHz loss, ~0ms jitter) - exactly where frames tip into
 //  unrecoverable → IDR while the controller sits at the 24ms floor. A SEPARATE
 //  loss accumulator (`observeLoss` / `lossLevel`) escalates the SAME reorder-hold
@@ -32,7 +32,7 @@
 //     sent - see EnetControlChannel.queueFrameFecStatus / SdpCodec). So a wire-
 //     side FEC/bitrate nudge is not available without protocol risk.
 //   * The reorder-hold window, by contrast, is a pure RECEIVE-side lever already
-//     present in RtpVideoQueue (Issue 2b): it only governs how long an incomplete
+//     present in RtpVideoQueue: it only governs how long an incomplete
 //     frame waits for its late tail/parity shards before we declare loss. Widening
 //     it during a degradation trend gives the host's existing parity more time to
 //     land and complete the frame via FEC - genuine proactive FEC HEADROOM - with
@@ -163,22 +163,9 @@ struct FecHeadroomController {
     /// guard on top of the asymmetric counters.
     static let minDwellWindows = 2
 
-    // MARK: - Loss axis (#25): widen the hold on ACTUAL loss, not just jitter
-    //
-    // The jitter/ooo/retransmit signals above miss the case #25 is about: a
-    // low-jitter but LOSSY link (bursty 5GHz packet loss with ~0ms jitter). There
-    // the controller would sit at the 24ms floor while frames tip into
-    // unrecoverable → IDR. So a SEPARATE accumulator escalates the hold on direct
-    // loss evidence - frames the host's parity had to RECOVER (`fecRecovered`,
-    // proactive: parity is being consumed, we're near the edge) and frames that
-    // went UNRECOVERABLE (reactive safety net). It drives ONLY the reorder-hold
-    // (combined with the jitter level via `max` in `holdWindowUs`), NEVER the
-    // pacer depth - a deeper present buffer does nothing for loss recovery and
-    // only adds latency. A clean link (zero recoveries, zero unrecoverable) keeps
-    // `lossLevel` at 0 → byte-identical, same do-no-harm contract as the jitter
-    // axis. Loss is BURSTY+SPARSE, so the cadence differs from the jitter axis: a
-    // qualifying window escalates fast (dwell-guarded), and the bleed-out is SLOW
-    // (`lossClearWindows`) so the headroom rides ACROSS the gaps between bursts.
+    // MARK: - Loss axis: widen the hold on ACTUAL loss, not just jitter
+    // (Rationale: the file header's LOSS AXIS note and observeLoss() below; the
+    // per-field docs that follow give the cadence numbers.)
 
     /// Consecutive loss-active windows before a loss-axis escalation. 1 = a single
     /// window with FEC recovery / an unrecoverable frame steps the hold (still
@@ -319,7 +306,7 @@ struct FecHeadroomController {
         return false
     }
 
-    /// INCREMENT 1 - RECONCILED drive. Adopt the UNIFIED jitter→headroom decision
+    /// RECONCILED drive. Adopt the UNIFIED jitter→headroom decision
     /// the EnvSignalController publishes instead of self-deciding from raw jitter:
     /// the published `headroomLevel` becomes this controller's `level`, and the
     /// published `smoothedJitterMs` drives the jitter-scaled base (the SAME EWMA
@@ -350,7 +337,7 @@ struct FecHeadroomController {
         return changed
     }
 
-    /// LOSS AXIS (#25). Feed one window's direct-loss evidence and step the
+    /// LOSS AXIS. Feed one window's direct-loss evidence and step the
     /// SEPARATE `lossLevel` (combined with the jitter axis via `max` in
     /// `holdWindowUs`). Returns true iff `lossLevel` changed, so the caller can log
     /// it. Called every window REGARDLESS of `reconcilerEnabled` - the loss axis is

--- a/Glimmer/Stream/Native/RtpVideoQueue+AddPacket.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue+AddPacket.swift
@@ -4,7 +4,7 @@
 //  The RtpvAddPacket reassembly half of the RTP video queue state machine, split
 //  out of RtpVideoQueue.swift to keep each file under the SwiftLint length limit.
 //  Ports RtpVideoQueue.c RtpvAddPacket: window/duplicate rejection, the bounded
-//  cross-frame reorder hold (Issue 2b), the new-frame / new-FEC-block transition
+//  cross-frame reorder hold, the new-frame / new-FEC-block transition
 //  (unrecoverable-frame reporting + drop, then per-frame buffer-window reset), the
 //  per-packet missing/received counting, and queuePacket (the duplicate/out-of-
 //  sequence detector that latches receivedOosData).
@@ -58,7 +58,7 @@ extension RtpVideoQueue {
             return .rejected
         }
 
-        // Issue 2b: return to the strict (no-hold) regime once the link has run
+        // Return to the strict (no-hold) regime once the link has run
         // clean for the cooldown period since the last out-of-order observation
         // (mirrors moonlight's 5-min SPECULATIVE_RFI_COOLDOWN hysteresis). Uses
         // presentation time (90kHz → µs) so it tracks media time, like the C.
@@ -105,7 +105,7 @@ extension RtpVideoQueue {
             return .rejected
         }
 
-        // Issue 2b: a deferred next-frame packet is held ONLY to give the
+        // A deferred next-frame packet is held ONLY to give the
         // CURRENT frame's late shards time to land. If the incoming datagram is
         // NOT for the current frame (it's another later frame, or even the
         // deferred frame's own next packet), the hold can no longer help - flush
@@ -166,7 +166,7 @@ extension RtpVideoQueue {
                                        receiveTimeUs: UInt64, allowHold: Bool) -> TransitionOutcome {
         let frameIndex = fields.frameIndex
 
-        // Issue 2b - BOUNDED CROSS-FRAME REORDER HOLD. The next frame's first
+        // BOUNDED CROSS-FRAME REORDER HOLD. The next frame's first
         // packet has arrived while the current frame is still incomplete. On
         // a link we've SEEN reorder (receivedOosData), the current frame's
         // late tail/EOF shards are probably microseconds away and FEC can
@@ -313,7 +313,7 @@ extension RtpVideoQueue {
 
     /// A reconstruct succeeded: stage the complete FEC block, then either advance
     /// to the next multi-FEC block or submit the now-complete frame and open the
-    /// next one (RtpVideoQueue.c:795-803, plus the Issue 2b deferred replay).
+    /// next one (RtpVideoQueue.c:795-803, plus the deferred replay).
     private func completeFecBlockOrFrame() {
         stageCompleteFecBlock()
 
@@ -323,7 +323,7 @@ extension RtpVideoQueue {
             submitCompletedFrame()
             currentFrameNumber &+= 1
             multiFecCurrentBlockNumber = 0
-            // Issue 2b: the held current frame just completed via its late
+            // The held current frame just completed via its late
             // shard. Replay the deferred next-frame packet now so the next
             // frame opens normally - strict in-order submit is preserved (we
             // never reorder frames into the depacketizer; we only delayed the
@@ -333,7 +333,7 @@ extension RtpVideoQueue {
         }
     }
 
-    // MARK: - Reorder-hold helpers (Issue 2b)
+    // MARK: - Reorder-hold helpers
 
     /// FEC could still recover the current frame: the data deficit is within the
     /// parity we expect to receive for this block. Never hold a frame that's

--- a/Glimmer/Stream/Native/RtpVideoQueue.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue.swift
@@ -109,7 +109,7 @@ final class RtpVideoQueue {
 
     var loggedFirstFecRecovery = false
 
-    // MARK: - Receive-side reorder tolerance (Issue 2b)
+    // MARK: - Receive-side reorder tolerance
     //
     // On a reordering link the tail/EOF data shards of frame N frequently arrive
     // AFTER the SOF of frame N+1 (cross-frame reordering). Declaring loss the
@@ -144,7 +144,7 @@ final class RtpVideoQueue {
     /// in-order link), so a non-reordering stream is byte-identical to before:
     /// zero hold, zero added latency.
     ///
-    /// This is the BASELINE (steady-state) value. PROACTIVE FEC headroom (#3): on a
+    /// This is the BASELINE (steady-state) value. PROACTIVE FEC headroom: on a
     /// SUSTAINED degradation trend the `fecHeadroom` controller widens the live
     /// window in bounded steps (up to 48ms) so the host's existing parity gets more
     /// time to complete a marginal frame via FEC BEFORE it tips into unrecoverable -
@@ -159,7 +159,7 @@ final class RtpVideoQueue {
     /// `internal`: read by the reorder-hold gate in RtpVideoQueue+AddPacket.swift.
     var reorderWindowUs: UInt64 { fecHeadroom.holdWindowUs }
 
-    /// PROACTIVE FEC headroom controller (#3). Driven once per ~2s receive-metrics
+    /// PROACTIVE FEC headroom controller. Driven once per ~2s receive-metrics
     /// window from maybeLogMetrics off the recv-jitter / out-of-order / ENet-
     /// retransmit signals; widens/relaxes `reorderWindowUs` on a sustained trend.
     /// Conservative + bounded + hysteretic by construction (see the type). Owned
@@ -172,7 +172,7 @@ final class RtpVideoQueue {
     /// ~2s window is a single cheap lock far off the per-datagram path.
     private var lastRetransmitTotalSnapshot: UInt64 = 0
     /// Unrecoverable-frame total snapshotted at the last window flush, so the FEC
-    /// headroom controller's LOSS axis (#25) sees the per-WINDOW delta - the
+    /// headroom controller's LOSS axis sees the per-WINDOW delta - the
     /// reactive loss signal alongside this window's `fecRecoveredFramesInWindow`.
     /// Same single-cheap-lock-per-2s-window cost as the retransmit snapshot above.
     private var lastUnrecoverableTotalSnapshot: UInt64 = 0
@@ -317,7 +317,7 @@ final class RtpVideoQueue {
     }
 
     /// Shared parse + dispatch. `isReplay` is true when re-driving a deferred
-    /// cross-frame-reorder packet (Issue 2b): jitter accumulation is skipped so
+    /// cross-frame-reorder packet: jitter accumulation is skipped so
     /// the held datagram isn't double-counted in the receive-smoothness metric.
     @discardableResult
     func dispatchDatagram(_ datagram: [UInt8], receiveTimeUs: UInt64,
@@ -347,7 +347,7 @@ final class RtpVideoQueue {
             accumulateReceiveQuality(seq: seq, receiveTimeUs: receiveTimeUs)
         }
 
-        // Issue 2b: if a previous datagram triggered a cross-frame reorder hold,
+        // If a previous datagram triggered a cross-frame reorder hold,
         // the current frame's reorder window may have elapsed before this
         // datagram arrived. Flush the deferred next-frame packet first if the
         // window is up, so loss is declared no later than reorderWindowUs after
@@ -443,7 +443,7 @@ final class RtpVideoQueue {
                 p50Us: gapQuantile(0.50), p95Us: gapQuantile(0.95), maxUs: gapMaxUs))
         }
 
-        // PROACTIVE FEC headroom (#3): step the reorder-hold window on a SUSTAINED
+        // PROACTIVE FEC headroom: step the reorder-hold window on a SUSTAINED
         // trend in the three receive-side health signals - the recv-jitter we just
         // smoothed, this window's genuine reorders, and the per-WINDOW ENet
         // reliable-retransmit delta. The retransmit counter is incremented on the
@@ -459,7 +459,7 @@ final class RtpVideoQueue {
         let retransmitDelta = retransmitTotalNow >= lastRetransmitTotalSnapshot
             ? Int(retransmitTotalNow - lastRetransmitTotalSnapshot) : 0
         lastRetransmitTotalSnapshot = retransmitTotalNow
-        // INCREMENT 1: when the reconciler is enabled, CONSUME the unified
+        // When the reconciler is enabled, CONSUME the unified
         // jitter→headroom decision EnvSignalController publishes (one short
         // controller-lock pull off this ~2s window - NEVER the per-datagram path)
         // instead of self-deciding from raw jitter, so this controller and the
@@ -478,7 +478,7 @@ final class RtpVideoQueue {
                                                       outOfOrder: windowOutOfOrder,
                                                       retransmits: retransmitDelta)
         }
-        // LOSS AXIS (#25): drive the SEPARATE loss accumulator off this window's
+        // LOSS AXIS: drive the SEPARATE loss accumulator off this window's
         // direct loss evidence - frames the host's parity recovered
         // (`fecRecoveredFramesInWindow`) and frames that went unrecoverable (a
         // per-window delta off the monotonic total). Runs every window regardless

--- a/Glimmer/Stream/Native/VideoRtpReceiver.swift
+++ b/Glimmer/Stream/Native/VideoRtpReceiver.swift
@@ -293,7 +293,7 @@ final class VideoRtpReceiver: VideoDepacketizerDelegate, @unchecked Sendable {
             // anonymous instead of mislabeling later unrelated work.
             pthread_setname_np("Glimmer.videoRecv")
             defer { pthread_setname_np("") }
-            // Batched receive (issue #24): up to `cap` datagrams per recvmsg_x
+            // Batched receive: up to `cap` datagrams per recvmsg_x
             // syscall, cutting the ~14k recvfrom/s floor at 4K240 (measurably
             // smoother). Buffers allocated once and reused; handleDatagram
             // copies each out - the win is the syscall COUNT. recvmsg_x is a

--- a/Glimmer/Stream/Network.swift
+++ b/Glimmer/Stream/Network.swift
@@ -21,12 +21,13 @@
 //    * Our own OpenSSL mutual-TLS HTTP client (ControlTransport) instead of
 //      QNetworkAccessManager - the client cert + host-cert pin run straight
 //      through libssl, no URLSession and no keychain in the path.
-//    * Trust-on-first-use: the very first /serverinfo call goes over plain
-//      HTTP, pulls the host cert out of the response (well - out of the next
-//      HTTPS handshake), pins it, and from then on we refuse to talk HTTPS to
-//      anything that doesn't present *exactly* that cert. This is the same
-//      model moonlight-qt uses; it does NOT do PKI validation, on purpose
-//      (every GameStream/Sunshine host is self-signed).
+//    * NOT trust-on-first-use: the first /serverinfo call goes over plain HTTP
+//      and the next HTTPS handshake exposes the host cert, but we do NOT pin it
+//      there. The pin is bound only AFTER the PIN/RSA pairing handshake has
+//      authenticated the host (see the SECURITY (C2) notes in
+//      NetworkClient+Endpoints.swift and Pairing.swift); from then on we refuse
+//      HTTPS to anything not presenting *exactly* that cert. No PKI validation,
+//      on purpose (every GameStream/Sunshine host is self-signed).
 //    * XMLParser-driven tree builder instead of QXmlStreamReader's pull API.
 //
 //  This file is concurrency-strict. `NetworkClient` is an actor, so all its

--- a/Glimmer/Stream/Pairing.swift
+++ b/Glimmer/Stream/Pairing.swift
@@ -216,7 +216,7 @@ public actor PairingClient {
         // NetworkClient layer to even attempt TLS, so we have to set the
         // in-memory pin here.
         //
-        // SECURITY (#11): the PERSISTED pin (PinnedCertStore.store(...))
+        // SECURITY: the PERSISTED pin (PinnedCertStore.store(...))
         // does NOT happen here. It happens AFTER step 7
         // (HTTPS pairchallenge) returns paired=1 - at which point the
         // host has proven, over a TLS handshake gated by THIS exact
@@ -248,7 +248,7 @@ public actor PairingClient {
 
         // ---------------------------------------------------------------
         // PERSISTED PIN COMMIT - SECURITY-CRITICAL LATE COMMIT.
-        // SECURITY (#11): this block MUST stay at the very bottom of the
+        // SECURITY: this block MUST stay at the very bottom of the
         // pair flow, AFTER step 7 (HTTPS pairchallenge) has returned a
         // paired=1 over a TLS handshake gated by the in-memory pin set
         // at step 5. Moving this block earlier in the flow re-introduces
@@ -450,7 +450,7 @@ public actor PairingClient {
     /// Step 5 host-proof verification, split out of `runPairingFlow`.
     ///
     /// (a) MITM check.
-    /// SECURITY (#10): collapse MITM-detection and wrong-PIN errors
+    /// SECURITY: collapse MITM-detection and wrong-PIN errors
     /// into a single externally-visible `.pairingRejected`. The
     /// attacker shouldn't get to learn whether their attempt failed
     /// because the PIN was wrong (offline-brute-force the PIN) or
@@ -517,7 +517,7 @@ public actor PairingClient {
 
     /// Commit the verified host cert to the file-backed pin store.
     ///
-    /// SECURITY (#11): the caller invokes this ONLY at the very bottom of
+    /// SECURITY: the caller invokes this ONLY at the very bottom of
     /// `runPairingFlow`, after step 7 (HTTPS pairchallenge) has confirmed
     /// paired=1 over a TLS handshake gated by the in-memory pin set at step 5.
     /// A storage failure must NOT abort an otherwise-successful pair: the cert
@@ -528,7 +528,7 @@ public actor PairingClient {
             log.error("No host uniqueId on ServerInfo at pairing-success - cannot persist pin; cert will need re-pairing on next launch")
             return
         }
-        // SECURITY (#4 + #9): persist into the file-backed
+        // SECURITY: persist into the file-backed
         // PinnedCertStore. Atomic mode-0600 write; the same-UID-
         // process write surface that UserDefaults exposed (cfprefsd
         // is shared) goes away because the file is in our

--- a/Glimmer/Stream/StreamSession+PresentTrip.swift
+++ b/Glimmer/Stream/StreamSession+PresentTrip.swift
@@ -9,15 +9,15 @@
 //  `tickPresentWatchdog` in StreamSession+Watchdog.swift.
 //
 //  JITTER REGRESSION FIX (root-caused on a clean-but-jittery wifi link): the
-//  old #2 "callback throttled" trip keyed on buffer depth (`depth >= maxQueuedFrames`)
+//  old "callback throttled" trip keyed on buffer depth (`depth >= maxQueuedFrames`)
 //  + late-drops, which is the NORMAL signature of healthy jitter absorption
-//  (the #3 FecHeadroomController deepens the buffer 24→48ms, so the FIFO
+//  (the FecHeadroomController deepens the buffer 24→48ms, so the FIFO
 //  legitimately fills and drop-to-newest late-drops under zero-loss wifi
 //  jitter). It mis-fired 98× on a clean-but-jittery link, its self-heal
 //  (force-release → rebuildLink) re-seeded the cadence and tripped the
 //  present_stall give-up that disabled the pacer for ~5s of unpaced direct
-//  presentation each - turning recoverable jitter into hard hitches. FIX #1
-//  (pinning `preferredFrameRateRange` to stream Hz) already PREVENTS the OS
+//  presentation each - turning recoverable jitter into hard hitches. The
+//  floor pin (pinning `preferredFrameRateRange` to stream Hz) already PREVENTS the OS
 //  from throttling the callback below cadence, so the throttle trip is
 //  redundant; it is REMOVED. The remaining present-freeze trip is jitter-proof:
 //  it keys ONLY on the present callback genuinely not releasing ANY frame while
@@ -146,7 +146,7 @@ extension StreamSession {
         // callback is still ticking (the link is alive, NOT linkDead), frames are
         // QUEUED, yet NO frame has reached the renderer for a full, jitter-proof
         // window. Crucially it never keys on the buffer being DEEP or on late-drop
-        // count: under zero-loss wifi jitter (amplified by the #3
+        // count: under zero-loss wifi jitter (amplified by the
         // FecHeadroomController deepening the buffer 24→48ms) the FIFO
         // LEGITIMATELY pins full and drop-to-newest late-drops some frames WHILE
         // the pacer keeps releasing ~1 frame/tick (and the present-loop backoff
@@ -167,7 +167,7 @@ extension StreamSession {
         // (drop-to-newest replaces the head, never empties), while a healthy
         // pacer releases a queued frame within a tick, keeping the release clock
         // fresh. The gate keys on depth being NON-ZERO, never HIGH - the
-        // jitter-misfire direction (the removed #2 trip) stays removed.
+        // jitter-misfire direction (the removed callback-throttle trip) stays removed.
         //
         // With frames queued, the release clock only goes stale for the whole
         // window if the `due` gate has latched false AND the pacer's own
@@ -308,7 +308,7 @@ extension StreamSession {
             // live link) → force the next tick to release (re-seed the cadence
             // base). Cheapest fix; preserves pacing. Escalates to drain+rebuild if
             // it doesn't resume - `installLink` re-pins `preferredFrameRateRange`
-            // (FIX #1) on the rebuilt link, so a stale floor (if any) is restored.
+            // on the rebuilt link, so a stale floor (if any) is restored.
             // A tick-deficit trip takes this branch too (the link IS ticking,
             // partially), but only transits it for ~one watchdog beat: its
             // stalledFor is fed from the MEASURED deficit duration (already at

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -250,7 +250,7 @@ extension StreamSession {
                     Task { [weak self] in await self?.clearDecodeOnlyStallLatch() }
                 }
 
-                // ACTIVE RECOVERY (#20): decode silent past the recovery
+                // ACTIVE RECOVERY: decode silent past the recovery
                 // threshold - request an IDR each tick to prompt a host that
                 // paused video (e.g. the Windows sign-in → desktop transition)
                 // to resume, rather than freezing until a manual reconnect.
@@ -553,7 +553,7 @@ extension StreamSession {
         didLogWatchdogHold = false
     }
 
-    /// Active stall recovery (#20): request an IDR to prompt the host to resume
+    /// Active stall recovery: request an IDR to prompt the host to resume
     /// the video stream after it paused (e.g. the Windows sign-in → desktop
     /// transition stops the encoder briefly). Called each watchdog tick for the
     /// whole stall once past `decodeStallRecoveryThreshold`; the request is
@@ -583,7 +583,7 @@ extension StreamSession {
         // teardown. It re-arms naturally once frames resume.
         guard isStreaming, !stopInProgress, !isReconnecting else { return }
 
-        // HOLD-IF-ALIVE (#20): a 10s video stall is NOT proof the session is
+        // HOLD-IF-ALIVE: a 10s video stall is NOT proof the session is
         // dead. During a Windows sign-in → desktop transition the host pauses
         // the encoder (Sunshine can't capture the secure desktop) while its
         // ENet control loop keeps ACKing our 100ms keepalives - so the link is

--- a/Glimmer/Stream/StreamSession.swift
+++ b/Glimmer/Stream/StreamSession.swift
@@ -169,7 +169,7 @@ public actor StreamSession {
     /// of waiting passively for the host to come back on its own. This is the
     /// fix for "stream freezes when the host's desktop switches (Windows
     /// sign-in / secure desktop) and stays frozen until you manually reconnect"
-    /// (#20): the host pauses video across the switch and needs a keyframe
+    /// The host pauses video across the switch and needs a keyframe
     /// request to resume - nothing else fires one when reception simply stops.
     /// We nudge from here up to `frameWatchdogTimeout` (the give-up), matching
     /// moonlight's recover-then-terminate behavior. Below the soft/hard
@@ -190,7 +190,7 @@ public actor StreamSession {
     /// never occurs on a healthy link. When `enetHealth().sinceLastAckMs` is
     /// under this, the frame watchdog HOLDS instead of tearing down: it keeps
     /// requesting IDRs and waits for the desktop to return, matching moonlight,
-    /// which terminates on connection loss - not on a video stall alone (#20).
+    /// which terminates on connection loss - not on a video stall alone.
     /// Teardown for a genuinely-gone host is owned by ENet's own dead-peer
     /// detection (`EnetControlChannel+ControlLoop`, `onTerminated(-1)`).
     static let enetAliveHoldThresholdMs: UInt32 = 5000

--- a/Glimmer/Stream/StreamWindow+Cursor.swift
+++ b/Glimmer/Stream/StreamWindow+Cursor.swift
@@ -94,7 +94,7 @@ extension StreamWindow {
     ///       synchronously inside makeKeyAndOrderFront without posting a fresh
     ///       notification) - so the cursor-hide latch that path (a) re-engages
     ///       was being skipped, leaving the system cursor drawn over the stream
-    ///       (the #14-adjacent bug). Funnelling both paths through this one
+    ///       (the cursor-model-adjacent bug). Funnelling both paths through this one
     ///       method makes them indistinguishable.
     ///
     /// Single-owner safe: `setCursorHidden(true)` is idempotent off

--- a/Glimmer/Stream/StreamWindow.swift
+++ b/Glimmer/Stream/StreamWindow.swift
@@ -292,7 +292,7 @@ public final class StreamWindow {
         window.acceptsMouseMovedEvents = true
         window.hidesOnDeactivate = false
 
-        // SECURITY (#8): refuse to be screen-captured. Prevents
+        // SECURITY: refuse to be screen-captured. Prevents
         // ScreenCaptureKit, the screencapture(1) tool, Cmd-Shift-5, Zoom /
         // Teams / Discord screen-share, and the Quick-Time screen recording
         // path from pulling the stream surface. Apps capturing the screen

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -37,8 +37,7 @@ extension TelemetryCounters {
         /// Negotiated video codec ("av1" / "hevc" / "h264"), derived from the
         /// stream format mask. The label that lets a multi-host capture answer
         /// "did this session actually go AV1?" - HEVC Main10 and AV1 Main10 are
-        /// otherwise indistinguishable on bit-depth/colorspace/pixel-format
-        /// (issue #23).
+        /// otherwise indistinguishable on bit-depth/colorspace/pixel-format.
         var codec: String
         /// Live output pixel format as a FourCC string (e.g. "x420" = 10-bit
         /// video-range 4:2:0 biplanar, "420v" = 8-bit). The decode-side truth of

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -6,11 +6,8 @@
 //  each unit focused; see that file for the exporter, gate, snapshot type, and
 //  the gate/safety contract.
 //
-//  These counters are ALWAYS live (NOT gated): the increments are unconditional,
-//  sub-microsecond integer adds at already-rare event sites (an IDR request, a
-//  lost frame, one input event), so gating them would buy nothing and risk a
-//  skew between the gate and the site. When the exporter is off (the default),
-//  nothing reads them and they simply accumulate harmlessly.
+//  These counters are always-live, not gated - see the `TelemetryCounters` type
+//  doc below for why.
 //
 //  Code map (this type is split across same-module extension files)
 //  ----------------------------------------------------------------
@@ -253,8 +250,7 @@ final class TelemetryCounters: @unchecked Sendable {
     // integer compares per packet. The PLAYOUT totals are bumped on the audio
     // decode/output path under the lock AudioDecoder already holds for the decode,
     // so they cost nothing extra. The exporter derives per-second rates from the
-    // monotonic deltas and reads the gauges at 1Hz; when telemetry is off nothing
-    // reads them and they simply accumulate harmlessly.
+    // monotonic deltas and reads the gauges at 1Hz.
     //
     /// Audio DATA packets accepted into the queue this session (RtpAudioQueue's
     /// `packetCountAudio`). The exporter derives audio pkts/s + the loss/FEC RATES

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -13,7 +13,7 @@
 //  Two pieces live here:
 //    * `SessionAggregate` - the running per-tick rollup the exporter folds each
 //      1Hz snapshot into (fps min/avg/max, peak depth, worst windows), GATE-
-//      AWARE (D4): each tick is classified active/gated/bring-up/resume and
+//      AWARE: each tick is classified active/gated/bring-up/resume and
 //      the headline numbers cover ACTIVE seconds only (see the type doc). The
 //      raw session-wide latency percentiles still come from the cumulative
 //      histograms at stop (lossless); the aggregate additionally stitches an
@@ -37,7 +37,7 @@ import Foundation
 /// min/avg/max, peak pacing depth, and the worst single 1s windows for the
 /// signals where a transient spike is the story.
 ///
-/// GATE-AWARE (D4): every tick is classified ACTIVE / GATED / BRING-UP /
+/// GATE-AWARE: every tick is classified ACTIVE / GATED / BRING-UP /
 /// RESUME before folding, and the HEADLINE numbers (fps min/avg/max, worst
 /// windows, latency percentiles) are computed over ACTIVE seconds only. The
 /// all-session versions lie: a long decode-gated AFK window working as designed
@@ -275,7 +275,7 @@ struct SessionReport {
         top.append("\"build\":{\"commit\":\"\(buildCommit)\",\"date\":\"\(buildDate)\"}")
         top.append("\"duration_s\":\(num(durationSeconds))")
         top.append("\"ticks\":\(aggregate.tickCount)")
-        // GATE-AWARE segmentation (D4): per-segment second counts first, so
+        // GATE-AWARE segmentation: per-segment second counts first, so
         // every headline below reads against its denominator. `fps`/`latency`/
         // `worst_windows` are ACTIVE-seconds; the `*_raw` keys are all-session.
         top.append("\"segments\":\(segmentsObject())")
@@ -311,7 +311,7 @@ struct SessionReport {
 
     // MARK: - Sub-objects
 
-    /// Per-segment second counts (D4) - the denominators that make the
+    /// Per-segment second counts - the denominators that make the
     /// headline-vs-raw split legible at a glance: a session that was 90%
     /// gated AFK self-describes as such on the first line.
     private func segmentsObject() -> String {

--- a/Glimmer/Stream/Types+Cert.swift
+++ b/Glimmer/Stream/Types+Cert.swift
@@ -89,7 +89,7 @@ public enum PinnedCertStore {
     // per-app ACL. For a pinned host cert the read leak is mostly
     // harmless (the cert is public anyway), but the write surface is the
     // problem: a same-UID attacker can swap the pin for their own,
-    // making us trust a MITM host across restarts. Group #9 of the
+    // making us trust a MITM host across restarts. Part of the
     // security pass.
     //
     // New shape: one PEM file per host at

--- a/Glimmer/Stream/Types.swift
+++ b/Glimmer/Stream/Types.swift
@@ -469,7 +469,7 @@ public enum StreamError: Error, Sendable, CustomStringConvertible, LocalizedErro
         case .binaryNotFound: return "Streaming library not available."
         case .hostUnreachable(let host): return "Couldn't reach \(host)."
         case .pairingFailed(let reason): return "Pairing failed: \(reason)"
-        // SECURITY (#10): uniform user-visible message regardless of
+        // SECURITY: uniform user-visible message regardless of
         // whether the host rejected because the PIN was wrong or because
         // its signature failed verification (the MITM-detected branch
         // also throws .pairingRejected). The internal log distinguishes;

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.19
-CURRENT_PROJECT_VERSION = 20260630
+MARKETING_VERSION = 2026.6.20
+CURRENT_PROJECT_VERSION = 20260631

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,25 +29,29 @@ start a second session while one is running (`isStreaming` guard).
 
 Top-level pieces:
 
-| Layer                 | Type                                     | Lives where                                                 |
-| --------------------- | ---------------------------------------- | ----------------------------------------------------------- |
-| SwiftUI views         | views + observable state                 | `Glimmer/ContentView.swift`, `SettingsView.swift`           |
-| `MoonlightManager`    | `@MainActor` `@Observable`               | `Glimmer/MoonlightManager.swift`                            |
-| `StreamSession`       | `actor`                                  | `Glimmer/Stream/StreamSession.swift` (+ extensions)         |
-| `StreamingBackend`    | protocol (the engine boundary)           | `Glimmer/Stream/StreamingBackend.swift`                     |
-| `NativeBackend`       | `final class`, sole backend conformer    | `Glimmer/Stream/NativeBackend.swift` + `Stream/Native/`     |
-| `StreamBridgeContext` | `final class`, `@unchecked Sendable`     | `Glimmer/Stream/StreamBridgeContext.swift`                  |
-| `NetworkClient`       | `actor` over `URLSession`                | `Glimmer/Stream/Network.swift`                              |
-| `PairingClient`       | `actor`                                  | `Glimmer/Stream/Pairing.swift`                              |
-| `IdentityManager`     | `actor` (singleton)                      | `Glimmer/Stream/Identity.swift`                             |
-| `VideoDecoder`        | `@MainActor final class`                 | `Glimmer/Stream/VideoDecoder.swift` (+`+HDR`, `+Bitstream`) |
-| `FramePacer`          | `final class`, `@unchecked Sendable`     | `Glimmer/Stream/FramePacer.swift` (+ extensions)            |
-| `AudioDecoder`        | `final class`, `@unchecked Sendable`     | `Glimmer/Stream/AudioDecoder.swift`                         |
-| `InputForwarder`      | `@MainActor final class`                 | `Glimmer/Stream/InputForwarder.swift`                       |
-| `ControllerForwarder` | `@MainActor` extension on InputForwarder | `Glimmer/Stream/ControllerForwarder.swift`                  |
-| `StreamWindow`        | `@MainActor final class`                 | `Glimmer/Stream/StreamWindow.swift`                         |
-| `StatsCollector`      | `final class`, `@unchecked Sendable`     | `Glimmer/Stream/StatsCollector.swift`                       |
-| Telemetry (opt-in)    | exporter + counters                      | `Glimmer/Stream/TelemetryExporter.swift` (+ extensions)     |
+| Layer                 | Type                                                       | Lives where                                                 |
+| --------------------- | ---------------------------------------------------------- | ----------------------------------------------------------- |
+| SwiftUI views         | views + observable state                                   | `Glimmer/ContentView.swift`, `SettingsView.swift`           |
+| `MoonlightManager`    | `@MainActor` `@Observable`                                 | `Glimmer/MoonlightManager.swift`                            |
+| `StreamSession`       | `actor`                                                    | `Glimmer/Stream/StreamSession.swift` (+ extensions)         |
+| `StreamingBackend`    | protocol (the engine boundary)                             | `Glimmer/Stream/StreamingBackend.swift`                     |
+| `NativeBackend`       | `final class`, sole backend conformer                      | `Glimmer/Stream/NativeBackend.swift` + `Stream/Native/`     |
+| `StreamBridgeContext` | `final class`, `@unchecked Sendable`                       | `Glimmer/Stream/StreamBridgeContext.swift`                  |
+| `NetworkClient`       | `actor` over `ControlTransport` (hand-rolled OpenSSL mTLS) | `Glimmer/Stream/Network.swift`                              |
+| `PairingClient`       | `actor`                                                    | `Glimmer/Stream/Pairing.swift`                              |
+| `IdentityManager`     | `actor` (singleton)                                        | `Glimmer/Stream/Identity.swift`                             |
+| `VideoDecoder`        | `@MainActor final class`                                   | `Glimmer/Stream/VideoDecoder.swift` (+`+HDR`, `+Bitstream`) |
+| `FramePacer`          | `final class`, `@unchecked Sendable`                       | `Glimmer/Stream/FramePacer.swift` (+ extensions)            |
+| `AudioDecoder`        | `final class`, `@unchecked Sendable`                       | `Glimmer/Stream/AudioDecoder.swift`                         |
+| `InputForwarder`      | `@MainActor final class`                                   | `Glimmer/Stream/InputForwarder.swift`                       |
+| `ControllerForwarder` | `@MainActor` extension on InputForwarder                   | `Glimmer/Stream/ControllerForwarder.swift`                  |
+| `StreamWindow`        | `@MainActor final class`                                   | `Glimmer/Stream/StreamWindow.swift`                         |
+| `StatsCollector`      | `final class`, `@unchecked Sendable`                       | `Glimmer/Stream/StatsCollector.swift`                       |
+| Telemetry (opt-in)    | exporter + counters                                        | `Glimmer/Stream/TelemetryExporter.swift` (+ extensions)     |
+
+> The control/HTTP path runs over `ControlTransport` (`ControlTransport.swift`):
+> a hand-rolled OpenSSL + POSIX-socket mutual-TLS client, deliberately **not**
+> `URLSession` - this keeps the (sleep-locking) keychain out of the path.
 
 ## The `StreamingBackend` boundary
 
@@ -324,12 +328,15 @@ enable (`0x5501` - answered with `sendControllerMotion` samples), and RGB
 lightbar (`0x5502`); `ControllerHaptics`, `ControllerMotion`, and
 `ControllerBattery` own the actuator/sampler sides.
 
-**Gesture suppression.** An `NSEvent.addLocalMonitorForEvents` for `.magnify` /
-`.smartMagnify` / `.swipe` / `.gesture` / `.beginGesture` / `.endGesture` /
-`.pressure` / `.rotate` swallows the gesture family while the stream window is
-key. Scroll wheel is NOT swallowed - scrolls forward as host scroll events.
-macOS Accessibility Zoom chords (⌥⌘8 / ⌥⌘= / ⌥⌘-) are intercepted
-unconditionally so they never reach the OS while a stream is up.
+**Gesture suppression.** An `NSEvent.addLocalMonitorForEvents` for the narrow
+mask `[.magnify, .smartMagnify, .swipe, .rotate]` swallows that gesture family
+while the stream window is key. The broader gesture/pressure types (`.gesture` /
+`.beginGesture` / `.endGesture` / `.pressure`) are deliberately EXCLUDED: they
+carry the trackpad pan/scroll the OS synthesizes `mouseMoved` from, so
+swallowing them would kill cursor + scroll on trackpad-only Macs. Scroll wheel
+is NOT swallowed - scrolls forward as host scroll events. macOS Accessibility
+Zoom chords (⌥⌘8 / ⌥⌘= / ⌥⌘-) are intercepted unconditionally so they never
+reach the OS while a stream is up.
 
 **Input gating.** The engine refuses input until the control channel is up: the
 backend's `send*` methods return -2 before then (mirroring upstream

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -171,11 +171,12 @@ NOT acceptable:
 
 The canonical place to surface a stream event to the consumer is
 `StreamBridgeContext.eventContinuation?.yield(_:)`. `AsyncStream.Continuation`
-is `Sendable` and FIFO-ordered, so yielding from a C worker thread preserves the
-order the C library invoked us in. The previous `Task { await deliver(...) }`
-pattern lost ordering because consecutive Tasks land on the global concurrent
-executor without inter-Task happens-before - see the comment at
-`StreamSession.swift:807` for the motivating regression.
+is `Sendable` and FIFO-ordered, so yielding from the engine's receive thread
+preserves the order the native engine delivered them in. The previous
+`Task { await deliver(...) }` pattern lost ordering because consecutive Tasks
+land on the global concurrent executor without inter-Task happens-before - see
+the comment at `StreamBridgeContext.eventContinuation` (in
+`StreamBridgeContext.swift`) for the motivating regression.
 
 ## Logging
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -155,7 +155,7 @@ trust-on-first-use: `NetworkClient.fetchServerInfo` will NOT auto-pin on first
 contact. The previous "auto-pin on first /serverinfo" behaviour was the
 canonical same-LAN-attacker-rides-an-induced-TLS-error gap; closed in the same
 refactor that moved the pin into the pairing flow (search for `SECURITY (C2)` in
-`Network.swift`).
+`NetworkClient+Endpoints.swift`).
 
 **Failure path.** Any deviation throws `StreamError.pairingFailed` with a
 specific message at `.private` log privacy. The caller sees a uniform "pairing
@@ -175,11 +175,12 @@ wipes, OS migrations, and Time Machine restores in a way the `SecCertificate`
 ref does not. The cert is public information; the threat addressed by mode-0600
 is _write_, not _read_.
 
-**Once pinned, ANY mismatch fails the connection.** The TLS delegate
-(`Network.swift:TLSDelegate.urlSession(_:didReceive:completionHandler:)`)
-refuses the handshake if the leaf cert doesn't byte-equal the pinned PEM. We do
-NOT silently re-pin on TLS error. The previous auto-rebind-on-TLS-error path was
-the gap a same-LAN attacker rode to pin their own cert - closed.
+**Once pinned, ANY mismatch fails the connection.** Enforcement lives in
+`ControlTransport.swift`: `performBlocking` runs a post-handshake exact-DER pin
+check via `X509_cmp` (no `URLSession`, no `SecTrust`), refusing the connection
+if the leaf cert doesn't byte-equal the pinned PEM. We do NOT silently re-pin on
+TLS error. The previous auto-rebind-on-TLS-error path was the gap a same-LAN
+attacker rode to pin their own cert - closed.
 
 A real cert rotation (Sunshine reinstall, OS reset on the host) lands the user
 on a loud `hostUnreachable` error directing them to **Settings → PCs → Compare


### PR DESCRIPTION
Audit cleanup pass (18/21 panel findings). Comment/doc/copy only — no behavior change beyond corrected copy.

- Fix 2 stale Settings → Input pointers left by the Troubleshooting→Diagnostics merge
- Correct stale security docs/comments (URLSession TLSDelegate + TOFU → OpenSSL ControlTransport pinning)
- Rewrite the dead audio drift comment (silence-packet → varispeed loop)
- Trim AI-cruft prose; scrub internal issue tags from comments (security/threading rationale preserved)
- UI copy: unify "Pair a PC", outcome-first mute toggle, "Use native resolution" button

Build + 146 tests green. Ships as 2026.6.20.