### PR TITLE
fix(audio): speed up drift-resampler catch-up to stop clock-skew crackle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.6.25 - 2026-06-25
+
+Smoother audio when the host and Mac clocks drift apart. The drift-tracking
+resampler now catches a clock-skew onset about twice as fast, so the audio
+cushion no longer briefly drains during the catch-up - which is what produced
+the occasional crackle on longer sessions. Pitch movement stays inaudible.
+
 ## 2026.6.24 - 2026-06-24
 
 Fixes a rare freeze when a stream drops. If the host cut the connection at just

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -117,8 +117,8 @@ public final class AudioDecoder: @unchecked Sendable {
     static let resamplerUpdateIntervalNanos: UInt64 = 250_000_000  // ~4Hz; drift is ppm-slow
     static let resamplerDeadbandMs = 1.0    // ignore sub-ms fill noise (integral anti-windup)
     static let resamplerKpPpmPerMs = 3.0    // proportional: answers transient fill excursions
-    static let resamplerKiPpmPerMs = 0.03   // integral: absorbs the steady ppm clock offset
-    static let resamplerSlewPpm = 2.0       // max ppm change per update ⇒ rate never steps
+    static let resamplerKiPpmPerMs = 0.06   // integral: absorbs the steady ppm clock offset (2x for faster catch-up)
+    static let resamplerSlewPpm = 4.0       // max ppm change per update; 16ppm/s still well under audible pitch step
     static let resamplerBoundPpm = 500.0    // hard clamp ≫ any real drift (~1 cent worst case)
     /// Mirror of `isShutdown` in the METER lock's domain, raised by `shutdown()`
     /// BEFORE `playerNode.stop()`. Stopping a node with a standing cushion fires

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.24
-CURRENT_PROJECT_VERSION = 20260635
+MARKETING_VERSION = 2026.6.25
+CURRENT_PROJECT_VERSION = 20260636


### PR DESCRIPTION
Telemetry on 2026.6.24 showed occasional audio crackle = host<->Mac clock skew the drift resampler catches too slowly. The resampler is stable (smooth ppm ramp, ~30% of authority) - the .24 deadlock fix is NOT implicated - but Ki=0.03 + slew=2ppm/update meant catching a real -150ppm skew took minutes, and the cushion drained during catch-up (min-fill hit 0 in ~9% of samples).

Raise resampler Ki 0.03->0.06 and slew 2.0->4.0 (both 2x) so it catches drift onsets ~2x faster, before the cushion drains. 16ppm/s is still well under an audible pitch step; small overshoot risk, no added latency. Cushion left alone (it already auto-ratchets). make app green.