### PR TITLE
feat(awdl): tighten awdl0 suppression (routing socket + sticky down + contention telemetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.6.27 - 2026-06-25
+
+Tightens the Wi-Fi network helper so it holds awdl0 down harder during a stream.
+macOS re-raises the AirDrop/Continuity radio on its own schedule; the helper now
+catches that the instant it happens (a kernel routing socket rather than a
+slower poll), strips the interface's IPv6 address, and verifies it actually went
+down - so the radio gets far less chance to hop off your stream's channel and
+stutter it. It also now records how often macOS fought the radio back up
+(visible in telemetry) and logs clearly whether it engaged for each stream.
+
 ## 2026.6.26 - 2026-06-24
 
 Holds audio together on hosts whose clock drifts hard. The drift resampler's

--- a/Glimmer/AWDLHelperManager.swift
+++ b/Glimmer/AWDLHelperManager.swift
@@ -20,6 +20,7 @@ import os.log
     func setAWDLDown(_ down: Bool, reason: String, reply: @escaping (Bool) -> Void)
     func currentStatus(reply: @escaping (Bool, Date?) -> Void)
     func ping(reply: @escaping (String) -> Void)
+    func reSuppressCount(reply: @escaping (UInt64) -> Void)
 }
 
 enum HelperConstants {
@@ -94,6 +95,20 @@ actor HelperClient {
             } as? GlimmerHelperProtocol
             guard let proxy else { once.resume(nil); return }
             proxy.currentStatus { isDown, since in once.resume((isDown, since)) }
+        }
+    }
+
+    /// The daemon's whack-a-mole count (macOS re-raises of awdl0 this stream), or
+    /// nil if unreachable. Read on the suppress heartbeat for the contention gauge.
+    func reSuppressCount() async -> UInt64? {
+        await withCheckedContinuation { (cont: CheckedContinuation<UInt64?, Never>) in
+            let once = SingleResume(cont)
+            let proxy = connect().remoteObjectProxyWithErrorHandler { [weak self] _ in
+                Task { await self?.drop() }
+                once.resume(nil)
+            } as? GlimmerHelperProtocol
+            guard let proxy else { once.resume(nil); return }
+            proxy.reSuppressCount { count in once.resume(count) }
         }
     }
 }
