### PR TITLE
fix: soften AV1 bitrate budget (0.67->0.80) for heavy-scene headroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.6.23 - 2026-06-24
+
+Restores headroom on AV1 streams. 2026.6.22's codec-aware budget trimmed AV1
+sessions a bit aggressively (a third off the H.264 figure); this softens that to
+match HEVC (~20% off), so busy, high-motion scenes keep more room before the
+encoder feels it - while still using less bandwidth than H.264 at the same
+quality.
+
 ## 2026.6.22 - 2026-06-24
 
 Uses less bandwidth on modern codecs at the same picture quality. The bitrate

--- a/Glimmer/QualityCalculator.swift
+++ b/Glimmer/QualityCalculator.swift
@@ -169,7 +169,7 @@ extension MoonlightManager {
     /// heavy scenes keep headroom; the 5 Mbps floor bounds the low end. Field-tunable.
     static func codecBudgetMultiplier(for formats: VideoFormats) -> Double {
         switch formats.topCodec {
-        case .av1:  return 0.67
+        case .av1:  return 0.80
         case .hevc: return 0.80
         case .h264: return 1.0
         }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.22
-CURRENT_PROJECT_VERSION = 20260633
+MARKETING_VERSION = 2026.6.23
+CURRENT_PROJECT_VERSION = 20260634


### PR DESCRIPTION
2026.6.22's codec-aware budget cut AV1 by 33% (x0.67). Telem on a real session showed no starvation (goodput util peaked 0.73, not pegged; pacer + link clean) — the felt chug was the ~3s decode-gated startup ramp, present in both builds. But heavy-scene headroom dropped from 55% spare to 27%, so this softens AV1 to match HEVC (x0.80 -> 84->67 Mbps), keeping ~20% savings with more room under load. One-line constant change.