### PR TITLE
release: 2026.6.22 — codec-aware bitrate, FEC dedup, pacer state split, release hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026.6.22 - 2026-06-24
+
+Uses less bandwidth on modern codecs at the same picture quality. The bitrate
+budget is now codec-aware: AV1 and HEVC sessions need fewer bits than H.264 for
+the same result, so Glimmer no longer spends the H.264-sized budget on them
+(roughly 20-33% fewer bytes against a capable host, with no visible change). An
+explicit Custom bitrate is always sent as-is.
+
+Under the hood: the audio and video FEC decoders now share one Reed-Solomon
+solver (and a copy-on-write allocation was removed from the loss-recovery hot
+path), the frame pacer's state was regrouped into cohesive structs behind the
+same single lock, and the release tooling now pins the source tag to the exact
+built commit and stamps the appcast in UTC. A link-state FEC arming-bias
+experiment is present but off by default.
+
 ## 2026.6.21 - 2026-06-22
 
 Clearer recovery when the Wi-Fi helper won't install. macOS occasionally keeps a

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -127,6 +127,16 @@ extension MoonlightManager {
         cfg.coversNotch = streamCoversNotch
         let codecPref = HostCodecPreference.load(for: host.id)
         cfg.videoFormats = codecPref.apply(to: .probedSupported)
+        // Codec-aware WIRE budget: `bitrateKbps` is H.264-anchored, so AV1/HEVC waste
+        // bytes at equal quality. Scale the host-bound budget by codec efficiency;
+        // effectiveBitrateKbps stays the H.264-equivalent quality dial the UI shows.
+        // Custom carries the user's explicit cap verbatim.
+        if case .custom = qualityPreset {
+            // explicit user cap → leave cfg.bitrateKbps == effectiveBitrateKbps
+        } else {
+            let mult = Self.codecBudgetMultiplier(for: cfg.videoFormats)
+            cfg.bitrateKbps = max(5_000, Int((Double(effectiveBitrateKbps) * mult).rounded()))
+        }
         return cfg
     }
 

--- a/Glimmer/QualityCalculator.swift
+++ b/Glimmer/QualityCalculator.swift
@@ -162,6 +162,19 @@ extension MoonlightManager {
         bitrateKbps(width: width, height: height, fps: fps, preset: .matchDisplay) / 1000
     }
 
+    // MARK: - Codec-aware budget
+
+    /// Discount on the H.264-anchored `bitrateKbps` budget for the intended top
+    /// codec (HEVC ~25% / AV1 more bits cheaper at equal quality). Conservative so
+    /// heavy scenes keep headroom; the 5 Mbps floor bounds the low end. Field-tunable.
+    static func codecBudgetMultiplier(for formats: VideoFormats) -> Double {
+        switch formats.topCodec {
+        case .av1:  return 0.67
+        case .hevc: return 0.80
+        case .h264: return 1.0
+        }
+    }
+
     // MARK: - Measured bitrate guidance (Tier 1: baked-in)
 
     /// One mode our harness actually measured, and the wire bitrate we

--- a/Glimmer/Stream/EnvSignalController.swift
+++ b/Glimmer/Stream/EnvSignalController.swift
@@ -91,6 +91,11 @@ final class EnvSignalController: @unchecked Sendable {
     /// so no synchronization is needed (the A/B is a compile-in-and-flip dial).
     nonisolated(unsafe) static var reconcilerEnabled = true
 
+    /// FEC arming bias (hardening #5), DEFAULT-OFF for shadow validation. When true,
+    /// caution/distress link state feeds the FecHeadroomController reorder-hold as a
+    /// third escalate axis (receive-side, zero wire bytes). Off → byte-identical.
+    nonisolated(unsafe) static var fecArmingBiasEnabled = false
+
     // MARK: - State
 
     /// The three-level link-condition state. Ordinals are stable (exported as
@@ -110,6 +115,16 @@ final class EnvSignalController: @unchecked Sendable {
             case .clear: return "clear"
             case .caution: return "caution"
             case .distress: return "distress"
+            }
+        }
+
+        /// FEC reorder-hold arming bias (hardening #5): caution → 1 step, distress →
+        /// 2, clear → 0. Combined via max in FecHeadroomController so it only widens.
+        var fecArmingBiasLevel: Int {
+            switch self {
+            case .clear: return 0
+            case .caution: return 1
+            case .distress: return 2
             }
         }
     }
