### PR TITLE
fix(audio): widen resampler skew-correction bound so a real host clock skew can't rail it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026.6.26 - 2026-06-24
+
+Holds audio together on hosts whose clock drifts hard. The drift resampler's
+correction ceiling was set for a near-perfect clock and could be hit by a host
+whose audio clock runs off by a few hundred parts-per-million - once pinned, it
+could no longer keep the buffer full and the audio would crackle. The ceiling is
+now high enough to absorb the skews real hosts actually show, with margin to
+spare; the rate change stays inaudible.
+
 ## 2026.6.25 - 2026-06-24
 
 Smoother audio when the host and Mac clocks drift apart. The drift-tracking

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -119,7 +119,7 @@ public final class AudioDecoder: @unchecked Sendable {
     static let resamplerKpPpmPerMs = 3.0    // proportional: answers transient fill excursions
     static let resamplerKiPpmPerMs = 0.06   // integral: absorbs the steady ppm clock offset (2x for faster catch-up)
     static let resamplerSlewPpm = 4.0       // max ppm change per update; 16ppm/s still well under audible pitch step
-    static let resamplerBoundPpm = 500.0    // hard clamp ≫ any real drift (~1 cent worst case)
+    static let resamplerBoundPpm = 1500.0   // skew-correction ceiling; real host skews seen ~450ppm, so 500 railed
     /// Mirror of `isShutdown` in the METER lock's domain, raised by `shutdown()`
     /// BEFORE `playerNode.stop()`. Stopping a node with a standing cushion fires
     /// the completion handler of EVERY queued buffer (.dataConsumed semantics:

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.25
-CURRENT_PROJECT_VERSION = 20260636
+MARKETING_VERSION = 2026.6.26
+CURRENT_PROJECT_VERSION = 20260637


### PR DESCRIPTION
Telemetry showed the drift resampler ramping to -451ppm against the ±500 bound on a real session, with buffer held + zero overruns — proving -451 is the TRUE host↔Mac clock skew (not windup; an over-wound integral would over-slow playout and overrun). The ±500 clamp's own comment claimed '≫ any real drift (~1 cent worst case)' — that assumption is wrong; this host skews ~450ppm, right at the clamp. One slightly-worse session pins it, the resampler can't correct further, the cushion drains, and audio crackles.

Widen resamplerBoundPpm 500→1500 (3.3x the observed real skew; ~2.6 cents only if a host actually skews 1500ppm, and normal operation sits far below at the real skew). This is a parameter correction, not a band-aid — the old value was simply too low for real hosts.

NOT adding a behavioral rail-guard: reading the reprime path, the existing under-run→cushion-ratchet→backfill already degrades a railed resampler gracefully (deepens the cushion to absorb the skew, one gap not continuous cracking), and a proactive guard would mean cross-thread surgery in the completion handler (the reprime is decode-path/AV-serialized — the same deadlock just fixed in .24). Widening the bound makes railing near-impossible for real hosts anyway. make app green.