### PR TITLE
fix(ux): network pill - sustained-only + reliable fade-out (2026.6.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.6.30 - 2026-06-25
+
+Fixes the in-stream "Network degraded" pill. A brief Wi-Fi co-gap blip could
+flash it, and once shown it could stay stuck on even after the link recovered.
+It now appears only for SUSTAINED degradation - a momentary blip is ignored -
+and reliably fades back out when the link clears.
+
 ## 2026.6.29 - 2026-06-25
 
 Fixes the choppiness in 2026.6.28. One of that release's frame-pacing changes

--- a/Glimmer/Stream/StreamBannerLayer.swift
+++ b/Glimmer/Stream/StreamBannerLayer.swift
@@ -89,13 +89,25 @@ public final class StreamBannerLayer {
             layer.isHidden = false
             layer.opacity = 1
         } else {
-            CATransaction.setCompletionBlock { [weak layer] in
-                // Don't hide if a re-show raced in during the fade.
-                if layer?.opacity == 0 { layer?.isHidden = true }
+            // Gate the final hide on the LATEST intent (not opacity): a re-show that
+            // raced in during the fade sets visible=true, so a stale completion can't
+            // un-hide a shown pill - and a real hide always lands.
+            CATransaction.setCompletionBlock { [weak self] in
+                if self?.visible == false { self?.layer.isHidden = true }
             }
             layer.opacity = 0
         }
         CATransaction.commit()
+    }
+
+    /// Sustained-degradation gate for the network pill: a leaky integrator over the
+    /// caller's ticks (the 4Hz overlay timer) so a brief co-gap FLAP never flashes the
+    /// pill - only mostly-sustained caution shows it, and clearing drains it back out.
+    private var degradeLevel = 0
+    public func setSustained(_ degraded: Bool, text: String) {
+        degradeLevel = max(0, min(12, degradeLevel + (degraded ? 1 : -1)))
+        if degradeLevel >= 8 { setText(text); setVisible(true) }   // ~2s sustained
+        else if degradeLevel <= 2 { setVisible(false) }            // hysteresis floor
     }
 
     /// Position the pill against the host's bounds, sizing width to the text.

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -118,9 +118,9 @@ extension StreamSession {
                     // toggle so a degrading link reaches the user with the HUD
                     // off. Shown at >= caution; cheap atomic read every tick.
                     let env = EnvSignalController.shared.state
-                    win.networkBanner.setText(
-                        env == .distress ? "Network unstable" : "Network degraded")
-                    win.networkBanner.setVisible(env.rawValue >= EnvSignalController.EnvState.caution.rawValue)
+                    win.networkBanner.setSustained(
+                        env.rawValue >= EnvSignalController.EnvState.caution.rawValue,
+                        text: env == .distress ? "Network unstable" : "Network degraded")
                     // Cheap early-out: if the overlay is hidden, skip the
                     // snapshot read entirely. The decoder's collectors keep
                     // ticking in the background so a re-enable shows fresh

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.29
-CURRENT_PROJECT_VERSION = 20260640
+MARKETING_VERSION = 2026.6.30
+CURRENT_PROJECT_VERSION = 20260641


### PR DESCRIPTION
The 'Network degraded' pill could flash on a brief co-gap and then stay stuck (live telem confirmed: link pristine, env_state=0 clear, pill still yellow). Adds a leaky-integrator debounce (only ~2s+ sustained env>=caution shows it; a blip is ignored) and gates the fade-out's final hide on the latest intent flag so a hide always lands. Fade kept. Build + 156 tests green.