@@ -296,11 +311,26 @@ final class AWDLHelperManager: ObservableObject {
     /// it keeps awdl0 down and can detect if we go away (stream end / crash) and
     /// restore it. No-op unless the helper is enabled.
     func suppressForStream() {
-        guard isEnabled else { return }
+        guard isEnabled else {
+            Diag.notice("AWDL helper NOT engaged - state \(String(describing: state)); awdl0 left to macOS", "Stream")
+            return
+        }
+        Diag.notice("AWDL helper engaged - parking awdl0 for the stream", "Stream")
         heartbeatTask?.cancel()
         heartbeatTask = Task { @MainActor in
+            var tick = 0
             while !Task.isCancelled {
                 self.suppressing = await self.client.setAWDLDown(true, reason: "stream")
+                // ~5s: pull the daemon's re-raise count → telemetry gauge + a breadcrumb
+                // when macOS is actively fighting awdl0 back up (link contention).
+                if tick % 5 == 0, let n = await self.client.reSuppressCount() {
+                    TelemetryCounters.shared.setAWDLHelper(
+                        .init(suppressing: self.suppressing, reSuppressTotal: n))
+                    if n > 0 {
+                        Diag.info("AWDL re-suppress \(n) - macOS re-raised awdl0 this stream", "Stream")
+                    }
+                }
+                tick &+= 1
                 try? await Task.sleep(for: .seconds(1))
             }
         }
@@ -314,6 +344,8 @@ final class AWDLHelperManager: ObservableObject {
         Task { @MainActor in
             _ = await client.setAWDLDown(false, reason: "stream-end")
             self.suppressing = false
+            TelemetryCounters.shared.setAWDLHelper(.init(suppressing: false, reSuppressTotal: 0))
+            Diag.info("AWDL helper released awdl0 (stream end)", "Stream")
         }
     }
 }

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -109,6 +109,15 @@ extension TelemetryCounters {
         return fecHealthValue
     }
 
+    /// AWDL-helper gauge: awdl0 parked this stream + how many times macOS re-raised
+    /// it (the contention rate the routing-socket suppressor fights). nil when off.
+    struct AWDLHelperSnapshot: Sendable {
+        var suppressing: Bool
+        var reSuppressTotal: UInt64
+    }
+    func setAWDLHelper(_ snapshot: AWDLHelperSnapshot) { awdlHelperState.withLock { $0 = snapshot } }
+    var awdlHelper: AWDLHelperSnapshot? { awdlHelperState.withLock { $0 } }
+
     func setRecvJitterMs(_ ms: Double) {
         os_unfair_lock_lock(jitterLock); recvJitterMsValue = ms; os_unfair_lock_unlock(jitterLock)
     }

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -397,6 +397,10 @@ final class TelemetryCounters: @unchecked Sendable {
     let fecHealthLock = os_unfair_lock_t.allocate(capacity: 1)
     var fecHealthValue: FecHealthSnapshot?
 
+    /// AWDL helper gauge (awdl0 parked + macOS re-raise count). Set by
+    /// AWDLHelperManager on the suppress heartbeat; read by the exporter. Self-locked.
+    let awdlHelperState = OSAllocatedUnfairLock<AWDLHelperSnapshot?>(initialState: nil)
+
     /// Host-RUMBLE receipt stamp (the last 0x010b receipt instant) - the detach-
     /// context breadcrumb's rumble-age source (ControllerForwarder.detach).
     /// Self-locked holder (the `P2State` idiom), defined in
@@ -587,6 +591,7 @@ final class TelemetryCounters: @unchecked Sendable {
         os_unfair_lock_lock(gapLock); packetGapValue = nil; os_unfair_lock_unlock(gapLock)
         os_unfair_lock_lock(decodeStateLock); decodeStateValue = nil; os_unfair_lock_unlock(decodeStateLock)
         os_unfair_lock_lock(fecHealthLock); fecHealthValue = nil; os_unfair_lock_unlock(fecHealthLock)
+        awdlHelperState.withLock { $0 = nil }
         os_unfair_lock_lock(audioStateLock)
         audioStateValue = nil; audioBufferFillMinMsValue = .infinity
         os_unfair_lock_unlock(audioStateLock)

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -245,6 +245,10 @@ extension TelemetryExporter {
             snap.fecPercentage = fec.fecPercentage
             snap.fecParityMargin = fec.parityMargin
         }
+        if let awdl = counters.awdlHelper {
+            snap.awdlSuppressing = awdl.suppressing
+            snap.awdlReSuppressTotal = awdl.reSuppressTotal
+        }
         // Refresh the live RTT gauge the per-frame glass-to-glass computation
         // reads at present (~RTT/2 for the transit leg). Done here on the 1Hz
         // queue, never the hot path; the present-side read is the only hot-path

--- a/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
@@ -42,6 +42,15 @@ extension TelemetryRenderer {
                      "Spare parity shards on the worst frame this window (parity - data deficit); "
                      + "trends toward 0 before a frame goes unrecoverable.",
                      snap.fecParityMargin.map(Double.init))
+        // AWDL helper: awdl0 parked + how hard macOS is fighting it back up. A
+        // contested link shows resuppress climbing; a clean one stays ~0.
+        builder.emit("glimmer_awdl_suppressing",
+                     "awdl0 parked by the Wi-Fi helper this stream (1 = parked, 0 = not).",
+                     snap.awdlSuppressing.map { $0 ? 1.0 : 0.0 })
+        builder.emit("glimmer_awdl_resuppress_total",
+                     "Times macOS re-raised awdl0 this stream - the AWDL-contention rate the helper fights "
+                     + "(per-stream; high on a contested link).",
+                     snap.awdlReSuppressTotal.map(Double.init))
         builder.emit("glimmer_net_packets_per_second", "Video packets received per second.", snap.packetsPerSecond)
         builder.emit("glimmer_net_rtt_ms", "ENet RTT estimate (high-res local clock), ms.", snap.rttMs)
         builder.emit("glimmer_net_rtt_variance_ms", "ENet RTT variance, ms.", snap.rttVarianceMs)

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -119,6 +119,11 @@ struct TelemetrySnapshot: Sendable {
     /// Spare parity shards on the worst frame this window (parity − deficit).
     var fecParityMargin: Int?
 
+    // AWDL Wi-Fi helper: whether awdl0 is parked this stream and how many times
+    // macOS re-raised it (the contention the helper fights). nil = helper off.
+    var awdlSuppressing: Bool?
+    var awdlReSuppressTotal: UInt64?
+
     // ENet reliable-stream health
     var enetSentReliable: Int?
     var enetOldestUnackedMs: UInt32?

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.26
-CURRENT_PROJECT_VERSION = 20260637
+MARKETING_VERSION = 2026.6.27
+CURRENT_PROJECT_VERSION = 20260638

--- a/helper/AWDLSuppressor.swift
+++ b/helper/AWDLSuppressor.swift
@@ -23,6 +23,13 @@ final class AWDLSuppressor: @unchecked Sendable {
     private var pollTimer: DispatchSourceTimer?
     private var _initialDownDone = false
     private var _reSuppressCount = 0
+    /// PF_ROUTE fast path — re-down awdl0 the instant the kernel re-raises it,
+    /// event-driven (no poll) and far lower latency than SCDynamicStore.
+    private var routeFd: Int32 = -1
+    private var routeSource: DispatchSourceRead?
+    /// Tight verify-retry per down: macOS can re-raise within ms, so confirm + retry.
+    private static let maxDownAttempts = 3
+    private static let downRetrySettleUs: UInt32 = 40_000
 
     var suppressing: Bool {
         stateLock.lock(); defer { stateLock.unlock() }
@@ -34,8 +41,15 @@ final class AWDLSuppressor: @unchecked Sendable {
         return _suppressionSince
     }
 
+    /// How many times macOS re-raised awdl0 this stream (the whack-a-mole rate).
+    var reSuppressCount: UInt64 {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return UInt64(_reSuppressCount)
+    }
+
     func start() {
         setupMonitoring()
+        setupRouteSocket()
         startPolling()
         os_log("AWDL suppressor started", log: log, type: .default)
     }
@@ -90,10 +104,7 @@ final class AWDLSuppressor: @unchecked Sendable {
 
     private func downIfUp() {
         guard isInterfaceUp() else { return }
-        guard executeIfconfig(args: [interfaceName, "down"]) else {
-            os_log("Failed to bring %{public}@ down", log: log, type: .error, interfaceName)
-            return
-        }
+        let confirmed = forceDownAwdl()
         stateLock.lock()
         let initial = !_initialDownDone
         _initialDownDone = true
@@ -110,6 +121,75 @@ final class AWDLSuppressor: @unchecked Sendable {
             os_log("%{public}@ re-enabled by macOS (#%ld this stream) - re-suppressed",
                    log: log, type: .default, interfaceName, count)
         }
+        if !confirmed {
+            os_log("%{public}@ STILL up after %d down attempts", log: log, type: .error,
+                   interfaceName, Self.maxDownAttempts)
+        }
+    }
+
+    /// Down awdl0, strip its IPv6 link-local (macOS re-derives it on re-raise, so
+    /// deleting it raises the cost of coming back), and VERIFY - a few tight retries
+    /// because macOS can re-raise within ms. Returns true once confirmed down.
+    private func forceDownAwdl() -> Bool {
+        for attempt in 0..<Self.maxDownAttempts {
+            _ = executeIfconfig(args: [interfaceName, "down"])
+            for addr in ipv6LinkLocalAddrs() {
+                _ = executeIfconfig(args: [interfaceName, "inet6", addr, "delete"])
+            }
+            if !isInterfaceUp() { return true }
+            if attempt < Self.maxDownAttempts - 1 { usleep(Self.downRetrySettleUs) }
+        }
+        return !isInterfaceUp()
+    }
+
+    /// awdl0's current IPv6 addresses in `ifconfig … delete` form (scoped link-local).
+    private func ipv6LinkLocalAddrs() -> [String] {
+        guard let out = captureIfconfig() else { return [] }
+        return out.components(separatedBy: "\n")
+            .filter { $0.contains("inet6") }
+            .compactMap { line -> String? in
+                let parts = line.trimmingCharacters(in: .whitespaces).components(separatedBy: " ")
+                return parts.count > 1 ? parts[1] : nil
+            }
+    }
+
+    private func captureIfconfig() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/sbin/ifconfig")
+        task.arguments = [interfaceName]
+        let pipe = Pipe(); task.standardOutput = pipe; task.standardError = Pipe()
+        do { try task.run(); task.waitUntilExit() } catch { return nil }
+        return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    }
+
+    // MARK: Routing-socket fast path
+
+    /// Listen on a PF_ROUTE socket for kernel interface events and re-down awdl0 the
+    /// instant it's re-raised - event-driven, no polling, far lower latency than
+    /// SCDynamicStore, so the firmware barely gets an AWDL scan window in.
+    private func setupRouteSocket() {
+        let fd = socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC)
+        guard fd >= 0 else { os_log("route socket failed (errno %d)", log: log, type: .error, errno); return }
+        _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK)
+        routeFd = fd
+        let src = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+        src.setEventHandler { [weak self] in self?.drainRouteSocket() }
+        src.setCancelHandler { close(fd) }
+        src.resume()
+        routeSource = src
+        os_log("route-socket fast path armed (fd %d)", log: log, type: .default, fd)
+    }
+
+    /// Drain pending routing messages then re-assert the down if awdl0 popped up. We
+    /// don't parse message types - `downIfUp` is the filter (no-op unless awdl0 is
+    /// actually up) - so this stays simple and catches every raise edge.
+    private func drainRouteSocket() {
+        var buf = [UInt8](repeating: 0, count: 4096)
+        var sawEvent = false
+        while read(routeFd, &buf, buf.count) > 0 { sawEvent = true }
+        guard sawEvent else { return }
+        stateLock.lock(); let suppressing = _suppressing; stateLock.unlock()
+        if suppressing { downIfUp() }
     }
 
     /// Restore awdl0 to its normal (up) state once suppression ends - mirror of
@@ -142,6 +222,7 @@ final class AWDLSuppressor: @unchecked Sendable {
         let idle = Date().timeIntervalSince(_lastHeartbeat)
         stateLock.unlock()
         if suppressing {
+            downIfUp()  // 1s backstop re-assert in case the route socket missed an edge
             if idle > 3 {
                 os_log("heartbeat stale %.1fs - releasing awdl0", log: log, type: .default, idle)
                 setSuppressing(false, reason: "heartbeat-timeout")

--- a/helper/HelperService.swift
+++ b/helper/HelperService.swift
@@ -98,4 +98,8 @@ final class HelperService: NSObject, NSXPCListenerDelegate, GlimmerHelperProtoco
     func ping(reply: @escaping (String) -> Void) {
         reply("glimmer-helper-ok")
     }
+
+    func reSuppressCount(reply: @escaping (UInt64) -> Void) {
+        reply(suppressor.reSuppressCount)
+    }
 }

--- a/helper/Protocol.swift
+++ b/helper/Protocol.swift
@@ -4,6 +4,8 @@ import Foundation
     func setAWDLDown(_ down: Bool, reason: String, reply: @escaping (Bool) -> Void)
     func currentStatus(reply: @escaping (Bool, Date?) -> Void)
     func ping(reply: @escaping (String) -> Void)
+    /// How many times macOS re-raised awdl0 this stream (the contention/whack-a-mole rate).
+    func reSuppressCount(reply: @escaping (UInt64) -> Void)
 }
 
 public let GlimmerHelperMachServiceName = "io.ugfugl.glimmer.helper"


### PR DESCRIPTION
Wi-Fi-helper contention is **firmware-level** (macOS firmware does periodic AWDL channel scans, `FirmwareStartedScan`, independent of advertising — Handoff/AirDrop already off, rapportd is NoAWDL; no userland/driver off-switch, SIP-blocked). So the reactive hold is the only lever; this makes it surgical.

**Daemon (AWDLSuppressor):** PF_ROUTE routing socket re-downs awdl0 the instant the kernel re-raises it (event-driven, no poll, lower latency than SCDynamicStore); sticky down (ifconfig down + IPv6 link-local delete + 3x verify-retry). SCDynamicStore + 1s poll kept as backstops (poll now re-asserts).

**Observability:** manager logs engage/NOT-engaged + reason to Diag (it was silent before); new `glimmer_awdl_suppressing` + `glimmer_awdl_resuppress_total` telemetry (XPC count → gauge → exporter) so a contested session shows whether the routing socket starves it.

make app + helper-build green, 146 tests pass.