### PR TITLE
fix(ux): in-stream pill on perceived hitching, not env_state (2026.6.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.6.31 - 2026-06-25
+
+Makes the in-stream degradation badge honest. It was driven by a link-contention
+signal (Wi-Fi AWDL co-gaps) that the error-correction quietly absorbs - so it
+lit when nothing was wrong and missed the actual picture stutter. It now fires
+on perceived present-side hitching (dropped, late, or repeated frames), so it
+lights when the picture actually stutters and stays dark when the link blips
+harmlessly. Relabeled "Stream stuttering". The link-health signal it used to
+read is still recorded in telemetry.
+
 ## 2026.6.30 - 2026-06-25
 
 Fixes the in-stream "Network degraded" pill. A brief Wi-Fi co-gap blip could

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -111,22 +111,27 @@ extension StreamSession {
             // between), so 4Hz does NOT reintroduce the ±4fps boundary noise a
             // literal 250ms window would; the live gauges refresh at full 4Hz.
             let overlayFpsWindowSeconds = 1.0
+            // Per-second-rate baselines for the perceived-hitch pill, carried
+            // across ticks. Reference type so the timer closure mutates one box.
+            let hitchBox = PerceivedHitchBox()
             let timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak dec, weak win, weak inp] _ in
                 MainActor.assumeIsolated {
                     guard let dec, let win else { return }
-                    // Auto network-health pill, independent of the stats-HUD
-                    // toggle so a degrading link reaches the user with the HUD
-                    // off. Shown at >= caution; cheap atomic read every tick.
-                    let env = EnvSignalController.shared.state
-                    win.networkBanner.setSustained(
-                        env.rawValue >= EnvSignalController.EnvState.caution.rawValue,
-                        text: env == .distress ? "Network unstable" : "Network degraded")
-                    // Cheap early-out: if the overlay is hidden, skip the
-                    // snapshot read entirely. The decoder's collectors keep
-                    // ticking in the background so a re-enable shows fresh
-                    // numbers immediately.
-                    guard dec.statsOverlayEnabled else { return }
+                    // Cheap stats read FIRST (cached ~1s window) so the pill
+                    // works with the HUD off - the expensive host/controller
+                    // probes below stay gated on `statsOverlayEnabled`.
                     var snap = dec.statsSnapshot(minWindowSeconds: overlayFpsWindowSeconds)
+                    // Auto pill, independent of the stats-HUD toggle so a
+                    // degrading PRESENT path reaches the user with the HUD off.
+                    // Drives off PERCEIVED present-hitching (render-gap / stale
+                    // repeats / late drops), not env_state (which measures link
+                    // contention and anti-correlates with felt stutter).
+                    let composite = hitchBox.perceivedHitch(snap: snap)
+                    win.networkBanner.setSustained(composite, text: "Stream stuttering")
+                    // Cheap early-out: if the overlay is hidden, skip the
+                    // expensive enrichment + HUD render. The decoder's collectors
+                    // keep ticking so a re-enable shows fresh numbers immediately.
+                    guard dec.statsOverlayEnabled else { return }
                     // estimatedRtt() returns nil if the engine isn't connected
                     // (very old GFE versions, or a transient drop, or the native
                     // stub). On nil we leave rtt nil and the row renders as "-".
@@ -655,5 +660,36 @@ extension StreamSession {
         // existing "Stream ended unexpectedly" handler in MoonlightManager.
         bridge?.eventContinuation?.yield(.connectionTerminated(errorCode: -1))
         await stop()
+    }
+}
+
+/// Carries per-second-rate baselines for the perceived-hitch pill across the
+/// 4Hz overlay ticks. MainActor-isolated: only ever touched from the timer body.
+@MainActor
+private final class PerceivedHitchBox {
+    private var prevStale: UInt64 = 0
+    private var prevLate: UInt64 = 0
+    private var prevTime: CFTimeInterval = 0
+
+    /// True when the PRESENT path is hitching enough for the user to feel it.
+    /// Composite of render-gap ratio, stale-repeats/s, and late-drops/s; the
+    /// banner's own leaky integrator debounces flaps. Counter deltas guard
+    /// against a reconnect resetting the totals (delta only when total >= prev).
+    func perceivedHitch(snap: StreamStatsSnapshot) -> Bool {
+        let now = CACurrentMediaTime()
+        let dt = prevTime > 0 ? now - prevTime : 0.25
+        prevTime = now
+
+        var hitch = false
+        if let decoded = snap.decodedFps, let rendered = snap.renderedFps, decoded > 0 {
+            if (decoded - rendered) / decoded > 0.12 { hitch = true }
+        }
+        let stale = TelemetryCounters.shared.staleFrameRepeatTotal.value
+        if dt > 0, stale >= prevStale, Double(stale - prevStale) / dt > 3.0 { hitch = true }
+        prevStale = stale
+        let late = snap.presentationLateDrops ?? 0
+        if dt > 0, late >= prevLate, Double(late - prevLate) / dt > 5.0 { hitch = true }
+        prevLate = late
+        return hitch
     }
 }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.30
-CURRENT_PROJECT_VERSION = 20260641
+MARKETING_VERSION = 2026.6.31
+CURRENT_PROJECT_VERSION = 20260642


### PR DESCRIPTION
Telemetry analysis showed the 'Network degraded' pill (driven by env_state = AWDL co-gap/radio contention) ANTI-correlates with felt stutter on a clean link (recall 0.20/precision 0.13; fired when the present path was calmer). Rewired it to a perceived-hitch composite (render-gap >12% OR stale-repeats >3/s OR present-late >5/s), verified recall 0.73/precision 0.39 and dark on 69% of FEC-absorbed co-gap windows. Reuses the .30 debounce+fade; fixes a HUD-off ordering bug (snapshot moved above the statsOverlayEnabled guard, expensive host/controller probes stay gated); env_state still recorded in telemetry. Relabeled 'Stream stuttering'. Build + 156 tests green.

Note: the residual ~7-8 micro-hitches/s at fps==refresh is a separate, known pacer depth-1/burst collision (PACER DEPTH FLOOR +1 dark code, gated on the display-link threading rework).