@@ -796,11 +811,9 @@ final class EnvSignalController: @unchecked Sendable {
     //    one audible blip after it (the one-blip-per-upward-ratchet pattern).
     //    Decays via the existing 60s target decay.
     //
-    //  * FEC HEADROOM ARMING BIAS (dark): feed `state != .clear` to
-    //    FecHeadroomController as an additional escalate input. Receive-side
-    //    only - zero extra bytes on the wire, same hard cap. Explicit
-    //    NON-GOAL stays: no bitrate/FEC wire request exists for this host
-    //    profile (see that controller's header).
+    //  * FEC HEADROOM ARMING BIAS (WIRED, DEFAULT-OFF via fecArmingBiasEnabled):
+    //    feeds caution/distress to FecHeadroomController as a third escalate axis.
+    //    Receive-side only - zero wire bytes, same hard cap. Flip on to shadow-validate.
     //
     //  * PACER DEPTH FLOOR +1 (dark, double-gated): raise FramePacer's
     //    adaptive depth floor by one within its existing cap during CAUTION+.

--- a/Glimmer/Stream/FramePacer+AdaptiveDepth.swift
+++ b/Glimmer/Stream/FramePacer+AdaptiveDepth.swift
@@ -35,26 +35,26 @@ extension FramePacer {
     func noteMeasuredJitter(_ ms: Double) {
         refreshReconciledTarget()
         os_unfair_lock_lock(&lock)
-        if ms.isFinite, ms >= 0 { measuredJitterMs = ms }
+        if ms.isFinite, ms >= 0 { adaptiveDepth.measuredJitterMs = ms }
         bumpTargetForJitterLocked()
         os_unfair_lock_unlock(&lock)
     }
 
     /// Pull the reconciler's latest published headroom level into
-    /// `reconciledTargetDepth` (mapped `targetDepth + level`, clamped). MUST be
+    /// `adaptiveDepth.reconciledTargetDepth` (mapped `targetDepth + level`, clamped). MUST be
     /// called WITHOUT the pacer lock held - it takes EnvSignalController's lock
     /// (via `.decision`), so calling it under the pacer lock would nest two locks.
     /// No-ops on an unchanged decision generation (the common path costs one
     /// short controller-lock read + a `UInt64` compare). When the reconciler is
-    /// off this leaves `reconciledTargetDepth` untouched - `justifiedDepthLocked`
-    /// ignores it and self-decides off `measuredJitterMs` instead.
+    /// off this leaves `adaptiveDepth.reconciledTargetDepth` untouched - `justifiedDepthLocked`
+    /// ignores it and self-decides off `adaptiveDepth.measuredJitterMs` instead.
     func refreshReconciledTarget() {
         guard EnvSignalController.reconcilerEnabled else { return }
         let decision = EnvSignalController.shared.decision
         os_unfair_lock_lock(&lock)
-        if decision.generation != reconciledDecisionGeneration {
-            reconciledDecisionGeneration = decision.generation
-            reconciledTargetDepth = min(FramePacer.maxTargetDepth,
+        if decision.generation != adaptiveDepth.reconciledDecisionGeneration {
+            adaptiveDepth.reconciledDecisionGeneration = decision.generation
+            adaptiveDepth.reconciledTargetDepth = min(FramePacer.maxTargetDepth,
                                         max(FramePacer.targetDepth,
                                             FramePacer.targetDepth + decision.headroomLevel))
         }
@@ -64,7 +64,7 @@ extension FramePacer {
     // MARK: - Adaptive target depth. All run under `lock`.
 
     /// The depth the CURRENT desired target justifies - the value the rate-limited
-    /// grow/decay actuator walks `adaptiveTargetDepth` toward. Clamped to
+    /// grow/decay actuator walks `adaptiveDepth.adaptiveTargetDepth` toward. Clamped to
     /// [targetDepth, maxTargetDepth].
     ///
     /// RECONCILER ON (the default): the desired depth comes from the UNIFIED
@@ -87,9 +87,9 @@ extension FramePacer {
             // Read ONLY the off-lock-refreshed snapshot - never the controller -
             // so the pacer holds exactly one lock (its own). Already clamped to
             // [targetDepth, maxTargetDepth] by the refresh.
-            return reconciledTargetDepth
+            return adaptiveDepth.reconciledTargetDepth
         }
-        let j = measuredJitterMs
+        let j = adaptiveDepth.measuredJitterMs
         let extra: Int = j <= FramePacer.jitterDeadZoneMs
             ? 0
             : Int(((j - FramePacer.jitterDeadZoneMs)
@@ -106,13 +106,13 @@ extension FramePacer {
     /// rate-limited in `decayTargetLocked`. Called under the lock.
     func bumpTargetForJitterLocked() {
         let justified = justifiedDepthLocked()
-        guard justified > adaptiveTargetDepth else { return }
+        guard justified > adaptiveDepth.adaptiveTargetDepth else { return }
         // Grow ONE step per call so a deeper buffer requires SUSTAINED jitter
         // across multiple windows, never a lone spike.
-        adaptiveTargetDepth = min(adaptiveTargetDepth + 1, justified)
+        adaptiveDepth.adaptiveTargetDepth = min(adaptiveDepth.adaptiveTargetDepth + 1, justified)
         // Arm the shrink clock so the new (higher) depth holds for at least one
         // shrink interval before it can start decaying.
-        lastTargetShrinkTime = CFAbsoluteTimeGetCurrent()
+        adaptiveDepth.lastTargetShrinkTime = CFAbsoluteTimeGetCurrent()
     }
 
     /// Decay the adaptive target back toward the baseline (depth 1) during clean
@@ -128,11 +128,11 @@ extension FramePacer {
         // diagnosis endorsed. RECONCILER ON: the pacer does NOT self-read the
         // shared gauge - `justifiedDepthLocked()` pulls the published headroom
         // level instead (the whole point of the unification: ONE reader of the
-        // jitter signal, not two racing). `measuredJitterMs` then just goes stale
+        // jitter signal, not two racing). `adaptiveDepth.measuredJitterMs` then just goes stale
         // (it feeds only the OFF path), which is harmless.
         if !EnvSignalController.reconcilerEnabled {
             let liveJitter = TelemetryCounters.shared.recvJitterMs
-            if liveJitter.isFinite, liveJitter >= 0 { measuredJitterMs = liveJitter }
+            if liveJitter.isFinite, liveJitter >= 0 { adaptiveDepth.measuredJitterMs = liveJitter }
         }
         // A rising signal/level must be able to GROW the buffer on the tick path
         // too (not only via the explicit note path), so a lossy link absorbs
@@ -140,28 +140,28 @@ extension FramePacer {
         // justifiedDepthLocked(), which is the published level when reconciling.
         bumpTargetForJitterLocked()
 
-        guard adaptiveTargetDepth > FramePacer.targetDepth else {
-            return adaptiveTargetDepth
+        guard adaptiveDepth.adaptiveTargetDepth > FramePacer.targetDepth else {
+            return adaptiveDepth.adaptiveTargetDepth
         }
         // What does CURRENT measured jitter justify? If it still wants the present
         // depth, hold - don't shrink into ongoing, sustained jitter. Because the
         // signal is the ~1s-smoothed RFC-3550 metric, a transient spike clears
         // quickly and the guard below releases, letting the rate-limited shrink
         // run back to 1.
-        guard justifiedDepthLocked() < adaptiveTargetDepth else {
-            return adaptiveTargetDepth
+        guard justifiedDepthLocked() < adaptiveDepth.adaptiveTargetDepth else {
+            return adaptiveDepth.adaptiveTargetDepth
         }
 
         let now = CFAbsoluteTimeGetCurrent()
-        if !lastTargetShrinkTime.isFinite {
-            lastTargetShrinkTime = now
-            return adaptiveTargetDepth
+        if !adaptiveDepth.lastTargetShrinkTime.isFinite {
+            adaptiveDepth.lastTargetShrinkTime = now
+            return adaptiveDepth.adaptiveTargetDepth
         }
-        if now - lastTargetShrinkTime >= FramePacer.targetShrinkInterval {
-            adaptiveTargetDepth -= 1            // one frame per interval
-            lastTargetShrinkTime = now
+        if now - adaptiveDepth.lastTargetShrinkTime >= FramePacer.targetShrinkInterval {
+            adaptiveDepth.adaptiveTargetDepth -= 1            // one frame per interval
+            adaptiveDepth.lastTargetShrinkTime = now
         }
-        return adaptiveTargetDepth
+        return adaptiveDepth.adaptiveTargetDepth
     }
 
     // MARK: - Helpers
@@ -208,9 +208,9 @@ extension FramePacer {
     /// or within the lenient window after one. Lets the post-gap catch-up play
     /// through instead of being trimmed/backed-off to newest. Called under `lock`.
     func inGapRecoveryLocked(now: CFTimeInterval) -> Bool {
-        emptyTickStreak >= FramePacer.gapRecoveryTickThreshold
-            || (lastGapRecoveryTime > 0
-                && now - lastGapRecoveryTime < FramePacer.postDrainLenientSeconds)
+        liveness.emptyTickStreak >= FramePacer.gapRecoveryTickThreshold
+            || (liveness.lastGapRecoveryTime > 0
+                && now - liveness.lastGapRecoveryTime < FramePacer.postDrainLenientSeconds)
     }
 
     /// Trim the FIFO toward the drop ceiling, returning the stalest dropped buffers
@@ -230,12 +230,12 @@ extension FramePacer {
     /// presenting right after an empty streak is the recovery edge. Under `lock`.
     func updateGapRecoveryLocked(presented: Bool, empty: Bool, now: CFTimeInterval) {
         if !presented, empty {
-            emptyTickStreak += 1
+            liveness.emptyTickStreak += 1
         } else {
-            if presented, emptyTickStreak >= FramePacer.gapRecoveryTickThreshold {
-                lastGapRecoveryTime = now
+            if presented, liveness.emptyTickStreak >= FramePacer.gapRecoveryTickThreshold {
+                liveness.lastGapRecoveryTime = now
             }
-            emptyTickStreak = 0
+            liveness.emptyTickStreak = 0
         }
     }
 }

--- a/Glimmer/Stream/FramePacer+DueGate.swift
+++ b/Glimmer/Stream/FramePacer+DueGate.swift
@@ -94,7 +94,7 @@ extension FramePacer {
         // latched not-due → a hard wedge (observed on a lossy wifi link). See
         // `anchorCadenceBaseOnGridLocked`. Clear the streak - we are presenting.
         anchorCadenceBaseOnGridLocked(targetTimestamp: targetTimestamp)
-        starvedTickStreak = 0
+        liveness.starvedTickStreak = 0
         return BackoffBeat(newest: newest, droppedCount: droppedCount)
     }
 
@@ -107,10 +107,10 @@ extension FramePacer {
     /// and the warm-handover direct present.
     func noteFramePresented(_ sampleBuffer: CMSampleBuffer) {
         os_unfair_lock_lock(&lock)
-        lastReleaseHostTime = CFAbsoluteTimeGetCurrent()
-        releaseCount &+= 1
-        presentRejectStreak = 0
-        lastPresentedSampleBuffer = sampleBuffer
+        liveness.lastReleaseHostTime = CFAbsoluteTimeGetCurrent()
+        liveness.releaseCount &+= 1
+        liveness.presentRejectStreak = 0
+        tickDeficit.lastPresentedSampleBuffer = sampleBuffer
         os_unfair_lock_unlock(&lock)
     }
 
@@ -129,7 +129,7 @@ extension FramePacer {
     /// upstream - can never accumulate toward the ladder's threshold.
     func noteGateReleaseRejected() {
         os_unfair_lock_lock(&lock)
-        presentRejectStreak += 1
+        liveness.presentRejectStreak += 1
         os_unfair_lock_unlock(&lock)
     }
 
@@ -233,16 +233,16 @@ extension FramePacer {
                 // zero added latency.
                 //
                 // STARTUP GATE: do NOT run the grow-hold until cadence has locked
-                // (`releaseCount > startupGrowHoldReleases`). During the first
+                // (`liveness.releaseCount > startupGrowHoldReleases`). During the first
                 // ~0.25s the PTS-median interval is still converging and startup
                 // jitter has transiently inflated the adaptive target; holding
                 // barely-due frames in that window presents half of them late (the
                 // startup chop) and trips the present-stall watchdog. Until cadence
                 // locks we use the normal slack-relaxed test, so the buffer primes
                 // from a clean link's natural slack WITHOUT ever holding a frame late.
-                let cadenceLocked = releaseCount > FramePacer.startupGrowHoldReleases
+                let cadenceLocked = liveness.releaseCount > FramePacer.startupGrowHoldReleases
                 if cadenceLocked && belowTarget
-                    && adaptiveTargetDepth > FramePacer.targetDepth {
+                    && adaptiveDepth.adaptiveTargetDepth > FramePacer.targetDepth {
                     due = sinceLast >= interval
                     // If the head was barely-due (would have presented under the
                     // normal slack test) but we held it to grow, mark it so the
@@ -283,12 +283,12 @@ extension FramePacer {
         refreshReconciledTarget()
 
         os_unfair_lock_lock(&lock)
-        // `!warmingUp`: during a warm handover the queue is empty by design
+        // `!tickDeficit.warmingUp`: during a warm handover the queue is empty by design
         // (submits direct-present until the rebuilt link proves healthy ticks
         // - FramePacer+TickDeficit.swift), so a tick here has nothing to do.
         // Bailing keeps the priming span from polluting the depth samples and
         // stale-repeat counter while real frames are demonstrably flowing.
-        guard running, !warmingUp else {
+        guard running, !tickDeficit.warmingUp else {
             os_unfair_lock_unlock(&lock)
             return
         }
@@ -400,27 +400,27 @@ extension FramePacer {
         var sinceLastForLog: CFTimeInterval = .nan
         var forcedSelfHeal = false
         if wedgedThisTick {
-            starvedTickStreak += 1
+            liveness.starvedTickStreak += 1
             sinceLastForLog = lastPresentMediaTime.isFinite
                 ? targetTimestamp - lastPresentMediaTime : .nan
-            if starvedTickStreak >= FramePacer.starvationFailsafeTicks {
+            if liveness.starvedTickStreak >= FramePacer.starvationFailsafeTicks {
                 // Re-anchor ON the live grid rather than reseeding to `.nan` (which
                 // RE-LATCHES the wedge into the ~15fps limp; telemetry rn~12). On-
                 // grid self-clears the wedge next vsync. See the helper.
                 anchorCadenceBaseOnGridLocked(targetTimestamp: targetTimestamp)
                 forcedSelfHeal = true
-                starvedTickStreak = 0
+                liveness.starvedTickStreak = 0
             }
         } else if toPresent != nil {
-            starvedTickStreak = 0
-            loggedStarvation = false
+            liveness.starvedTickStreak = 0
+            liveness.loggedStarvation = false
         }
         let shouldLogStarvation = wedgedThisTick
-            && starvedTickStreak >= FramePacer.starvationLogTicks
-            && !loggedStarvation
-        if shouldLogStarvation { loggedStarvation = true }
+            && liveness.starvedTickStreak >= FramePacer.starvationLogTicks
+            && !liveness.loggedStarvation
+        if shouldLogStarvation { liveness.loggedStarvation = true }
         let starvationSnapshot = StarvationSnapshot(
-            streak: starvedTickStreak, depth: sampledDepth,
+            streak: liveness.starvedTickStreak, depth: sampledDepth,
             sinceLastMs: sinceLastForLog * 1000, targetTimestamp: targetTimestamp,
             lastPresent: lastPresentMediaTime, intervalMs: streamFrameIntervalSeconds * 1000)
         os_unfair_lock_unlock(&lock)
@@ -537,15 +537,15 @@ extension FramePacer {
         var shouldSignpost = false
         os_unfair_lock_lock(&lock)
         if forced {
-            overTargetReleaseStreak += 1
-            streakSnapshot = overTargetReleaseStreak
+            liveness.overTargetReleaseStreak += 1
+            streakSnapshot = liveness.overTargetReleaseStreak
             // Signpost once, when the streak first crosses the starvation log
             // threshold - a sustained over-target episode is the same
             // self-oscillation signature, surfaced before it could ever reach the
             // failsafe (which it now never will, since we force the release).
-            shouldSignpost = overTargetReleaseStreak == FramePacer.starvationLogTicks
+            shouldSignpost = liveness.overTargetReleaseStreak == FramePacer.starvationLogTicks
         } else if released {
-            overTargetReleaseStreak = 0
+            liveness.overTargetReleaseStreak = 0
         }
         os_unfair_lock_unlock(&lock)
         guard forced else { return }

--- a/Glimmer/Stream/FramePacer+FrameRateRange.swift
+++ b/Glimmer/Stream/FramePacer+FrameRateRange.swift
@@ -65,7 +65,7 @@ extension FramePacer {
         // Mirror under the lock for the off-main floor-violation detector
         // (FramePacer+TickDeficit.swift) - same dual-write as installLink.
         os_unfair_lock_lock(&lock)
-        pinnedFloorHz = Double(range.minimum)
+        tickDeficit.pinnedFloorHz = Double(range.minimum)
         os_unfair_lock_unlock(&lock)
         Diag.info(
             "FramePacer pinned present floor to requested \(Double(range.minimum))Hz "

--- a/Glimmer/Stream/FramePacer+Recovery.swift
+++ b/Glimmer/Stream/FramePacer+Recovery.swift
@@ -148,7 +148,7 @@ extension FramePacer {
         // Mirror the floor under the lock for the off-main floor-violation
         // detector (the rate-window roll can't touch main-actor state).
         os_unfair_lock_lock(&lock)
-        pinnedFloorHz = Double(range.minimum)
+        tickDeficit.pinnedFloorHz = Double(range.minimum)
         os_unfair_lock_unlock(&lock)
         link.add(to: .main, forMode: .common)
         self.setTickProxy(proxy)
@@ -242,23 +242,23 @@ extension FramePacer {
     func refreshWindowSnapshot() -> RefreshWindowSnapshot {
         os_unfair_lock_lock(&lock); defer { os_unfair_lock_unlock(&lock) }
         defer {
-            refreshIntervalSumSeconds = 0
-            refreshIntervalSamples = 0
-            refreshIntervalMinSeconds = .nan
-            refreshIntervalMaxSeconds = .nan
-            refreshChangedSinceRead = false
+            refreshTelemetry.refreshIntervalSumSeconds = 0
+            refreshTelemetry.refreshIntervalSamples = 0
+            refreshTelemetry.refreshIntervalMinSeconds = .nan
+            refreshTelemetry.refreshIntervalMaxSeconds = .nan
+            refreshTelemetry.refreshChangedSinceRead = false
         }
-        guard refreshIntervalSamples > 0 else {
+        guard refreshTelemetry.refreshIntervalSamples > 0 else {
             return RefreshWindowSnapshot(minHz: nil, avgHz: nil, maxHz: nil,
-                                         changed: refreshChangedSinceRead)
+                                         changed: refreshTelemetry.refreshChangedSinceRead)
         }
-        let avgInterval = refreshIntervalSumSeconds / Double(refreshIntervalSamples)
+        let avgInterval = refreshTelemetry.refreshIntervalSumSeconds / Double(refreshTelemetry.refreshIntervalSamples)
         // A LONGER interval = a LOWER Hz: max interval → min Hz, min interval → max Hz.
-        let minHz = refreshIntervalMaxSeconds > 0 ? 1.0 / refreshIntervalMaxSeconds : nil
-        let maxHz = refreshIntervalMinSeconds > 0 ? 1.0 / refreshIntervalMinSeconds : nil
+        let minHz = refreshTelemetry.refreshIntervalMaxSeconds > 0 ? 1.0 / refreshTelemetry.refreshIntervalMaxSeconds : nil
+        let maxHz = refreshTelemetry.refreshIntervalMinSeconds > 0 ? 1.0 / refreshTelemetry.refreshIntervalMinSeconds : nil
         let avgHz = avgInterval > 0 ? 1.0 / avgInterval : nil
         return RefreshWindowSnapshot(minHz: minHz, avgHz: avgHz, maxHz: maxHz,
-                                     changed: refreshChangedSinceRead)
+                                     changed: refreshTelemetry.refreshChangedSinceRead)
     }
 
     /// One-shot consistent read of the present-side liveness state. ALSO rolls
@@ -270,23 +270,23 @@ extension FramePacer {
         let now = CFAbsoluteTimeGetCurrent()
         os_unfair_lock_lock(&lock)
         let events = serviceTickDeficitLocked(now: now)
-        let sinceTick = lastTickHostTime.isFinite ? now - lastTickHostTime : .infinity
-        let sinceRelease = lastReleaseHostTime.isFinite ? now - lastReleaseHostTime : .infinity
+        let sinceTick = liveness.lastTickHostTime.isFinite ? now - liveness.lastTickHostTime : .infinity
+        let sinceRelease = liveness.lastReleaseHostTime.isFinite ? now - liveness.lastReleaseHostTime : .infinity
         let snapshot = LivenessSnapshot(
             secondsSinceLastTick: sinceTick,
             secondsSinceLastRelease: sinceRelease,
             depth: queue.count,
             running: running,
-            totalTicks: tickCount,
-            totalReleases: releaseCount,
+            totalTicks: liveness.tickCount,
+            totalReleases: liveness.releaseCount,
             streamFrameIntervalSeconds: streamFrameIntervalSeconds,
-            adaptiveTargetDepth: adaptiveTargetDepth,
-            recentTicksPerSecond: measuredTicksPerSecond,
-            recentReleasesPerSecond: measuredReleasesPerSecond,
-            tickDeficitSeconds: tickDeficitSince.isFinite ? now - tickDeficitSince : 0,
-            expectedTickHz: lastExpectedTickHz,
-            tickDeficitModeActive: deficitModeActive,
-            presentRejectStreak: presentRejectStreak)
+            adaptiveTargetDepth: adaptiveDepth.adaptiveTargetDepth,
+            recentTicksPerSecond: tickDeficit.measuredTicksPerSecond,
+            recentReleasesPerSecond: tickDeficit.measuredReleasesPerSecond,
+            tickDeficitSeconds: tickDeficit.tickDeficitSince.isFinite ? now - tickDeficit.tickDeficitSince : 0,
+            expectedTickHz: tickDeficit.lastExpectedTickHz,
+            tickDeficitModeActive: tickDeficit.deficitModeActive,
+            presentRejectStreak: liveness.presentRejectStreak)
         os_unfair_lock_unlock(&lock)
         // Emit breadcrumbs / reconcile the off-tick timer OFF the lock (LogStore
         // takes its own lock; timer ops dispatch) - same discipline as handleTick.
@@ -307,7 +307,7 @@ extension FramePacer {
         os_unfair_lock_lock(&lock)
         let depth = queue.count
         anchorCadenceBaseOnGridLocked(targetTimestamp: target)
-        starvedTickStreak = 0
+        liveness.starvedTickStreak = 0
         os_unfair_lock_unlock(&lock)
         log.warning("FramePacer self-heal: force-release-next-tick (\(reason, privacy: .public)) depth=\(depth, privacy: .public)")
         Diag.notice(
@@ -338,8 +338,8 @@ extension FramePacer {
         queue.removeAll(keepingCapacity: true)
         // Re-seed so a rebuilt link starts clean.
         resetCadenceBaseLocked()
-        starvedTickStreak = 0
-        lastReleaseHostTime = CFAbsoluteTimeGetCurrent()
+        liveness.starvedTickStreak = 0
+        liveness.lastReleaseHostTime = CFAbsoluteTimeGetCurrent()
         os_unfair_lock_unlock(&lock)
 
         for _ in stale { stats.recordPresentationLateDrop() }
@@ -414,7 +414,7 @@ extension FramePacer {
         let discarded = queue.count
         queue.removeAll(keepingCapacity: true)
         resetCadenceBaseLocked()
-        starvedTickStreak = 0
+        liveness.starvedTickStreak = 0
         os_unfair_lock_unlock(&lock)
 
         for _ in 0..<discarded { stats.recordPresentationLateDrop() }

--- a/Glimmer/Stream/FramePacer+Submit.swift
+++ b/Glimmer/Stream/FramePacer+Submit.swift
@@ -84,7 +84,7 @@ extension FramePacer {
         // the atomic flip hands release back to the due gate. Suppressed wins
         // over warm-up (nothing may present at a hidden layer) - the suppressed
         // branch below keeps its single-newest-frame behavior.
-        if warmingUp && !presentSuppressed {
+        if tickDeficit.warmingUp && !presentSuppressed {
             os_unfair_lock_unlock(&lock)
             presentWarmHandoverFrame(entry)
             return
@@ -178,7 +178,7 @@ extension FramePacer {
             events = clearForSuppressionLocked(now: now)
             if !suppressed {
                 reseedRateWindowLocked(now: now)
-                deficitVerdictHoldUntilHostTime =
+                tickDeficit.deficitVerdictHoldUntilHostTime =
                     now + FramePacer.resumeVerdictHoldSeconds
             }
         }

--- a/Glimmer/Stream/FramePacer+Tick.swift
+++ b/Glimmer/Stream/FramePacer+Tick.swift
@@ -83,8 +83,8 @@ extension FramePacer {
         var changedToHz = 0.0
         os_unfair_lock_lock(&lock)
         let hostNow = CFAbsoluteTimeGetCurrent()
-        lastTickHostTime = hostNow
-        tickCount &+= 1
+        liveness.lastTickHostTime = hostNow
+        liveness.tickCount &+= 1
         // Snapshot the PTS-refined stream interval under the lock so the
         // main-actor floor re-apply reads a consistent value without a
         // second lock acquisition. `streamFrameIntervalSeconds` is written on the
@@ -93,13 +93,13 @@ extension FramePacer {
         let refinedIntervalSeconds = streamFrameIntervalSeconds
         if realizedInterval.isFinite, realizedInterval > 0,
            realizedInterval <= Self.maxRealizedTickDeltaSeconds {
-            refreshIntervalSumSeconds += realizedInterval
-            refreshIntervalSamples &+= 1
-            if !refreshIntervalMinSeconds.isFinite || realizedInterval < refreshIntervalMinSeconds {
-                refreshIntervalMinSeconds = realizedInterval
+            refreshTelemetry.refreshIntervalSumSeconds += realizedInterval
+            refreshTelemetry.refreshIntervalSamples &+= 1
+            if !refreshTelemetry.refreshIntervalMinSeconds.isFinite || realizedInterval < refreshTelemetry.refreshIntervalMinSeconds {
+                refreshTelemetry.refreshIntervalMinSeconds = realizedInterval
             }
-            if !refreshIntervalMaxSeconds.isFinite || realizedInterval > refreshIntervalMaxSeconds {
-                refreshIntervalMaxSeconds = realizedInterval
+            if !refreshTelemetry.refreshIntervalMaxSeconds.isFinite || realizedInterval > refreshTelemetry.refreshIntervalMaxSeconds {
+                refreshTelemetry.refreshIntervalMaxSeconds = realizedInterval
             }
         }
         if vsyncInterval.isFinite, vsyncInterval > 0 {
@@ -107,17 +107,17 @@ extension FramePacer {
             // previous tick's. A >1Hz delta (well above vsync-timing noise)
             // flags a real panel-cadence change - the ProMotion ramp 120↔24, a
             // 60↔120 switch, etc. - without firing on realized skip noise.
-            if lastRefreshIntervalSeconds.isFinite {
-                let prevHz = 1.0 / lastRefreshIntervalSeconds
+            if refreshTelemetry.lastRefreshIntervalSeconds.isFinite {
+                let prevHz = 1.0 / refreshTelemetry.lastRefreshIntervalSeconds
                 let nowHz = 1.0 / vsyncInterval
                 if abs(nowHz - prevHz) > 1.0 {
-                    refreshChangedSinceRead = true
+                    refreshTelemetry.refreshChangedSinceRead = true
                     emitRefreshChange = true
                     changedFromHz = prevHz
                     changedToHz = nowHz
                 }
             }
-            lastRefreshIntervalSeconds = vsyncInterval
+            refreshTelemetry.lastRefreshIntervalSeconds = vsyncInterval
         }
         // Tick-deficit service: roll the realized-rate window when due and
         // advance the deficit / floor-violation / warm-handover machines off

--- a/Glimmer/Stream/FramePacer+TickDeficit.swift
+++ b/Glimmer/Stream/FramePacer+TickDeficit.swift
@@ -144,14 +144,14 @@ extension FramePacer {
     /// once per `rateWindowSeconds`, and only the roller observes transitions.
     func serviceTickDeficitLocked(now: CFTimeInterval) -> [TickDeficitEvent] {
         guard running else { return [] }
-        guard rateWindowStartHostTime.isFinite else {
+        guard tickDeficit.rateWindowStartHostTime.isFinite else {
             // First service after start - seed and measure from here.
-            rateWindowStartHostTime = now
-            rateWindowStartTicks = tickCount
-            rateWindowStartReleases = releaseCount
+            tickDeficit.rateWindowStartHostTime = now
+            tickDeficit.rateWindowStartTicks = liveness.tickCount
+            tickDeficit.rateWindowStartReleases = liveness.releaseCount
             return []
         }
-        let elapsed = now - rateWindowStartHostTime
+        let elapsed = now - tickDeficit.rateWindowStartHostTime
         guard elapsed >= FramePacer.rateWindowSeconds else { return [] }
         // SERVICE-GAP DISCARD: an oversized window spans time nobody was
         // servicing (suppressed span / modal stall) - re-seed and measure only
@@ -161,13 +161,13 @@ extension FramePacer {
             reseedRateWindowLocked(now: now)
             return []
         }
-        let ticksPerS = Double(tickCount &- rateWindowStartTicks) / elapsed
-        let releasesPerS = Double(releaseCount &- rateWindowStartReleases) / elapsed
-        measuredTicksPerSecond = ticksPerS
-        measuredReleasesPerSecond = releasesPerS
-        rateWindowStartHostTime = now
-        rateWindowStartTicks = tickCount
-        rateWindowStartReleases = releaseCount
+        let ticksPerS = Double(liveness.tickCount &- tickDeficit.rateWindowStartTicks) / elapsed
+        let releasesPerS = Double(liveness.releaseCount &- tickDeficit.rateWindowStartReleases) / elapsed
+        tickDeficit.measuredTicksPerSecond = ticksPerS
+        tickDeficit.measuredReleasesPerSecond = releasesPerS
+        tickDeficit.rateWindowStartHostTime = now
+        tickDeficit.rateWindowStartTicks = liveness.tickCount
+        tickDeficit.rateWindowStartReleases = liveness.releaseCount
 
         // Expected tick rate = min(stream Hz, NOMINAL panel Hz). The nominal
         // link duration keeps reading the panel's rated cadence even while
@@ -177,10 +177,10 @@ extension FramePacer {
         // reading as a deficit. Falls back to stream Hz before the first tick.
         let streamHz = streamFrameIntervalSeconds > 0
             ? 1.0 / streamFrameIntervalSeconds : 60.0
-        let nominalHz = lastRefreshIntervalSeconds.isFinite && lastRefreshIntervalSeconds > 0
-            ? 1.0 / lastRefreshIntervalSeconds : streamHz
+        let nominalHz = refreshTelemetry.lastRefreshIntervalSeconds.isFinite && refreshTelemetry.lastRefreshIntervalSeconds > 0
+            ? 1.0 / refreshTelemetry.lastRefreshIntervalSeconds : streamHz
         let expectedHz = min(streamHz, nominalHz)
-        lastExpectedTickHz = expectedHz
+        tickDeficit.lastExpectedTickHz = expectedHz
 
         // Suppressed presentation: the link stops ticking BY DESIGN (window
         // hidden), the exact mirror of the watchdog's suppression bail. A
@@ -194,16 +194,16 @@ extension FramePacer {
         // rolled and the rates updated - but no deficit / floor-violation
         // latch may form off the rebound link's delayed first ticks. Latches
         // are kept cleared so backdating can't reach into the held span.
-        if deficitVerdictHoldUntilHostTime.isFinite {
-            guard now >= deficitVerdictHoldUntilHostTime else {
-                tickDeficitSince = .nan
-                floorViolationSince = .nan
-                floorViolationLogged = false
+        if tickDeficit.deficitVerdictHoldUntilHostTime.isFinite {
+            guard now >= tickDeficit.deficitVerdictHoldUntilHostTime else {
+                tickDeficit.tickDeficitSince = .nan
+                tickDeficit.floorViolationSince = .nan
+                tickDeficit.floorViolationLogged = false
                 return []
             }
-            deficitVerdictHoldUntilHostTime = .nan
+            tickDeficit.deficitVerdictHoldUntilHostTime = .nan
         }
-        if warmingUp {
+        if tickDeficit.warmingUp {
             // A priming rebuilt link is ALREADY direct-presenting (the warm
             // handover path in submit). Engaging the deficit timer or judging
             // the floor against its delayed first ticks would be noise - only
@@ -224,26 +224,26 @@ extension FramePacer {
         // Hysteresis latch on the MEASURED rate. The deficit onset is backdated
         // to the window start: the whole deficient window is measured deficit,
         // so engage (below) and the watchdog's sustained trip both clock from
-        // when the sag actually began, not when we noticed. `tickCount > 0`:
+        // when the sag actually began, not when we noticed. `liveness.tickCount > 0`:
         // before the link's first-ever tick a low window is "link not started
         // yet" (the linkDead watchdog's territory), not a measured sag - keeps
         // a slow cold-start bind from minting a fake deficit breadcrumb.
-        if tickCount > 0, ticksPerS < FramePacer.deficitEnterTickRatio * expectedHz {
-            if !tickDeficitSince.isFinite { tickDeficitSince = now - windowSeconds }
+        if liveness.tickCount > 0, ticksPerS < FramePacer.deficitEnterTickRatio * expectedHz {
+            if !tickDeficit.tickDeficitSince.isFinite { tickDeficit.tickDeficitSince = now - windowSeconds }
         } else if ticksPerS >= FramePacer.deficitExitTickRatio * expectedHz {
-            tickDeficitSince = .nan
+            tickDeficit.tickDeficitSince = .nan
         }
 
-        if deficitModeActive {
-            guard !tickDeficitSince.isFinite else { return [] }
+        if tickDeficit.deficitModeActive {
+            guard !tickDeficit.tickDeficitSince.isFinite else { return [] }
             // Ticks are back (≥0.8× expected for a full window) - hand release
             // back to the real vsync. FULLY self-recovering: nothing latches.
-            deficitModeActive = false
-            let duration = deficitEngagedAt.isFinite ? now - deficitEngagedAt : 0
-            let released = releaseCount &- deficitEngageReleaseCount
-            let repaints = deficitRepaints
-            deficitEngagedAt = .nan
-            lastRepaintHostTime = .nan
+            tickDeficit.deficitModeActive = false
+            let duration = tickDeficit.deficitEngagedAt.isFinite ? now - tickDeficit.deficitEngagedAt : 0
+            let released = liveness.releaseCount &- tickDeficit.deficitEngageReleaseCount
+            let repaints = tickDeficit.deficitRepaints
+            tickDeficit.deficitEngagedAt = .nan
+            tickDeficit.lastRepaintHostTime = .nan
             return [.deficitDisengaged(
                 reason: "ticks recovered", durationSeconds: duration,
                 releases: released, repaints: repaints, ticksPerS: ticksPerS)]
@@ -253,12 +253,12 @@ extension FramePacer {
         // static scene - in neither case is there anything to release. The
         // depth>0 + measured-deficit pair is the same fault signature the
         // watchdog trips on, caught here within ~one window instead of seconds.
-        guard tickDeficitSince.isFinite, !queue.isEmpty else { return [] }
-        deficitModeActive = true
-        deficitEngagedAt = now
-        deficitEngageReleaseCount = releaseCount
-        deficitRepaints = 0
-        lastRepaintHostTime = .nan
+        guard tickDeficit.tickDeficitSince.isFinite, !queue.isEmpty else { return [] }
+        tickDeficit.deficitModeActive = true
+        tickDeficit.deficitEngagedAt = now
+        tickDeficit.deficitEngageReleaseCount = liveness.releaseCount
+        tickDeficit.deficitRepaints = 0
+        tickDeficit.lastRepaintHostTime = .nan
         return [.deficitEngaged(
             ticksPerS: ticksPerS, expectedHz: expectedHz, depth: queue.count)]
     }
@@ -270,23 +270,23 @@ extension FramePacer {
     private func trackFloorViolationLocked(
         now: CFTimeInterval, windowSeconds: Double, ticksPerS: Double
     ) -> [TickDeficitEvent] {
-        let floor = pinnedFloorHz
+        let floor = tickDeficit.pinnedFloorHz
         guard floor.isFinite, floor > 0 else { return [] }
         if ticksPerS < floor * FramePacer.floorViolationRatio {
-            if !floorViolationSince.isFinite { floorViolationSince = now - windowSeconds }
-            if !floorViolationLogged,
-               now - floorViolationSince >= FramePacer.floorViolationNoticeSeconds {
+            if !tickDeficit.floorViolationSince.isFinite { tickDeficit.floorViolationSince = now - windowSeconds }
+            if !tickDeficit.floorViolationLogged,
+               now - tickDeficit.floorViolationSince >= FramePacer.floorViolationNoticeSeconds {
                 // Once per episode - a multi-second collapse logs one NOTICE,
                 // not one per window.
-                floorViolationLogged = true
+                tickDeficit.floorViolationLogged = true
                 return [.floorViolation(ticksPerS: ticksPerS, floorHz: floor)]
             }
             return []
         }
-        let wasLogged = floorViolationLogged
-        let since = floorViolationSince
-        floorViolationSince = .nan
-        floorViolationLogged = false
+        let wasLogged = tickDeficit.floorViolationLogged
+        let since = tickDeficit.floorViolationSince
+        tickDeficit.floorViolationSince = .nan
+        tickDeficit.floorViolationLogged = false
         guard wasLogged, since.isFinite else { return [] }
         return [.floorRecovered(durationSeconds: now - since, ticksPerS: ticksPerS)]
     }
@@ -297,8 +297,8 @@ extension FramePacer {
         ticksPerS: Double, expectedHz: Double
     ) -> [TickDeficitEvent] {
         if ticksPerS >= FramePacer.deficitExitTickRatio * expectedHz {
-            warmHealthyWindowStreak += 1
-            guard warmHealthyWindowStreak >= FramePacer.warmHandoverHealthyWindows else {
+            tickDeficit.warmHealthyWindowStreak += 1
+            guard tickDeficit.warmHealthyWindowStreak >= FramePacer.warmHandoverHealthyWindows else {
                 return []
             }
             // ATOMIC flip under the lock: the very next submit queues instead
@@ -306,12 +306,12 @@ extension FramePacer {
             // went direct), so resetting the cadence base reproduces the clean
             // session-start state - first tick releases immediately and
             // re-seeds the grid from the live link's clock.
-            warmingUp = false
-            warmHealthyWindowStreak = 0
+            tickDeficit.warmingUp = false
+            tickDeficit.warmHealthyWindowStreak = 0
             resetCadenceBaseLocked()
             return [.warmHandoverComplete(ticksPerS: ticksPerS)]
         }
-        warmHealthyWindowStreak = 0
+        tickDeficit.warmHealthyWindowStreak = 0
         return []
     }
 
@@ -322,17 +322,17 @@ extension FramePacer {
     /// call it too, so a deficit episode live at the hide instant disengages
     /// immediately instead of leaving the off-tick timer spinning while hidden.
     func clearForSuppressionLocked(now: CFTimeInterval) -> [TickDeficitEvent] {
-        tickDeficitSince = .nan
-        floorViolationSince = .nan
-        floorViolationLogged = false
-        warmHealthyWindowStreak = 0
-        guard deficitModeActive else { return [] }
-        deficitModeActive = false
-        let duration = deficitEngagedAt.isFinite ? now - deficitEngagedAt : 0
-        let released = releaseCount &- deficitEngageReleaseCount
-        let repaints = deficitRepaints
-        deficitEngagedAt = .nan
-        lastRepaintHostTime = .nan
+        tickDeficit.tickDeficitSince = .nan
+        tickDeficit.floorViolationSince = .nan
+        tickDeficit.floorViolationLogged = false
+        tickDeficit.warmHealthyWindowStreak = 0
+        guard tickDeficit.deficitModeActive else { return [] }
+        tickDeficit.deficitModeActive = false
+        let duration = tickDeficit.deficitEngagedAt.isFinite ? now - tickDeficit.deficitEngagedAt : 0
+        let released = liveness.releaseCount &- tickDeficit.deficitEngageReleaseCount
+        let repaints = tickDeficit.deficitRepaints
+        tickDeficit.deficitEngagedAt = .nan
+        tickDeficit.lastRepaintHostTime = .nan
         return [.deficitDisengaged(
             reason: "presentation suppressed", durationSeconds: duration,
             releases: released, repaints: repaints, ticksPerS: 0)]
@@ -344,36 +344,36 @@ extension FramePacer {
     /// the suppression-clear edge (the deficit machinery must measure only
     /// un-suppressed time) and the oversized-window discard. Under `lock`.
     func reseedRateWindowLocked(now: CFTimeInterval) {
-        rateWindowStartHostTime = now
-        rateWindowStartTicks = tickCount
-        rateWindowStartReleases = releaseCount
-        measuredTicksPerSecond = .nan
-        measuredReleasesPerSecond = .nan
+        tickDeficit.rateWindowStartHostTime = now
+        tickDeficit.rateWindowStartTicks = liveness.tickCount
+        tickDeficit.rateWindowStartReleases = liveness.releaseCount
+        tickDeficit.measuredTicksPerSecond = .nan
+        tickDeficit.measuredReleasesPerSecond = .nan
     }
 
     /// Reset EVERY tick-deficit / warm-handover / floor-violation field and
     /// release the held repaint frame - the stop() reset, colocated with the
     /// state machine it clears so a new field can't be forgotten in a far-away
-    /// teardown list (`deficitVerdictHoldUntilHostTime` nearly was). Under `lock`.
+    /// teardown list (`tickDeficit.deficitVerdictHoldUntilHostTime` nearly was). Under `lock`.
     func resetTickDeficitStateLocked() {
-        rateWindowStartHostTime = .nan
-        rateWindowStartTicks = 0
-        rateWindowStartReleases = 0
-        measuredTicksPerSecond = .nan
-        measuredReleasesPerSecond = .nan
-        lastExpectedTickHz = .nan
-        tickDeficitSince = .nan
-        deficitVerdictHoldUntilHostTime = .nan
-        deficitModeActive = false
-        deficitEngagedAt = .nan
-        deficitRepaints = 0
-        lastRepaintHostTime = .nan
-        lastPresentedSampleBuffer = nil
-        warmingUp = false
-        warmHealthyWindowStreak = 0
-        floorViolationSince = .nan
-        floorViolationLogged = false
-        pinnedFloorHz = .nan
+        tickDeficit.rateWindowStartHostTime = .nan
+        tickDeficit.rateWindowStartTicks = 0
+        tickDeficit.rateWindowStartReleases = 0
+        tickDeficit.measuredTicksPerSecond = .nan
+        tickDeficit.measuredReleasesPerSecond = .nan
+        tickDeficit.lastExpectedTickHz = .nan
+        tickDeficit.tickDeficitSince = .nan
+        tickDeficit.deficitVerdictHoldUntilHostTime = .nan
+        tickDeficit.deficitModeActive = false
+        tickDeficit.deficitEngagedAt = .nan
+        tickDeficit.deficitRepaints = 0
+        tickDeficit.lastRepaintHostTime = .nan
+        tickDeficit.lastPresentedSampleBuffer = nil
+        tickDeficit.warmingUp = false
+        tickDeficit.warmHealthyWindowStreak = 0
+        tickDeficit.floorViolationSince = .nan
+        tickDeficit.floorViolationLogged = false
+        tickDeficit.pinnedFloorHz = .nan
     }
 
     // MARK: - Warm re-enable cadence stash
@@ -395,15 +395,15 @@ extension FramePacer {
 
     /// Adopt the stashed refined cadence into a WARM-HANDOVER pacer before its
     /// link installs (called from start() under `lock`; armWarmHandover ran
-    /// first on the re-enable path, so `warmingUp` distinguishes it). This
+    /// first on the re-enable path, so `tickDeficit.warmingUp` distinguishes it). This
     /// fix: without this, installLink pinned floor = configured fps (240.0Hz)
     /// while content ran ~174.4 - a dishonest floor for the rebuilt link's
     /// first beats and a wrong `expectedHz` bar for the handover verdict. A
-    /// cold session start (warmingUp false) keeps the configured seed - its
+    /// cold session start (tickDeficit.warmingUp false) keeps the configured seed - its
     /// predecessor (if any) is a torn-down SESSION, not the same stream.
     @MainActor
     func adoptStashedRefinedCadenceLocked() {
-        guard warmingUp else { return }
+        guard tickDeficit.warmingUp else { return }
         let stashed = FramePacer.stashedRefinedIntervalSeconds
         let stashedAt = FramePacer.stashedRefinedIntervalAt
         guard stashed.isFinite, stashedAt.isFinite,
@@ -494,20 +494,20 @@ extension FramePacer {
     /// converge on the latest state instead of double-arming.
     func reconcileDeficitTimer() {
         os_unfair_lock_lock(&lock)
-        let want = deficitModeActive && running
+        let want = tickDeficit.deficitModeActive && running
         let interval = streamFrameIntervalSeconds
         os_unfair_lock_unlock(&lock)
-        if want, deficitTimer == nil {
+        if want, tickDeficit.deficitTimer == nil {
             let timer = DispatchSource.makeTimerSource(queue: pacingQueue)
             timer.schedule(
                 deadline: .now() + interval, repeating: interval,
                 leeway: .milliseconds(1))
             timer.setEventHandler { [weak self] in self?.deficitTimerFired() }
-            deficitTimer = timer
+            tickDeficit.deficitTimer = timer
             timer.resume()
-        } else if !want, let timer = deficitTimer {
+        } else if !want, let timer = tickDeficit.deficitTimer {
             timer.cancel()
-            deficitTimer = nil
+            tickDeficit.deficitTimer = nil
         }
     }
 
@@ -520,7 +520,7 @@ extension FramePacer {
     /// at one per stream interval no matter how the two sources interleave).
     func deficitTimerFired() {
         os_unfair_lock_lock(&lock)
-        let active = deficitModeActive && running && !presentSuppressed
+        let active = tickDeficit.deficitModeActive && running && !presentSuppressed
         let interval = streamFrameIntervalSeconds
         os_unfair_lock_unlock(&lock)
         guard active else { return }
@@ -548,16 +548,16 @@ extension FramePacer {
         let now = CFAbsoluteTimeGetCurrent()
         var repaint: CMSampleBuffer?
         os_unfair_lock_lock(&lock)
-        let sinceRelease = lastReleaseHostTime.isFinite
-            ? now - lastReleaseHostTime : .infinity
-        let sinceRepaint = lastRepaintHostTime.isFinite
-            ? now - lastRepaintHostTime : .infinity
-        if deficitModeActive, !presentSuppressed,
+        let sinceRelease = liveness.lastReleaseHostTime.isFinite
+            ? now - liveness.lastReleaseHostTime : .infinity
+        let sinceRepaint = tickDeficit.lastRepaintHostTime.isFinite
+            ? now - tickDeficit.lastRepaintHostTime : .infinity
+        if tickDeficit.deficitModeActive, !presentSuppressed,
            sinceRelease > interval * FramePacer.repaintAfterIdleIntervals,
            sinceRepaint >= interval,
-           let sampleBuffer = lastPresentedSampleBuffer {
-            lastRepaintHostTime = now
-            deficitRepaints &+= 1
+           let sampleBuffer = tickDeficit.lastPresentedSampleBuffer {
+            tickDeficit.lastRepaintHostTime = now
+            tickDeficit.deficitRepaints &+= 1
             repaint = sampleBuffer
         }
         os_unfair_lock_unlock(&lock)
@@ -576,8 +576,8 @@ extension FramePacer {
     /// itself a felt freeze, separate from the original stall).
     func armWarmHandover() {
         os_unfair_lock_lock(&lock)
-        warmingUp = true
-        warmHealthyWindowStreak = 0
+        tickDeficit.warmingUp = true
+        tickDeficit.warmHealthyWindowStreak = 0
         os_unfair_lock_unlock(&lock)
     }
 

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -146,26 +146,7 @@ final class FramePacer: @unchecked Sendable {
     /// Recent hostPTS deltas (seconds) for the median estimate. Bounded.
     var ptsDeltas: [Double] = []
 
-    // MARK: - Adaptive jitter buffer state
-
-    /// The most recent SMOOTHED RFC-3550 reorder jitter (ms) measured by the RTP
-    /// receive path (`RtpVideoQueue` → `TelemetryCounters.recvJitterMs`), refreshed
-    /// each tick from the shared gauge. This is the signal that drives grow/decay
-    /// - 0.09ms on a clean wired link, ~22ms on lossy wifi - read instead of the
-    /// old wall-clock submit-spacing estimator (which was dominated by VT/FEC
-    /// drain unevenness on a clean link and falsely pinned the target at the cap).
-    var measuredJitterMs: Double = 0.0
-    /// The current adaptive target depth. Rests at the baseline (1) on a clean
-    /// link, grows by at most one frame per call when SUSTAINED measured jitter
-    /// (above the dead-zone) demands more, and decays back to 1 during clean
-    /// running. Read on the pacing queue (trim + due-gate floor); written on the
-    /// pacing queue (decay/grow) under `lock`.
-    var adaptiveTargetDepth: Int = FramePacer.targetDepth
-    /// Last time (`CFAbsoluteTimeGetCurrent()`) the adaptive target shrank by a
-    /// frame, so the decay is rate-limited to one frame per `targetShrinkInterval`.
-    var lastTargetShrinkTime: CFTimeInterval = .nan
-
-    // MARK: - Reconciler desired-target snapshot
+    // MARK: - Adaptive jitter buffer + reconciler-target state
     //
     // THREAD ISOLATION: the reconciler's desired depth comes from
     // EnvSignalController's published `headroomLevel`. To honor never-hold-two-
@@ -175,12 +156,32 @@ final class FramePacer: @unchecked Sendable {
     // unchanged. Reconciler OFF: stays at `targetDepth`; the self-decide jitter path
     // drives the target.
 
-    /// Desired adaptive target depth pulled from the reconciler's last published
-    /// decision (`targetDepth + headroomLevel`, clamped), refreshed off-lock.
-    var reconciledTargetDepth: Int = FramePacer.targetDepth
-    /// Generation of the published decision last folded into `reconciledTargetDepth`
-    /// - the refresh re-maps only when the controller's generation advances.
-    var reconciledDecisionGeneration: UInt64 = 0
+    /// Adaptive target-depth + reconciler-snapshot state (guarded by `lock`).
+    struct AdaptiveDepthState {
+        /// The most recent SMOOTHED RFC-3550 reorder jitter (ms) measured by the RTP
+        /// receive path (`RtpVideoQueue` → `TelemetryCounters.recvJitterMs`), refreshed
+        /// each tick from the shared gauge. This is the signal that drives grow/decay
+        /// - 0.09ms on a clean wired link, ~22ms on lossy wifi - read instead of the
+        /// old wall-clock submit-spacing estimator (which was dominated by VT/FEC
+        /// drain unevenness on a clean link and falsely pinned the target at the cap).
+        var measuredJitterMs: Double = 0.0
+        /// The current adaptive target depth. Rests at the baseline (1) on a clean
+        /// link, grows by at most one frame per call when SUSTAINED measured jitter
+        /// (above the dead-zone) demands more, and decays back to 1 during clean
+        /// running. Read on the pacing queue (trim + due-gate floor); written on the
+        /// pacing queue (decay/grow) under `lock`.
+        var adaptiveTargetDepth: Int = FramePacer.targetDepth
+        /// Last time (`CFAbsoluteTimeGetCurrent()`) the adaptive target shrank by a
+        /// frame, so the decay is rate-limited to one frame per `targetShrinkInterval`.
+        var lastTargetShrinkTime: CFTimeInterval = .nan
+        /// Desired adaptive target depth pulled from the reconciler's last published
+        /// decision (`targetDepth + headroomLevel`, clamped), refreshed off-lock.
+        var reconciledTargetDepth: Int = FramePacer.targetDepth
+        /// Generation of the published decision last folded into `reconciledTargetDepth`
+        /// - the refresh re-maps only when the controller's generation advances.
+        var reconciledDecisionGeneration: UInt64 = 0
+    }
+    var adaptiveDepth = AdaptiveDepthState()
 
     /// Display-clock time (`CADisplayLink.targetTimestamp`) of the last
     /// present - the cadence base we gate the next "is a frame DUE" decision
@@ -211,45 +212,49 @@ final class FramePacer: @unchecked Sendable {
     // here lets the watchdog see "frames are queued/decoding but nothing has
     // reached the renderer for N ms" and self-heal.
 
-    /// `CFAbsoluteTimeGetCurrent()` at the top of the most recent `handleTick`.
-    /// A 240Hz link ticks every ~4.17ms; if this stops advancing the link has
-    /// died (a same-screen HDR/VRR/mode switch that posts no didChangeScreen).
-    var lastTickHostTime: CFTimeInterval = .nan
-    /// `CFAbsoluteTimeGetCurrent()` when a frame last actually reached the
-    /// renderer (`willPresent` returned true). If this stops advancing while
-    /// the queue is non-empty, the present path is wedged.
-    var lastReleaseHostTime: CFTimeInterval = .nan
-    /// Count of consecutive ticks where the queue was non-empty but nothing was
-    /// released (the wedge signature: `due` latched false). Reset on any
-    /// release. Used to log the diagnostic once it crosses a threshold.
-    var starvedTickStreak: Int = 0
-    /// Consecutive empty-queue ticks - the delivery-GAP signature (vs the non-empty
-    /// wedge above). Drives `releaseDueFrame`'s post-gap leniency.
-    var emptyTickStreak: Int = 0
-    /// `CFAbsoluteTime` of the last gap-recovery edge; lenient window measures from here.
-    var lastGapRecoveryTime: CFTimeInterval = 0
-    /// Count of consecutive ticks the OVER-TARGET short-circuit had to force a
-    /// release (a genuine backlog above the adaptive target the due gate would
-    /// otherwise have latched not-due - the no-network present-stall fix). Reset
-    /// the moment a normally-due release lands, so the streak measures ONLY the
-    /// over-drain↔re-grow oscillation episodes, not steady state (where it stays
-    /// 0). Drives a one-shot diagnostic signpost; never affects the present.
-    var overTargetReleaseStreak: Int = 0
-    /// Consecutive pacer-path releases the RENDERER refused (`willPresent` false -
-    /// backpressure / not-ready), reset on any frame that reached it. The renderer-
-    /// wedge signature: the due gate kept dequeuing while every frame died at
-    /// `isReadyForMoreMediaData == false`, so `releaseCount` froze and the starvation
-    /// failsafe never armed. Surfaced via LivenessSnapshot so the recovery ladder
-    /// reaches for the renderer flush. Guarded by `lock`.
-    var presentRejectStreak: Int = 0
-    /// Latched so the starvation-diagnostic warning logs once per episode, not
-    /// every tick. Cleared on the next successful release.
-    var loggedStarvation = false
-    /// Total ticks observed since start - exposed so instrumentation can derive
-    /// a ticks/sec rate across a sampling window.
-    var tickCount: UInt64 = 0
-    /// Total releases observed since start - same, for a present/sec rate.
-    var releaseCount: UInt64 = 0
+    /// Present-side liveness clocks + counters (guarded by `lock`).
+    struct PresentLivenessState {
+        /// `CFAbsoluteTimeGetCurrent()` at the top of the most recent `handleTick`.
+        /// A 240Hz link ticks every ~4.17ms; if this stops advancing the link has
+        /// died (a same-screen HDR/VRR/mode switch that posts no didChangeScreen).
+        var lastTickHostTime: CFTimeInterval = .nan
+        /// `CFAbsoluteTimeGetCurrent()` when a frame last actually reached the
+        /// renderer (`willPresent` returned true). If this stops advancing while
+        /// the queue is non-empty, the present path is wedged.
+        var lastReleaseHostTime: CFTimeInterval = .nan
+        /// Count of consecutive ticks where the queue was non-empty but nothing was
+        /// released (the wedge signature: `due` latched false). Reset on any
+        /// release. Used to log the diagnostic once it crosses a threshold.
+        var starvedTickStreak: Int = 0
+        /// Consecutive empty-queue ticks - the delivery-GAP signature (vs the non-empty
+        /// wedge above). Drives `releaseDueFrame`'s post-gap leniency.
+        var emptyTickStreak: Int = 0
+        /// `CFAbsoluteTime` of the last gap-recovery edge; lenient window measures from here.
+        var lastGapRecoveryTime: CFTimeInterval = 0
+        /// Count of consecutive ticks the OVER-TARGET short-circuit had to force a
+        /// release (a genuine backlog above the adaptive target the due gate would
+        /// otherwise have latched not-due - the no-network present-stall fix). Reset
+        /// the moment a normally-due release lands, so the streak measures ONLY the
+        /// over-drain↔re-grow oscillation episodes, not steady state (where it stays
+        /// 0). Drives a one-shot diagnostic signpost; never affects the present.
+        var overTargetReleaseStreak: Int = 0
+        /// Consecutive pacer-path releases the RENDERER refused (`willPresent` false -
+        /// backpressure / not-ready), reset on any frame that reached it. The renderer-
+        /// wedge signature: the due gate kept dequeuing while every frame died at
+        /// `isReadyForMoreMediaData == false`, so `releaseCount` froze and the starvation
+        /// failsafe never armed. Surfaced via LivenessSnapshot so the recovery ladder
+        /// reaches for the renderer flush. Guarded by `lock`.
+        var presentRejectStreak: Int = 0
+        /// Latched so the starvation-diagnostic warning logs once per episode, not
+        /// every tick. Cleared on the next successful release.
+        var loggedStarvation = false
+        /// Total ticks observed since start - exposed so instrumentation can derive
+        /// a ticks/sec rate across a sampling window.
+        var tickCount: UInt64 = 0
+        /// Total releases observed since start - same, for a present/sec rate.
+        var releaseCount: UInt64 = 0
+    }
+    var liveness = PresentLivenessState()
 
     // MARK: - Display-refresh telemetry (ProMotion ramp-down detector)
     //
@@ -259,23 +264,27 @@ final class FramePacer: @unchecked Sendable {
     // interval means the pacer paces slow / the buffer builds, then spikes when
     // motion resumes. Guarded by `lock`; accumulators roll in handleTick.
 
-    /// Sum of vsync intervals (seconds) observed since the last snapshot read,
-    /// with the tick count, for a per-second average. Reset on read.
-    var refreshIntervalSumSeconds: Double = 0
-    var refreshIntervalSamples: UInt64 = 0
-    /// Min/max vsync interval (seconds) since the last snapshot read. `.nan` =
-    /// no sample yet this window; reset on read.
-    var refreshIntervalMinSeconds: Double = .nan
-    var refreshIntervalMaxSeconds: Double = .nan
-    /// Last vsync interval seen (seconds), retained across snapshots so a
-    /// refresh CHANGE (the ProMotion ramp edge) can be detected per tick. `.nan`
-    /// until the first tick.
-    var lastRefreshIntervalSeconds: Double = .nan
-    /// Set true by a tick whose derived refresh Hz differs from the previous
-    /// tick's by more than a small tolerance - surfaces a "refresh changed"
-    /// marker in the snapshot. Reset on read. The signpost is emitted on the
-    /// main run loop (in handleTick); this flag is the snapshot-side latch.
-    var refreshChangedSinceRead: Bool = false
+    /// Display-refresh telemetry accumulators (guarded by `lock`).
+    struct RefreshTelemetryState {
+        /// Sum of vsync intervals (seconds) observed since the last snapshot read,
+        /// with the tick count, for a per-second average. Reset on read.
+        var refreshIntervalSumSeconds: Double = 0
+        var refreshIntervalSamples: UInt64 = 0
+        /// Min/max vsync interval (seconds) since the last snapshot read. `.nan` =
+        /// no sample yet this window; reset on read.
+        var refreshIntervalMinSeconds: Double = .nan
+        var refreshIntervalMaxSeconds: Double = .nan
+        /// Last vsync interval seen (seconds), retained across snapshots so a
+        /// refresh CHANGE (the ProMotion ramp edge) can be detected per tick. `.nan`
+        /// until the first tick.
+        var lastRefreshIntervalSeconds: Double = .nan
+        /// Set true by a tick whose derived refresh Hz differs from the previous
+        /// tick's by more than a small tolerance - surfaces a "refresh changed"
+        /// marker in the snapshot. Reset on read. The signpost is emitted on the
+        /// main run loop (in handleTick); this flag is the snapshot-side latch.
+        var refreshChangedSinceRead: Bool = false
+    }
+    var refreshTelemetry = RefreshTelemetryState()
 
     // MARK: - Tick-deficit degraded mode + warm handover (guarded by `lock`)
     //
@@ -287,70 +296,74 @@ final class FramePacer: @unchecked Sendable {
     // releases due frames OFF-TICK at stream cadence until ticks return. Logic in
     // FramePacer+TickDeficit.swift; this is the stored state.
 
-    /// Rolling ~250ms rate window over `tickCount`/`releaseCount` - the MEASURED
-    /// (not inferred) realized tick/release rates everything below keys on.
-    /// Rolled by `serviceTickDeficitLocked` from handleTick, livenessSnapshot
-    /// (the 20Hz watchdog keeps it rolling even when ticks stop), and the
-    /// deficit timer. `.nan` start = window not seeded yet.
-    var rateWindowStartHostTime: CFTimeInterval = .nan
-    var rateWindowStartTicks: UInt64 = 0
-    var rateWindowStartReleases: UInt64 = 0
-    /// Realized rates from the last completed window. `.nan` until the first
-    /// window completes. Surfaced through LivenessSnapshot for the watchdog's
-    /// tick-deficit trip and the exporter.
-    var measuredTicksPerSecond: Double = .nan
-    var measuredReleasesPerSecond: Double = .nan
-    /// Expected tick rate from the last window: min(stream Hz, NOMINAL panel
-    /// Hz). The nominal link duration keeps reading the rated panel cadence
-    /// even while callbacks are throttled (verified: refresh_changed=0 through
-    /// every collapse), so this is the honest "what ticks SHOULD arrive" bar -
-    /// and it keeps a 120fps-stream-on-60Hz-panel setup (ticks legitimately
-    /// half the stream rate) from ever reading as a deficit.
-    var lastExpectedTickHz: Double = .nan
-    /// When the measured tick rate first fell below the deficit enter ratio
-    /// (hysteresis: enter <0.5×, clear ≥0.8× expected). `.nan` = no deficit.
-    var tickDeficitSince: CFTimeInterval = .nan
-    /// Until this host time, deficit / floor-violation VERDICTS are held (the
-    /// rates keep being measured) - armed on the suppression-clear edge so the
-    /// rebound link's delayed first post-refocus ticks can't mint a false
-    /// engage (all 8 false engages + the 1 false FLOOR VIOLATION observed were
-    /// this resume-edge artifact). `.nan` = no hold.
-    var deficitVerdictHoldUntilHostTime: CFTimeInterval = .nan
-    /// True while the off-tick release timer is the active release path.
-    var deficitModeActive = false
-    /// Engage bookkeeping for the disengage breadcrumb (duration + flow proof).
-    var deficitEngagedAt: CFTimeInterval = .nan
-    var deficitEngageReleaseCount: UInt64 = 0
-    var deficitRepaints: UInt64 = 0
-    /// Last governor-repaint instant, so repaints are rate-limited to stream
-    /// cadence. `.nan` = none this episode.
-    var lastRepaintHostTime: CFTimeInterval = .nan
-    /// The most recent sample buffer that reached the renderer via the pacing
-    /// queue - the repaint source during a deficit (re-committing the current
-    /// frame so the governor never classifies the layer as static). Holds the
-    /// SAME buffer the layer is already displaying, so no extra surface is
-    /// retained from VT's pool. Cleared on stop().
-    var lastPresentedSampleBuffer: CMSampleBuffer?
-    /// WARM HANDOVER: true while a re-enabled pacer keeps presenting DIRECT
-    /// (submit bypasses the queue) until the rebuilt link proves a healthy
-    /// realized tick rate - the cold cutover onto an un-primed link queued
-    /// arriving frames to the depth cap and re-froze 350ms after re-enable
-    /// (measured on a battery wifi link). Armed by
-    /// `armWarmHandover()` before start().
-    var warmingUp = false
-    /// Consecutive healthy rate windows seen while warming up.
-    var warmHealthyWindowStreak = 0
-    /// Floor-violation breadcrumb state (NOTICE when realized ticks violate the
-    /// pinned preferredFrameRateRange floor >1s - direct governor evidence).
-    var floorViolationSince: CFTimeInterval = .nan
-    var floorViolationLogged = false
-    /// Lock-guarded mirror of the main-actor `appliedFloorHz`, written wherever
-    /// the range is (re)applied, so the off-main rate-window roll can compare
-    /// realized ticks against the pinned floor without an actor hop.
-    var pinnedFloorHz: Double = .nan
-    /// The off-tick release timer. Created/cancelled ONLY on `pacingQueue`
-    /// (see `reconcileDeficitTimer`), so it needs no lock of its own.
-    var deficitTimer: DispatchSourceTimer?
+    /// Tick-deficit / warm-handover / floor-violation state (guarded by `lock`).
+    struct TickDeficitState {
+        /// Rolling ~250ms rate window over `tickCount`/`releaseCount` - the MEASURED
+        /// (not inferred) realized tick/release rates everything below keys on.
+        /// Rolled by `serviceTickDeficitLocked` from handleTick, livenessSnapshot
+        /// (the 20Hz watchdog keeps it rolling even when ticks stop), and the
+        /// deficit timer. `.nan` start = window not seeded yet.
+        var rateWindowStartHostTime: CFTimeInterval = .nan
+        var rateWindowStartTicks: UInt64 = 0
+        var rateWindowStartReleases: UInt64 = 0
+        /// Realized rates from the last completed window. `.nan` until the first
+        /// window completes. Surfaced through LivenessSnapshot for the watchdog's
+        /// tick-deficit trip and the exporter.
+        var measuredTicksPerSecond: Double = .nan
+        var measuredReleasesPerSecond: Double = .nan
+        /// Expected tick rate from the last window: min(stream Hz, NOMINAL panel
+        /// Hz). The nominal link duration keeps reading the rated panel cadence
+        /// even while callbacks are throttled (verified: refresh_changed=0 through
+        /// every collapse), so this is the honest "what ticks SHOULD arrive" bar -
+        /// and it keeps a 120fps-stream-on-60Hz-panel setup (ticks legitimately
+        /// half the stream rate) from ever reading as a deficit.
+        var lastExpectedTickHz: Double = .nan
+        /// When the measured tick rate first fell below the deficit enter ratio
+        /// (hysteresis: enter <0.5×, clear ≥0.8× expected). `.nan` = no deficit.
+        var tickDeficitSince: CFTimeInterval = .nan
+        /// Until this host time, deficit / floor-violation VERDICTS are held (the
+        /// rates keep being measured) - armed on the suppression-clear edge so the
+        /// rebound link's delayed first post-refocus ticks can't mint a false
+        /// engage (all 8 false engages + the 1 false FLOOR VIOLATION observed were
+        /// this resume-edge artifact). `.nan` = no hold.
+        var deficitVerdictHoldUntilHostTime: CFTimeInterval = .nan
+        /// True while the off-tick release timer is the active release path.
+        var deficitModeActive = false
+        /// Engage bookkeeping for the disengage breadcrumb (duration + flow proof).
+        var deficitEngagedAt: CFTimeInterval = .nan
+        var deficitEngageReleaseCount: UInt64 = 0
+        var deficitRepaints: UInt64 = 0
+        /// Last governor-repaint instant, so repaints are rate-limited to stream
+        /// cadence. `.nan` = none this episode.
+        var lastRepaintHostTime: CFTimeInterval = .nan
+        /// The most recent sample buffer that reached the renderer via the pacing
+        /// queue - the repaint source during a deficit (re-committing the current
+        /// frame so the governor never classifies the layer as static). Holds the
+        /// SAME buffer the layer is already displaying, so no extra surface is
+        /// retained from VT's pool. Cleared on stop().
+        var lastPresentedSampleBuffer: CMSampleBuffer?
+        /// WARM HANDOVER: true while a re-enabled pacer keeps presenting DIRECT
+        /// (submit bypasses the queue) until the rebuilt link proves a healthy
+        /// realized tick rate - the cold cutover onto an un-primed link queued
+        /// arriving frames to the depth cap and re-froze 350ms after re-enable
+        /// (measured on a battery wifi link). Armed by
+        /// `armWarmHandover()` before start().
+        var warmingUp = false
+        /// Consecutive healthy rate windows seen while warming up.
+        var warmHealthyWindowStreak = 0
+        /// Floor-violation breadcrumb state (NOTICE when realized ticks violate the
+        /// pinned preferredFrameRateRange floor >1s - direct governor evidence).
+        var floorViolationSince: CFTimeInterval = .nan
+        var floorViolationLogged = false
+        /// Lock-guarded mirror of the main-actor `appliedFloorHz`, written wherever
+        /// the range is (re)applied, so the off-main rate-window roll can compare
+        /// realized ticks against the pinned floor without an actor hop.
+        var pinnedFloorHz: Double = .nan
+        /// The off-tick release timer. Created/cancelled ONLY on `pacingQueue`
+        /// (see `reconcileDeficitTimer`), so it needs no lock of its own.
+        var deficitTimer: DispatchSourceTimer?
+    }
+    var tickDeficit = TickDeficitState()
 
     // MARK: - Collaborators
 
@@ -461,18 +474,18 @@ final class FramePacer: @unchecked Sendable {
         // the pacer a grace period to produce its first frame rather than
         // tripping on the .nan startup state.
         let now = CFAbsoluteTimeGetCurrent()
-        lastTickHostTime = now
-        lastReleaseHostTime = now
-        starvedTickStreak = 0
-        overTargetReleaseStreak = 0
-        presentRejectStreak = 0
-        loggedStarvation = false
+        liveness.lastTickHostTime = now
+        liveness.lastReleaseHostTime = now
+        liveness.starvedTickStreak = 0
+        liveness.overTargetReleaseStreak = 0
+        liveness.presentRejectStreak = 0
+        liveness.loggedStarvation = false
         // Seed the realized-rate window from "now" too, so the first deficit /
         // floor-violation verdicts measure from start - never from a stale or
         // .nan origin that would mint a giant fake first window.
-        rateWindowStartHostTime = now
-        rateWindowStartTicks = tickCount
-        rateWindowStartReleases = releaseCount
+        tickDeficit.rateWindowStartHostTime = now
+        tickDeficit.rateWindowStartTicks = liveness.tickCount
+        tickDeficit.rateWindowStartReleases = liveness.releaseCount
         // Warm re-enable cadence seed: a re-enabled pacer is freshly built
         // from the CONFIGURED fps, but its predecessor had already refined the
         // true content cadence - adopt it to warm-start the DUE GATE's pacing
@@ -509,28 +522,28 @@ final class FramePacer: @unchecked Sendable {
         queue.removeAll(keepingCapacity: false)
         // Reset liveness so a future restart starts clean (the watchdog reads
         // these; a stale "never ticked" must not survive a restart).
-        lastTickHostTime = .nan
-        lastReleaseHostTime = .nan
-        starvedTickStreak = 0
-        overTargetReleaseStreak = 0
-        presentRejectStreak = 0
-        loggedStarvation = false
+        liveness.lastTickHostTime = .nan
+        liveness.lastReleaseHostTime = .nan
+        liveness.starvedTickStreak = 0
+        liveness.overTargetReleaseStreak = 0
+        liveness.presentRejectStreak = 0
+        liveness.loggedStarvation = false
         // Reset the adaptive jitter buffer so a restart begins at the low-latency
         // baseline (depth 1) rather than inheriting a stale deepened target.
-        adaptiveTargetDepth = FramePacer.targetDepth
-        measuredJitterMs = 0.0
-        lastTargetShrinkTime = .nan
+        adaptiveDepth.adaptiveTargetDepth = FramePacer.targetDepth
+        adaptiveDepth.measuredJitterMs = 0.0
+        adaptiveDepth.lastTargetShrinkTime = .nan
         // Reset the reconciler snapshot so a restart begins at the REST target
         // (depth 1, generation 0) and re-pulls the live decision on its first tick.
-        reconciledTargetDepth = FramePacer.targetDepth
-        reconciledDecisionGeneration = 0
+        adaptiveDepth.reconciledTargetDepth = FramePacer.targetDepth
+        adaptiveDepth.reconciledDecisionGeneration = 0
         // Reset display-refresh telemetry so a restart's first window is clean.
-        refreshIntervalSumSeconds = 0
-        refreshIntervalSamples = 0
-        refreshIntervalMinSeconds = .nan
-        refreshIntervalMaxSeconds = .nan
-        lastRefreshIntervalSeconds = .nan
-        refreshChangedSinceRead = false
+        refreshTelemetry.refreshIntervalSumSeconds = 0
+        refreshTelemetry.refreshIntervalSamples = 0
+        refreshTelemetry.refreshIntervalMinSeconds = .nan
+        refreshTelemetry.refreshIntervalMaxSeconds = .nan
+        refreshTelemetry.lastRefreshIntervalSeconds = .nan
+        refreshTelemetry.refreshChangedSinceRead = false
         // Reset the tick-deficit / warm-handover state and release the held
         // repaint frame so a torn-down pacer pins nothing and a restart begins
         // with fresh measurements (never an inherited deficit verdict). The

--- a/Glimmer/Stream/Native/AudioFecDecoder.swift
+++ b/Glimmer/Stream/Native/AudioFecDecoder.swift
@@ -1,248 +1,42 @@
 //
 //  AudioFecDecoder.swift
 //
-//  Fixed-geometry Reed-Solomon RS(4,2) ERASURE decoder for the Swift-native
-//  AUDIO receive path. Recovers up to 2 lost data shards from a 4-data + 2-parity
-//  FEC block (recovers iff >= 4 of the 6 shards are present).
-//
-//  WHY A SEPARATE DECODER (and not ReedSolomon.swift):
-//  ReedSolomon.swift builds a GENERATED Cauchy parity matrix `INV[(ps+i)^j]`,
-//  which is correct for the VIDEO FEC. AUDIO does NOT use that matrix. For
-//  reasons documented in RtpAudioQueue.c:52-58, Nvidia's audio FEC uses a
-//  DIFFERENT, HARDCODED parity matrix (the one OpenFEC generates):
-//      { 0x77, 0x40, 0x38, 0x0e, 0xc7, 0xa7, 0x0d, 0x6c }
-//  laid out 2x4 row-major (ps=2 rows, ds=4 cols):
-//      row0 = [0x77, 0x40, 0x38, 0x0e]   (parity shard 0)
-//      row1 = [0xc7, 0xa7, 0x0d, 0x6c]   (parity shard 1)
-//  Using the Cauchy matrix here would decode to SILENT GARBAGE (no error). So we
-//  keep a dedicated decoder that hardcodes this matrix and reuses ONLY
-//  `enum GF256` (mul / log / exp / inv tables, poly 0x11D) from ReedSolomon.swift.
-//
-//  Ports nanors reed_solomon_decode + invert_mat (rs.c:42-76, 128-170) reduced to
-//  the constant (ds=4, ps=2) audio case, scalar GF only.
+//  Fixed RS(4,2) erasure decoder for the AUDIO receive path (recovers up to 2 of
+//  4 data shards). LOAD-BEARING: audio uses Nvidia's HARDCODED non-Cauchy parity
+//  matrix (RtpAudioQueue.c:52-58), NOT the generated Cauchy one - feeding Cauchy
+//  here decodes to SILENT GARBAGE (no error). Thin wrapper that pins that matrix,
+//  delegating the shared GF(256) solver to ReedSolomon's explicit-matrix init.
 //
 //  Transport ported from moonlight-common-c (GPLv3); see CREDITS.md.
 
 import Foundation
 
 /// Fixed RS(4,2) erasure decoder using Nvidia's hardcoded audio parity matrix.
-/// Reuses `GF256` (from ReedSolomon.swift) for all field arithmetic.
+/// Thin wrapper over `ReedSolomon`, which owns the shared GF(256) erasure solver.
 struct AudioFecDecoder {
     static let dataShards = 4
     static let fecShards = 2
     static let totalShards = 6
 
     /// Nvidia's hardcoded audio parity matrix, 2x4 row-major (RtpAudioQueue.c:57).
-    /// p[row * dataShards + col]: row in [0,2) = parity shard, col in [0,4) = data shard.
+    /// m[row * dataShards + col]: row in [0,2) = parity shard, col in [0,4) = data shard.
     private static let parity: [UInt8] = [0x77, 0x40, 0x38, 0x0e,
                                           0xc7, 0xa7, 0x0d, 0x6c]
 
-    // MARK: - GF row ops (rs.c axpy / scal, scalar OBLAS_TINY path)
+    private let rs: ReedSolomon
 
-    /// a[i] ^= coeff * b[i]  (GF mul-add). coeff==0 → no-op; coeff==1 → XOR.
-    @inline(__always)
-    private static func axpy(_ a: inout [UInt8], _ b: [UInt8], _ coeff: UInt8, _ k: Int) {
-        if coeff == 0 { return }
-        if coeff == 1 {
-            for i in 0..<k { a[i] ^= b[i] }
-        } else {
-            let lu = Int(GF256.log[Int(coeff)])
-            for i in 0..<k {
-                let bv = b[i]
-                if bv != 0 {
-                    a[i] ^= GF256.exp[lu + Int(GF256.log[Int(bv)])]
-                }
-            }
-        }
+    init() {
+        // Force-unwrap is safe: geometry and matrix are compile-time constants
+        // (ds=4, ps=2, matrix.count == 8 == ps*ds), so this init never returns nil.
+        rs = ReedSolomon(matrix: Self.parity,
+                         dataShards: Self.dataShards,
+                         parityShards: Self.fecShards)!
     }
 
-    /// a[i] = coeff * a[i]. coeff < 2 → no-op (rs.c scal).
-    @inline(__always)
-    private static func scal(_ a: inout [UInt8], _ coeff: UInt8, _ k: Int) {
-        if coeff < 2 { return }
-        let lu = Int(GF256.log[Int(coeff)])
-        for i in 0..<k {
-            let av = a[i]
-            if av != 0 {
-                a[i] = GF256.exp[lu + Int(GF256.log[Int(av)])]
-            }
-        }
-    }
-
-    /// Matrix-element variant for the small unknowns×unknowns work matrix.
-    @inline(__always)
-    private static func axpyRange(_ a: inout [UInt8], _ aOff: Int,
-                                  _ b: [UInt8], _ bOff: Int, _ coeff: UInt8, _ k: Int) {
-        if coeff == 0 { return }
-        if coeff == 1 {
-            for i in 0..<k { a[aOff + i] ^= b[bOff + i] }
-        } else {
-            let lu = Int(GF256.log[Int(coeff)])
-            for i in 0..<k {
-                let bv = b[bOff + i]
-                if bv != 0 {
-                    a[aOff + i] ^= GF256.exp[lu + Int(GF256.log[Int(bv)])]
-                }
-            }
-        }
-    }
-
-    @inline(__always)
-    private static func scalRange(_ a: inout [UInt8], _ off: Int, _ coeff: UInt8, _ k: Int) {
-        if coeff < 2 { return }
-        let lu = Int(GF256.log[Int(coeff)])
-        for i in 0..<k {
-            let av = a[off + i]
-            if av != 0 {
-                a[off + i] = GF256.exp[lu + Int(GF256.log[Int(av)])]
-            }
-        }
-    }
-
-    // MARK: - Decode (rs.c reed_solomon_decode + invert_mat)
-
-    /// Reconstruct erased DATA shards in place.
-    ///
-    /// - `shards`: exactly 6 buffers, each `blockSize` bytes. Indices 0..<4 are
-    ///   data shards (the opus payload bytes, header-stripped), 4..<6 are the two
-    ///   parity shards. Erased data slots may contain any content; this method
-    ///   overwrites them with the recovered bytes.
-    /// - `marks`: length 6; non-zero == shard MISSING/erased (matches the C
-    ///   `block->marks` array, 1 == missing). Only the 4 data slots are recovered;
-    ///   parity recovery is never requested.
-    /// - `blockSize`: bytes per shard.
-    ///
-    /// Returns `true` on success (erased data shards now valid), `false` if
-    /// unrecoverable (fewer present parity shards than gaps). Mirrors rs.c:128-170.
+    /// Reconstruct erased data shards in place; see `ReedSolomon.decode`. `shards`:
+    /// 6 buffers of `blockSize` (0..<4 data, 4..<6 parity). `marks`: length 6,
+    /// non-zero == missing. Returns false if unrecoverable (too few parity shards).
     func decode(shards: inout [[UInt8]], marks: [UInt8], blockSize: Int) -> Bool {
-        let ds = Self.dataShards
-        let total = Self.totalShards
-        guard shards.count >= total, marks.count >= total else { return false }
-        // GF row ops below index 0..<blockSize on every shard; reject short shards
-        // / a negative blockSize rather than read out of bounds.
-        guard blockSize >= 0, shards.allSatisfy({ $0.count >= blockSize }) else { return false }
-
-        // Collect erased DATA shard indices (rs.c:145-147).
-        var erasures = [Int]()
-        erasures.reserveCapacity(ds)
-        for i in 0..<ds where marks[i] != 0 {
-            erasures.append(i)
-        }
-        let gaps = erasures.count
-        if gaps == 0 { return true } // all data shards present; nothing to recover
-
-        // colperm: first (ds-gaps) = surviving data indices in order, last gaps =
-        // the erased indices (rs.c:148-154).
-        var colperm = [Int](repeating: 0, count: ds)
-        do {
-            var j = 0
-            for i in 0..<(ds - gaps) {
-                while marks[j] != 0 { j += 1 }
-                colperm[i] = j
-                j += 1
-            }
-        }
-        for i in 0..<gaps {
-            colperm[(ds - gaps) + i] = erasures[i]
-        }
-
-        // rowperm: for each gap find a PRESENT parity shard (j>=ds, marks[j]==0),
-        // record its index relative to ds, and seed the erased data slot by
-        // copying that parity shard's bytes into it (rs.c:156-166).
-        var rowperm = [Int](repeating: 0, count: gaps)
-        do {
-            var j = ds
-            var i = 0
-            while i < gaps {
-                while j < total && marks[j] != 0 { j += 1 }
-                if j >= total { break }
-                rowperm[i] = j - ds
-                // Seed: data[erasures[i]] = data[j]  (load-bearing copy).
-                shards[erasures[i]] = shards[j]
-                i += 1
-                j += 1
-            }
-            if i < gaps {
-                // Not enough present parity shards to recover.
-                return false
-            }
-        }
-
-        invertMat(shards: &shards, survBase: ds - gaps, dataCount: ds,
-                  shardSize: blockSize, colPerm: colperm, rowPerm: rowperm)
-        return true
-    }
-
-    /// invert_mat (rs.c:42-76). Gaussian elimination over GF(256) to solve for the
-    /// missing data shards. `survBase` = surviving-data count, `dataCount` = ds=4,
-    /// `shardSize` = blockSize, `colPerm`/`rowPerm` = the C colperm/rowperm.
-    private func invertMat(shards: inout [[UInt8]], survBase: Int, dataCount: Int,
-                           shardSize: Int, colPerm: [Int], rowPerm: [Int]) {
-        let parityMatrix = Self.parity
-        let unknowns = dataCount - survBase   // == gaps
-
-        // (1) Build unknowns×unknowns submatrix `wrk` from p rows=rowPerm, cols =
-        // erased columns (colPerm[survBase..]) (rs.c:46-49).
-        var wrk = [UInt8](repeating: 0, count: unknowns * unknowns)
-        for i in 0..<unknowns {
-            let dr = rowPerm[i] * dataCount
-            for j in 0..<unknowns {
-                wrk[i * unknowns + j] = parityMatrix[dr + colPerm[survBase + j]]
-            }
-        }
-
-        // (2) Subtract contribution of the known (surviving) data shards from each
-        // seeded unknown shard (rs.c:51-57).
-        var col = survBase
-        while col < dataCount {
-            let dr = rowPerm[col - survBase] * dataCount
-            for row in 0..<survBase {
-                let coeff = parityMatrix[dr + colPerm[row]]
-                if coeff != 0 {
-                    var target = shards[colPerm[col]]
-                    Self.axpy(&target, shards[colPerm[row]], coeff, shardSize)
-                    shards[colPerm[col]] = target
-                }
-            }
-            col += 1
-        }
-
-        // (3) Gauss-Jordan forward elimination on wrk, applying the same row ops to
-        // the unknown data shards (rs.c:58-67).
-        for x in 0..<unknowns {
-            let pivot = wrk[x * unknowns + x]
-            let coeff = GF256.inv[Int(pivot)]
-            // Scale only the in-row remainder [x, unknowns); cols [0, x) are
-            // already 0 so this is byte-identical to the C (which intentionally
-            // overruns into harmless scratch), without an out-of-bounds write.
-            Self.scalRange(&wrk, x * unknowns + x, coeff, unknowns - x)
-            do {
-                var target = shards[colPerm[survBase + x]]
-                Self.scal(&target, coeff, shardSize)
-                shards[colPerm[survBase + x]] = target
-            }
-            if x + 1 < unknowns {
-                for row in (x + 1)..<unknowns {
-                    let rowCoeff = wrk[row * unknowns + x]
-                    Self.axpyRange(&wrk, row * unknowns, wrk, x * unknowns, rowCoeff, unknowns)
-                    var target = shards[colPerm[survBase + row]]
-                    Self.axpy(&target, shards[colPerm[survBase + x]], rowCoeff, shardSize)
-                    shards[colPerm[survBase + row]] = target
-                }
-            }
-        }
-
-        // (4) Back-substitution (rs.c:68-74).
-        var x = unknowns - 1
-        while x >= 0 {
-            let from = shards[colPerm[survBase + x]]
-            for row in 0..<x {
-                let coeff = wrk[row * unknowns + x]
-                var target = shards[colPerm[survBase + row]]
-                Self.axpy(&target, from, coeff, shardSize)
-                shards[colPerm[survBase + row]] = target
-            }
-            x -= 1
-        }
+        rs.decode(shards: &shards, marks: marks.map { $0 != 0 }, bs: blockSize)
     }
 }

--- a/Glimmer/Stream/Native/FecHeadroomController.swift
+++ b/Glimmer/Stream/Native/FecHeadroomController.swift
@@ -204,10 +204,15 @@ struct FecHeadroomController {
     /// Windows since the last loss-axis level change (its dwell guard).
     private var lossWindowsSinceChange = Int.max
 
-    /// The level the reorder-hold actually rides: the WORSE of the jitter axis and
-    /// the loss axis. `max` (not sum) keeps the total bounded at `maxHoldUs` and
-    /// means a link that's both jittery and lossy doesn't double-count.
-    var effectiveLevel: Int { max(level, lossLevel) }
+    /// FEC arming-bias axis from the link-state reconciler (hardening #5). 0 unless
+    /// EnvSignalController's default-off `fecArmingBiasEnabled` feeds caution/distress
+    /// in. Receive-side only; combined via `max` so it can only widen the hold.
+    private(set) var armingBiasLevel = 0
+
+    /// The level the reorder-hold actually rides: the WORST of the jitter axis, the
+    /// loss axis, and the arming-bias axis. `max` (not sum) keeps the total bounded
+    /// at `maxHoldUs` and means overlapping evidence doesn't double-count.
+    var effectiveLevel: Int { max(level, lossLevel, armingBiasLevel) }
 
     /// The jitter-scaled BASE hold (µs): the clean `baseHoldUs` plus a bounded
     /// widening for the link's standing jitter above `jitterBaseFloorMs`. A
@@ -388,6 +393,17 @@ struct FecHeadroomController {
         return false
     }
 
+    /// Set the arming-bias axis from the link-state reconciler (caution/distress →
+    /// 1/2 steps; hardening #5). Receive-side only, zero wire bytes; 0-clamped and
+    /// default-off, so off → byte-identical. Returns true iff it changed.
+    @discardableResult
+    mutating func observeArmingBias(level newLevel: Int) -> Bool {
+        let clamped = min(Self.maxLevel, max(0, newLevel))
+        let changed = clamped != armingBiasLevel
+        armingBiasLevel = clamped
+        return changed
+    }
+
     /// Reset to baseline. Called when the queue resets its per-window accumulators
     /// for a fresh session so the controller never carries a stale escalation into
     /// a new stream.
@@ -401,5 +417,6 @@ struct FecHeadroomController {
         lossEventRun = 0
         lossClearRun = 0
         lossWindowsSinceChange = Int.max
+        armingBiasLevel = 0
     }
 }

--- a/Glimmer/Stream/Native/ReedSolomon.swift
+++ b/Glimmer/Stream/Native/ReedSolomon.swift
@@ -104,6 +104,16 @@ struct ReedSolomon {
         self.matrix = cauchy
     }
 
+    /// Build from an explicit row-major `m[j*ds + i]` parity matrix (fixed non-Cauchy
+    /// profiles, e.g. the audio matrix; see AudioFecDecoder) instead of generating
+    /// Cauchy. nil for bad geometry or `matrix.count != ps*ds`.
+    init?(matrix: [UInt8], dataShards ds: Int, parityShards ps: Int) {
+        guard ds > 0, ps > 0, ds + ps <= 255, matrix.count == ps * ds else { return nil }
+        self.ds = ds
+        self.ps = ps
+        self.matrix = matrix
+    }
+
     // MARK: - GF row ops (rs.c axpy/scal)
 
     /// a[i] ^= coeff * b[i]  (GF mul-add). coeff==0 → no-op; coeff==1 → XOR.
@@ -165,6 +175,30 @@ struct ReedSolomon {
                 a[i] = GF256.exp[lu + Int(GF256.log[Int(av)])]
             }
         }
+    }
+
+    // MARK: - In-place shard mutation (copy-on-write avoidance)
+
+    // Mutate one shard WITHOUT per-op CoW: `var t = shards[i]` double-refs the buffer,
+    // so the next write copies the whole ~1.1KB shard on every axpy/scal during loss
+    // bursts. Assigning `shards[i] = []` first drops that ref so `t` owns it alone.
+
+    @inline(__always)
+    private static func axpyShardInPlace(_ shards: inout [[UInt8]], _ tIdx: Int,
+                                         _ src: [UInt8], _ coeff: UInt8, _ k: Int) {
+        var t = shards[tIdx]
+        shards[tIdx] = []
+        axpyShard(&t, src, coeff, k)
+        shards[tIdx] = t
+    }
+
+    @inline(__always)
+    private static func scalShardInPlace(_ shards: inout [[UInt8]], _ tIdx: Int,
+                                         _ coeff: UInt8, _ k: Int) {
+        var t = shards[tIdx]
+        shards[tIdx] = []
+        scalShard(&t, coeff, k)
+        shards[tIdx] = t
     }
 
     // MARK: - Decode (rs.c reed_solomon_decode + invert_mat)
@@ -263,9 +297,8 @@ struct ReedSolomon {
             for row in 0..<survBase {
                 let coeff = matrix[dr + colPerm[row]]
                 if coeff != 0 {
-                    var target = shards[colPerm[col]]
-                    Self.axpyShard(&target, shards[colPerm[row]], coeff, shardSize)
-                    shards[colPerm[col]] = target
+                    let src = shards[colPerm[row]]
+                    Self.axpyShardInPlace(&shards, colPerm[col], src, coeff, shardSize)
                 }
             }
             col += 1
@@ -282,18 +315,13 @@ struct ReedSolomon {
             // [0, x) are already 0 so this is byte-identical for every value that
             // is ever read, without the out-of-bounds write.
             Self.scal(&wrk, x * unknowns + x, coeff, unknowns - x)
-            do {
-                var target = shards[colPerm[survBase + x]]
-                Self.scalShard(&target, coeff, shardSize)
-                shards[colPerm[survBase + x]] = target
-            }
+            Self.scalShardInPlace(&shards, colPerm[survBase + x], coeff, shardSize)
             if x + 1 < unknowns {
+                let src = shards[colPerm[survBase + x]]
                 for row in (x + 1)..<unknowns {
                     let rowCoeff = wrk[row * unknowns + x]
                     Self.axpy(&wrk, row * unknowns, wrk, x * unknowns, rowCoeff, unknowns)
-                    var target = shards[colPerm[survBase + row]]
-                    Self.axpyShard(&target, shards[colPerm[survBase + x]], rowCoeff, shardSize)
-                    shards[colPerm[survBase + row]] = target
+                    Self.axpyShardInPlace(&shards, colPerm[survBase + row], src, rowCoeff, shardSize)
                 }
             }
         }
@@ -304,9 +332,7 @@ struct ReedSolomon {
             let from = shards[colPerm[survBase + x]]
             for row in 0..<x {
                 let coeff = wrk[row * unknowns + x]
-                var target = shards[colPerm[survBase + row]]
-                Self.axpyShard(&target, from, coeff, shardSize)
-                shards[colPerm[survBase + row]] = target
+                Self.axpyShardInPlace(&shards, colPerm[survBase + row], from, coeff, shardSize)
             }
             x -= 1
         }

--- a/Glimmer/Stream/Native/RtpVideoQueue.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue.swift
@@ -491,10 +491,15 @@ final class RtpVideoQueue {
         lastUnrecoverableTotalSnapshot = unrecoverableTotalNow
         let lossChanged = fecHeadroom.observeLoss(fecRecovered: fecRecoveredFramesInWindow,
                                                   unrecoverable: unrecoverableDelta)
-        if jitterChanged || lossChanged {
+        // ARMING BIAS (hardening #5, DEFAULT-OFF): bias the reorder-hold up on
+        // caution/distress link state - receive-side only, never the pacer depth.
+        let biasLevel = EnvSignalController.fecArmingBiasEnabled
+            ? EnvSignalController.shared.state.fecArmingBiasLevel : 0
+        let biasChanged = fecHeadroom.observeArmingBias(level: biasLevel)
+        if jitterChanged || lossChanged || biasChanged {
             Diag.notice("NativeVideo PROACTIVE FEC headroom: reorder-hold → "
                 + "\(reorderWindowUs / 1000)ms (jitter-lvl \(fecHeadroom.level) "
-                + "loss-lvl \(fecHeadroom.lossLevel)) "
+                + "loss-lvl \(fecHeadroom.lossLevel) bias-lvl \(fecHeadroom.armingBiasLevel)) "
                 + "[recv-jitter=\(String(format: "%.1f", jitterUs / 1000.0))ms "
                 + "ooo=\(windowOutOfOrder) retransmit=\(retransmitDelta) "
                 + "fec-recovered=\(fecRecoveredFramesInWindow) unrecoverable=\(unrecoverableDelta)]",

--- a/Glimmer/Stream/Types.swift
+++ b/Glimmer/Stream/Types.swift
@@ -311,6 +311,24 @@ public struct VideoFormats: OptionSet, Sendable {
     }
 }
 
+public extension VideoFormats {
+    /// All AV1 profile bits (Main8/Main10 + High 4:4:4 8/10-bit).
+    static let anyAV1: VideoFormats = [.av1, .av1Main10, .av1High8_444, .av1High10_444]
+    /// All HEVC profile bits (Main/Main10 + RExt 4:4:4 8/10-bit).
+    static let anyHEVC: VideoFormats = [.hevc, .hevcMain10, .hevcRext8_444, .hevcRext10_444]
+
+    enum TopCodec: Sendable { case av1, hevc, h264 }
+
+    /// Codec family the host will most likely settle on for this mask (negotiation
+    /// prefers AV1 → HEVC → H.264). Lets bitrate budget be codec-aware pre-launch,
+    /// before the SDP handshake finalizes the exact format.
+    var topCodec: TopCodec {
+        if !isDisjoint(with: .anyAV1) { return .av1 }
+        if !isDisjoint(with: .anyHEVC) { return .hevc }
+        return .h264
+    }
+}
+
 public enum ColorSpace: Sendable {
     case rec601, rec709, rec2020
     var cValue: Int32 {

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.21
-CURRENT_PROJECT_VERSION = 20260632
+MARKETING_VERSION = 2026.6.22
+CURRENT_PROJECT_VERSION = 20260633

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -27,6 +27,18 @@ APPCAST="appcast.xml"
 "$CREDS" get SPARKLE_ED_PRIVATE_KEY >/dev/null || {
 	echo "ERR: SPARKLE_ED_PRIVATE_KEY missing from $($CREDS path) - run 'make sparkle-keys' once" >&2; exit 1; }
 
+# The release tag is advertised as the GPLv3 source, so it must be the exact commit
+# we built: require local HEAD == origin/main before pinning the tag below.
+git -C "$HERE" fetch --quiet origin main
+HEAD_SHA="$(git -C "$HERE" rev-parse HEAD)"
+MAIN_SHA="$(git -C "$HERE" rev-parse origin/main)"
+[ "$HEAD_SHA" = "$MAIN_SHA" ] || {
+	echo "ERR: local HEAD ($HEAD_SHA) != origin/main ($MAIN_SHA)." >&2
+	echo "  Bump Version.xcconfig, commit, merge to main, then 'git pull --ff-only' before publishing -" >&2
+	echo "  the release tag is the GPLv3 source and must match the built commit." >&2
+	exit 1
+}
+
 echo "▶ Zipping notarized bundle for Sparkle..."
 rm -f "$ZIP"
 ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
@@ -44,21 +56,25 @@ ASSETS=("$ZIP")
 if gh release view "$TAG" -R "$REPO" >/dev/null 2>&1; then
 	gh release upload "$TAG" "${ASSETS[@]}" -R "$REPO" --clobber
 else
-	gh release create "$TAG" "${ASSETS[@]}" -R "$REPO" --title "Glimmer $SHORT" \
+	gh release create "$TAG" "${ASSETS[@]}" -R "$REPO" --target "$HEAD_SHA" --title "Glimmer $SHORT" \
 		--notes "Glimmer $SHORT. Auto-updates via Sparkle; the notarized DMG is attached. Source: this repo at tag $TAG (GPLv3)."
 fi
 echo "  ✓ release published"
 
-echo "▶ Updating the Pages appcast..."
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
-gh api "repos/$REPO/contents/$APPCAST" -H "Accept: application/vnd.github.raw" > "$TMP/appcast.xml"
-SHA="$(gh api "repos/$REPO/contents/$APPCAST" --jq '.sha')"
-"$HERE/scripts/update-appcast.py" "$TMP/appcast.xml" \
+# Single source of truth: the committed appcast.xml IS what Pages serves
+# (main:/appcast.xml). Edit it in the tree and commit + push to main (no `gh api`
+# PUT), so the committed copy never drifts. Committed AFTER the tag is pinned.
+echo "▶ Updating the committed appcast (main:/$APPCAST is what Pages serves)..."
+"$HERE/scripts/update-appcast.py" "$HERE/$APPCAST" \
 	--short-version "$SHORT" --version "$BUILD" \
 	--url "$ASSET_URL" --ed-signature "$ED_SIG" --length "$LENGTH" --min-system 26.0
-CONTENT="$(base64 -i "$TMP/appcast.xml" | tr -d '\n')"
-jq -n --arg m "appcast: Glimmer $SHORT" --arg c "$CONTENT" --arg s "$SHA" \
-	'{message:$m, content:$c, sha:$s}' \
-	| gh api -X PUT "repos/$REPO/contents/$APPCAST" --input - --jq '"  ✓ appcast → " + .commit.html_url'
+if git -C "$HERE" diff --quiet -- "$APPCAST"; then
+	echo "  ✓ appcast already current (no change to publish)"
+else
+	git -C "$HERE" add "$APPCAST"
+	git -C "$HERE" commit -m "appcast: Glimmer $SHORT" --quiet
+	git -C "$HERE" push --quiet origin HEAD:main
+	echo "  ✓ appcast committed + pushed to main → $(git -C "$HERE" rev-parse --short HEAD)"
+fi
 
 echo "✅ Published Glimmer $SHORT - Sparkle clients see it within a day (or now via Check for Updates...)."

--- a/scripts/update-appcast.py
+++ b/scripts/update-appcast.py
@@ -52,7 +52,9 @@ def main() -> None:
 
     item = ET.Element("item")
     ET.SubElement(item, "title").text = a.short_version
-    ET.SubElement(item, "pubDate").text = formatdate(localtime=True)
+    # UTC, not localtime: the appcast is public-by-design, and a local timezone
+    # offset (e.g. -0400) is a free geolocation signal on a pseudonymous project.
+    ET.SubElement(item, "pubDate").text = formatdate(usegmt=True)
     ET.SubElement(item, sk("version")).text = a.version
     ET.SubElement(item, sk("shortVersionString")).text = a.short_version
     ET.SubElement(item, sk("minimumSystemVersion")).text = a.min_system


### PR DESCRIPTION
One batch branch (you OK'd a single release branch). All items build clean and the full 146-test suite passes.

**Bandwidth**
- `QualityCalculator`: codec-aware wire budget — the H.264-anchored curve is discounted for the intended top codec (HEVC ×0.80, AV1 ×0.67), ~20-33% fewer bytes at equal quality. `effectiveBitrateKbps` stays the H.264-equivalent quality dial the UI shows; a Custom bitrate is sent verbatim. (4:2:0-vs-4:4:4 deliberately excluded — it's a real quality trade-off.)

**Refactors**
- `ReedSolomon`: new `init(matrix:dataShards:parityShards:)`; `AudioFecDecoder` collapses to a thin wrapper over the shared solver (−210 dup lines). FEC fuzz tests prove byte-identical.
- `ReedSolomon`: removed the per-op copy-on-write that copied a whole ~1.1KB shard on every GF row op during loss bursts.
- `FramePacer`: regrouped ~50 fields into 4 cohesive sub-state structs (`refreshTelemetry`, `tickDeficit`, `liveness`, `adaptiveDepth`) under the same single `os_unfair_lock` — pure namespacing, lock contract preserved, verified by a diff scan (every changed line is a rename or struct def).

**Hardening (default-off)**
- `FecHeadroomController`: link-state (caution/distress) arming-bias as a third reorder-hold axis, behind `EnvSignalController.fecArmingBiasEnabled = false` — byte-identical until flipped on to shadow-validate.

**Release tooling**
- Pin the release tag to the exact built commit (`--target HEAD` + a `HEAD == origin/main` preflight) so the GPLv3 source tag matches the binary.
- Single-source the committed `appcast.xml` (drop the out-of-band `gh api` PUT) so it never drifts from the served copy.
- `pubDate` now UTC (drops a local-timezone geolocation signal).
