### PR TITLE
fix(audio): break audio-teardown deadlock (varispeed rate off the completion handler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.6.24 - 2026-06-24
+
+Fixes a rare freeze when a stream drops. If the host cut the connection at just
+the wrong instant - mid audio-playout - the app's audio teardown could deadlock
+against the audio engine, hanging Glimmer so it couldn't reconnect until it was
+force-quit and relaunched. The drift resampler now applies its rate change off
+the audio completion handler, removing the lock-order inversion that caused it.
+
 ## 2026.6.23 - 2026-06-24
 
 Restores headroom on AV1 streams. 2026.6.22's codec-aware budget trimmed AV1

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -447,7 +447,7 @@ extension AudioDecoder {
             if resamplerEpsPpm != 0 {
                 resamplerEpsPpm += max(-Self.resamplerSlewPpm,
                                        min(Self.resamplerSlewPpm, -resamplerEpsPpm))
-                varispeed.rate = Float(1.0 + resamplerEpsPpm * 1e-6)
+                applyVarispeedRate(Float(1.0 + resamplerEpsPpm * 1e-6))
             }
             return
         }
@@ -462,10 +462,17 @@ extension AudioDecoder {
         // Slew-limit the APPLIED offset so the rate (hence pitch) never steps.
         resamplerEpsPpm += max(-Self.resamplerSlewPpm,
                                min(Self.resamplerSlewPpm, targetPpm - resamplerEpsPpm))
-        varispeed.rate = Float(1.0 + resamplerEpsPpm * 1e-6)
+        applyVarispeedRate(Float(1.0 + resamplerEpsPpm * 1e-6))
     }
 
     private func clampResamplerPpm(_ v: Double) -> Double {
         max(-Self.resamplerBoundPpm, min(Self.resamplerBoundPpm, v))
+    }
+
+    /// Apply `varispeed.rate` OFF the player-node completion handler: writing it there
+    /// (holding AVAudio's messenger lock) deadlocks against teardown's
+    /// `playerNode.stop()` (engine lock). The hop breaks it; post-shutdown writes no-op.
+    func applyVarispeedRate(_ rate: Float) {
+        varispeedRateQueue.async { [weak self] in self?.varispeed.rate = rate }
     }
 }

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -34,6 +34,11 @@ public final class AudioDecoder: @unchecked Sendable {
     /// one-directional/clicky silence micro-stretch. ε is ppm-scale (the bound is
     /// ±500ppm = ±0.5 cents, inaudible; the slew limit keeps the pitch from stepping).
     let varispeed = AVAudioUnitVarispeed()
+    /// Serial queue for `varispeed.rate` writes — keeps the write (which takes
+    /// AVAudio's engine lock) OFF the completion handler, which holds the messenger
+    /// lock and would deadlock against teardown's `playerNode.stop()`. Non-private:
+    /// `applyVarispeedRate` (the resampler extension) writes through it.
+    let varispeedRateQueue = DispatchQueue(label: "io.ugfugl.Glimmer.audio.varispeed-rate")
     private var inputFormat: AVAudioFormat?
     private var channelCount: Int = 2
     private var samplesPerFrame: Int = 240         // 5ms at 48kHz, common GFE/Sunshine config

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.23
-CURRENT_PROJECT_VERSION = 20260634
+MARKETING_VERSION = 2026.6.24
+CURRENT_PROJECT_VERSION = 20260635


### PR DESCRIPTION
**Real deadlock**, root-caused from a process sample of a wedged client after a host-error disconnect.

**Cycle (lock-order inversion):**
- The drift resampler (`driveResampler`) runs inside the AVAudioPlayerNode buffer **completion handler**, which holds AVAudio's RealtimeMessenger lock. It wrote `varispeed.rate`, which takes AVAudio's **engine lock** → completion thread holds messenger, wants engine.
- Teardown (`StreamSession.stop` → `AudioDecoder.shutdown` → `playerNode.stop()`) holds the **engine lock**, then drains pending completions → wants the **messenger lock**.
- `host_error` (host silently reset the ENet peer) landed mid-playout and triggered the inversion → app froze, couldn't reconnect until force-quit.

**Fix:** `varispeed.rate` writes now hop to a serial queue (`applyVarispeedRate`), so the rate write never holds the messenger lock while taking the engine lock. The resampler math is unchanged; only the hardware rate apply is deferred (sub-ms, the loop is ppm-slow at ~4Hz). The session-setup write (rate=1.0, engine idle) stays synchronous.

`make app` + 146 tests green. The deadlock is a race (can't unit-test); validated by reasoning + the sample. Pre-existing (drift-resampler era), surfaced now.