### PR TITLE
feat(pacer): present tick off the main run loop (2026.6.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026.6.32 - 2026-06-25
+
+Drops fewer frames on high-refresh displays. The present-timing tick ran on the
+main thread, where the macOS frame-rate governor could starve it whenever the
+thread was busy - the display link missed callbacks, frames piled up, and the
+pacer trimmed them. On a clean link that was the biggest source of micro-stutter
+(~73% of the dropped frames). The tick now runs on its own high-priority thread
+so it fires on time, at no added latency.
+
 ## 2026.6.31 - 2026-06-25
 
 Makes the in-stream degradation badge honest. It was driven by a link-contention

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		D1000B71 /* StreamSession+Start.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000B72 /* StreamSession+Start.swift */; };
 		D1000B73 /* StreamSession+StartSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000B74 /* StreamSession+StartSetup.swift */; };
 		D1000BD1 /* FramePacer+TickDeficit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000BD2 /* FramePacer+TickDeficit.swift */; };
+		D1000BE0 /* FramePacer+TickThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000BE1 /* FramePacer+TickThread.swift */; };
 		D1000BD3 /* VideoDecoder+GovernorRepaint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000BD4 /* VideoDecoder+GovernorRepaint.swift */; };
 		D1000C01 /* StreamWindow+Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000C02 /* StreamWindow+Cursor.swift */; };
 		D1000C11 /* StreamWindow+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000C12 /* StreamWindow+Views.swift */; };
@@ -390,6 +391,7 @@
 		D1000B72 /* StreamSession+Start.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamSession+Start.swift"; sourceTree = "<group>"; };
 		D1000B74 /* StreamSession+StartSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamSession+StartSetup.swift"; sourceTree = "<group>"; };
 		D1000BD2 /* FramePacer+TickDeficit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/FramePacer+TickDeficit.swift"; sourceTree = "<group>"; };
+		D1000BE1 /* FramePacer+TickThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/FramePacer+TickThread.swift"; sourceTree = "<group>"; };
 		D1000BD4 /* VideoDecoder+GovernorRepaint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/VideoDecoder+GovernorRepaint.swift"; sourceTree = "<group>"; };
 		D1000C02 /* StreamWindow+Cursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamWindow+Cursor.swift"; sourceTree = "<group>"; };
 		D1000C12 /* StreamWindow+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamWindow+Views.swift"; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 				D1000B42 /* FramePacer+AdaptiveDepth.swift */,
 				D1000B52 /* FramePacer+Submit.swift */,
 				D1000BD2 /* FramePacer+TickDeficit.swift */,
+				D1000BE1 /* FramePacer+TickThread.swift */,
 				D1000B62 /* FramePacer+Constants.swift */,
 				D1000079 /* VideoDecoder+Sink.swift */,
 				D1000077 /* VideoDecoder+Session.swift */,
@@ -857,6 +860,7 @@
 				D1000B41 /* FramePacer+AdaptiveDepth.swift in Sources */,
 				D1000B51 /* FramePacer+Submit.swift in Sources */,
 				D1000BD1 /* FramePacer+TickDeficit.swift in Sources */,
+				D1000BE0 /* FramePacer+TickThread.swift in Sources */,
 				D1000B61 /* FramePacer+Constants.swift in Sources */,
 				D100007A /* VideoDecoder+Sink.swift in Sources */,
 				D1000078 /* VideoDecoder+Session.swift in Sources */,

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -143,7 +143,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // mouse deltas are raw 1:1; the non-UI gate reads it via UserDefaults.bool,
         // which needs the registered default to read `true` before first toggle.
         UserDefaults.standard.register(defaults: [
-            MouseAccelerationControl.enabledDefaultsKey: true
+            MouseAccelerationControl.enabledDefaultsKey: true,
+            // Fire the present tick on a private high-QoS run loop (not .main)
+            // so a busy main thread can't starve the CADisplayLink callback.
+            // Flip false for an instant fallback to the main-runloop tick.
+            FramePacer.tickOffMainDefaultsKey: true
         ])
         // Crash recovery: if a prior session died mid-stream with the pointer
         // acceleration linearized, restore the user's saved value now (no-op in

--- a/Glimmer/Stream/FramePacer+Recovery.swift
+++ b/Glimmer/Stream/FramePacer+Recovery.swift
@@ -100,8 +100,9 @@ extension FramePacer {
         // tied to the display the view is currently on and tracks it as the
         // view moves between screens - exactly the binding moonlight-qt builds
         // by hand with CVDisplayLinkCreateWithCGDisplay against the window's
-        // NSScreen. We add it to the main run loop in the common modes so it
-        // keeps firing during tracking loops / modal-ish UI beats.
+        // NSScreen. We add it (in the common modes) to the private tick run loop
+        // by default - the off-main path that un-starves the callback - or to
+        // `.main` when the flag is off; either keeps it firing across UI beats.
         // Reset the cadence base BEFORE the new link starts ticking, so the
         // first tick on the new (possibly discontinuous) timebase re-seeds
         // `lastPresentMediaTime` from this link's clock instead of comparing
@@ -150,7 +151,22 @@ extension FramePacer {
         os_unfair_lock_lock(&lock)
         tickDeficit.pinnedFloorHz = Double(range.minimum)
         os_unfair_lock_unlock(&lock)
-        link.add(to: .main, forMode: .common)
+        // Add the link to the PRIVATE tick run loop (default) so the present
+        // callback isn't starved when the main thread is busy - the governor
+        // callback-gap that trimmed ~73% of clean-link frame drops. `.main` is
+        // the instant fallback (flag off). The thread is created lazily and
+        // reused across rebuilds (installLink is the single rebind path), so a
+        // reconnect / screen change re-adds to it without spawning a second one.
+        // The watchdog's tick-deficit/linkDead net (livenessSnapshot, a Timer)
+        // still fires off-main, so even a non-firing off-main link self-heals.
+        if Self.tickOffMain {
+            let tickThread = pacerTickThread ?? PacerTickThread()
+            pacerTickThread = tickThread
+            tickThread.start()
+            tickThread.add(link)
+        } else {
+            link.add(to: .main, forMode: .common)
+        }
         self.setTickProxy(proxy)
         self.displayLink = link
         // Seed the bound-screen signature so `screenDidChange` can distinguish

--- a/Glimmer/Stream/FramePacer+Tick.swift
+++ b/Glimmer/Stream/FramePacer+Tick.swift
@@ -15,17 +15,19 @@ import os
 
 extension FramePacer {
 
-    // MARK: - Realized-cadence telemetry state (main actor, metric-only)
+    // MARK: - Realized-cadence telemetry state (tick-confined, metric-only)
 
     /// Previous tick's `targetTimestamp`, so the refresh-window telemetry can
     /// accumulate the REALIZED callback cadence (deltas of successive targets)
     /// rather than the nominal `link.duration`, which reads the panel's rated
-    /// interval even while callbacks are being skipped. Main-actor confined:
-    /// `handleTick` is the only reader/writer. Static because an extension can't
-    /// add instance storage; safe process-wide since exactly one pacer ticks at
-    /// a time (one streaming session), and a stale cross-instance value just
-    /// produces one delta the plausibility bounds in `handleTick` discard.
-    @MainActor static var lastTickTargetTimestamp: CFTimeInterval = .nan
+    /// interval even while callbacks are being skipped. TICK-THREAD confined:
+    /// `handleTick` is the only reader/writer, and the link fires on exactly one
+    /// run loop at a time (the private tick thread, or `.main` in fallback), so
+    /// the reads/writes are serialized with no lock. Static because an extension
+    /// can't add instance storage; safe process-wide since exactly one pacer
+    /// ticks at a time (one streaming session), and a stale cross-instance value
+    /// just produces one delta the plausibility bounds in `handleTick` discard.
+    nonisolated(unsafe) static var lastTickTargetTimestamp: CFTimeInterval = .nan
 
     /// Ceiling for a plausible realized tick delta (seconds). Above this the
     /// gap is a link suspension (backgrounded window), a rebuild, or a stale
@@ -35,12 +37,17 @@ extension FramePacer {
     /// any suspension-scale gap.
     static let maxRealizedTickDeltaSeconds: Double = 0.5
 
-    // MARK: - Vsync tick (main run loop → pacingQueue)
+    // MARK: - Vsync tick (private tick run loop → pacingQueue)
 
-    /// CADisplayLink callback (main run loop). We capture only the cheap link
-    /// timing here, then hand the release decision to the serial pacing queue
-    /// so nothing on the present path runs on the main actor.
-    @MainActor
+    /// CADisplayLink callback. Fires on the private high-QoS tick run loop (the
+    /// `pacerTickOffMain` default; `.main` in fallback) - moved off `.main` so a
+    /// busy main thread can't STARVE this callback (the governor callback-gap
+    /// that trimmed ~73% of clean-link frame drops). We capture only the cheap
+    /// link timing here, then hand the release decision to the serial pacing
+    /// queue. Every shared touch is lock-guarded (telemetry / liveness / deficit
+    /// service) or tick-thread-confined (`lastTickTargetTimestamp`); the one
+    /// main-only access (`reapplyPreferredRangeIfNeeded`, which reads the NSView)
+    /// is hopped to the main actor below. Nothing here runs on the main actor.
     func handleTick(_ link: CADisplayLink) {
         // The link's realized cadence - refresh-agnostic. `duration` is the
         // nominal vsync interval; `targetTimestamp` is when the frame we
@@ -50,12 +57,12 @@ extension FramePacer {
         let target = link.targetTimestamp
         // `duration` is reliably > 0 on a running link; the 1/60 fallback only
         // guards a degenerate first tick. We deliberately use a constant here
-        // (not the shared cadence estimate) so this main-thread read touches no
+        // (not the shared cadence estimate) so this pre-lock read touches no
         // lock-guarded state.
         let vsyncInterval = link.duration > 0 ? link.duration : (1.0 / 60.0)
 
-        // Present-side liveness: stamp that the LINK is alive on the main run
-        // loop. This is the clock the watchdog's "link dead" trip gates on - a
+        // Present-side liveness: stamp that the LINK is alive (on the tick run
+        // loop). This is the clock the watchdog's "link dead" trip gates on - a
         // stopped link (same-screen HDR/VRR mode switch) freezes this value
         // even though VT keeps decoding. Cheap: one lock + two stores.
         //
@@ -137,17 +144,36 @@ extension FramePacer {
         }
 
         // Floor re-apply: the present-callback floor is seeded at install from
-        // the CONFIGURED fps, but the true cadence is learned from PTS deltas once
-        // frames flow (a configured-vs-actual mismatch, or a mid-stream fps change
-        // like 60→120). Re-pin the floor from the refined cadence here - on the
-        // main actor, where the link lives - when it has drifted past the
-        // hysteresis. Cheap: only touches the link object on a real change.
-        reapplyPreferredRangeIfNeeded(refinedIntervalSeconds: refinedIntervalSeconds)
+        // the CONFIGURED fps, but the true cadence is learned from PTS deltas
+        // once frames flow (a configured-vs-actual mismatch, or a mid-stream fps
+        // change like 60→120). It touches the link + NSView, both main-affine, so
+        // it CANNOT run on the tick thread - HOP it to the main actor. The hop is
+        // THROTTLED to ~10Hz (tick-thread-confined timestamp) so a 120-240Hz tick
+        // doesn't flood the main queue with the steady-state no-op check; the real
+        // re-pin rate is ~0.5/s, far under the throttle, and the method's own
+        // hysteresis decides whether to actually rewrite the range, so nothing is
+        // missed. On the `.main` fallback this is already a main-actor context;
+        // the async hop is harmless there too.
+        let sinceReapply = hostNow - Self.lastReapplyHopHostTime
+        if !Self.lastReapplyHopHostTime.isFinite || sinceReapply >= Self.reapplyHopMinInterval {
+            Self.lastReapplyHopHostTime = hostNow
+            let refined = refinedIntervalSeconds
+            DispatchQueue.main.async { [weak self] in
+                self?.reapplyPreferredRangeIfNeeded(refinedIntervalSeconds: refined)
+            }
+        }
 
         pacingQueue.async { [weak self] in
             self?.releaseDueFrame(targetTimestamp: target, vsyncInterval: vsyncInterval)
         }
     }
+
+    /// Min seconds between main-actor `reapplyPreferredRangeIfNeeded` hops, and
+    /// the last hop's host time (tick-thread confined, like
+    /// `lastTickTargetTimestamp`). Throttles the per-tick main hop to ~10Hz - the
+    /// floor re-pin it gates is ~0.5/s, so no real re-pin is delayed meaningfully.
+    static let reapplyHopMinInterval: CFTimeInterval = 0.1
+    nonisolated(unsafe) static var lastReapplyHopHostTime: CFTimeInterval = .nan
 
     // The floor re-apply (`reapplyPreferredRangeIfNeeded`) lives in
     // FramePacer+FrameRateRange.swift alongside the range builders it calls.
@@ -156,13 +182,16 @@ extension FramePacer {
 /// `@objc` shim that forwards the CADisplayLink callback into a Swift closure.
 /// CADisplayLink retains its target, so keeping the proxy separate from
 /// `FramePacer` (which `VideoDecoder` retains) avoids a retain cycle and keeps
-/// the selector signature trivial. Lives on the main actor - the link fires on
-/// the run loop it's added to (`.main`). Declared here with the tick handler it
-/// forwards to (moved out of FramePacer.swift for the length limit).
-@MainActor
-final class DisplayLinkProxy: NSObject {
-    private let onTick: (CADisplayLink) -> Void
-    init(onTick: @escaping (CADisplayLink) -> Void) {
+/// the selector signature trivial. NOT main-actor: the link fires on whichever
+/// run loop it was added to - the private tick thread by default, `.main` in
+/// fallback - so the callback (and `handleTick`, which it forwards to) must run
+/// off-main. `@unchecked Sendable` because the proxy carries only an immutable
+/// `@Sendable` closure across the bind (main actor) → fire (tick thread) hand-off.
+/// Declared here with the tick handler it forwards to (moved out of
+/// FramePacer.swift for the length limit).
+final class DisplayLinkProxy: NSObject, @unchecked Sendable {
+    private let onTick: @Sendable (CADisplayLink) -> Void
+    init(onTick: @escaping @Sendable (CADisplayLink) -> Void) {
         self.onTick = onTick
     }
     @objc func tick(_ link: CADisplayLink) {

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -1,0 +1,146 @@
+//
+//  FramePacer+TickThread.swift
+//
+//  The dedicated high-QoS run loop the present tick fires on when
+//  `pacerTickOffMain` is set (the default). On a pristine link ~73% of the
+//  pre-render frame drops were the macOS frame-rate governor STARVING the
+//  CADisplayLink callback: the link was added to the MAIN run loop, so its tick
+//  was delayed whenever the main thread was busy (display_refresh_min_hz dipped
+//  to 48 while the panel held 120). The present itself already runs off-main on
+//  `pacingQueue`; only the cheap timing-capture callback was main-bound. Moving
+//  that callback onto a private userInteractive run loop un-starves it at ZERO
+//  added latency. The link bind/unbind themselves stay on the main actor
+//  (installLink reads the NSView); we hand the live link to this thread to add.
+//  Split out of FramePacer.swift to keep that file under the length limit.
+//
+
+import Foundation
+import QuartzCore
+import os
+
+extension FramePacer {
+    /// UserDefaults key gating whether the CADisplayLink callback fires on the
+    /// private high-QoS run loop (`true`, the default) instead of `.main`. The
+    /// default-true is registered in GlimmerApp; the bool read below sees it.
+    /// Flip to false for an instant fallback to the main-runloop tick (the
+    /// historical path) without a rebuild.
+    static let tickOffMainDefaultsKey = "pacerTickOffMain"
+    static var tickOffMain: Bool {
+        UserDefaults.standard.bool(forKey: tickOffMainDefaultsKey)
+    }
+}
+
+/// Owns the private run loop the CADisplayLink callback fires on when the tick
+/// is moved off the main run loop. One per FramePacer, created lazily on the
+/// first off-main bind and stopped on teardown so no thread leaks across a
+/// reconnect / screen-change rebuild.
+///
+/// `@unchecked Sendable`: the only cross-thread state is `runLoop`/`cfRunLoop`,
+/// published once (under `lock`) by the thread body before any caller reads it
+/// and immutable thereafter. The link add/invalidate are routed back ONTO this
+/// thread via `perform(...)`, so they touch the loop from its owning thread;
+/// `CFRunLoopStop` is documented thread-safe to call from another thread.
+final class PacerTickThread: @unchecked Sendable {
+
+    private var thread: Thread?
+    /// The thread's own RunLoop object (the canonical one for that thread),
+    /// published by the thread body once it is up. Used as the perform target
+    /// so the link add/remove run ON the tick thread. Guarded by `lock` for the
+    /// start handshake; immutable once set.
+    private var runLoop: RunLoop?
+    /// The CF handle for the same loop, so `stop()` can break CFRunLoopRun from
+    /// the caller's thread (CFRunLoopStop is thread-safe).
+    private var cfRunLoop: CFRunLoop?
+    private var lock = os_unfair_lock_s()
+    /// Released by the thread body once the loop is published, so `start()`
+    /// returns only after the run loop can take the link.
+    private let ready = DispatchSemaphore(value: 0)
+
+    /// Spin up the thread + run loop if not already running. Idempotent: a
+    /// rebuild that re-binds onto the same FramePacer reuses the live thread
+    /// rather than spawning a second one. Blocks (briefly) until the run loop
+    /// is ready so the immediately-following `add(_:)` lands on a live loop.
+    func start() {
+        os_unfair_lock_lock(&lock)
+        let alreadyUp = thread != nil
+        os_unfair_lock_unlock(&lock)
+        guard !alreadyUp else { return }
+
+        let tickThread = Thread { [weak self] in
+            guard let self else { return }
+            os_unfair_lock_lock(&self.lock)
+            self.runLoop = RunLoop.current
+            self.cfRunLoop = CFRunLoopGetCurrent()
+            os_unfair_lock_unlock(&self.lock)
+            // Keep the loop alive with a perpetual source (a bare RunLoop returns
+            // immediately with no input source). The link, added later, is the
+            // real source; the port is just the keep-alive so the loop blocks
+            // instead of spinning before the link binds. Added BEFORE signaling
+            // ready so the loop is fully set up when the (waited-on) link add lands.
+            RunLoop.current.add(Port(), forMode: .common)
+            self.ready.signal()
+            // CFRunLoopRun blocks until CFRunLoopStop breaks it; RunLoop.run()'s
+            // no-source early-return is the freeze this avoids.
+            CFRunLoopRun()
+        }
+        tickThread.name = "Glimmer.pacerTick"
+        tickThread.qualityOfService = .userInteractive
+        os_unfair_lock_lock(&lock)
+        thread = tickThread
+        os_unfair_lock_unlock(&lock)
+        tickThread.start()
+        // Bounded wait: the run loop comes up in microseconds. The timeout only
+        // guards a pathological scheduler stall - add(_:) no-ops on a nil loop
+        // and the caller stays on the main-runloop tick path.
+        _ = ready.wait(timeout: .now() + .seconds(2))
+    }
+
+    /// Add the live link to this thread's run loop, ON that thread. Routed via
+    /// `perform(...)` (waitUntilDone) so the source is registered from the loop's
+    /// owning thread - the safe way to mutate a run loop's sources. Removal needs
+    /// no counterpart: the caller `invalidate()`s the link, which detaches it
+    /// from every run loop from any thread.
+    func add(_ link: CADisplayLink) {
+        os_unfair_lock_lock(&lock)
+        let runLoop = runLoop
+        let thread = thread
+        os_unfair_lock_unlock(&lock)
+        guard let runLoop, let thread else { return }
+        let op = LinkRunLoopAdd(link: link, runLoop: runLoop)
+        op.perform(
+            #selector(LinkRunLoopAdd.run), on: thread,
+            with: nil, waitUntilDone: true, modes: [RunLoop.Mode.common.rawValue])
+    }
+
+    /// Stop the run loop and let the thread exit. The link must already be
+    /// `invalidate()`d by the caller (which removes it from this loop); we only
+    /// break CFRunLoopRun so the thread returns. Idempotent.
+    func stop() {
+        os_unfair_lock_lock(&lock)
+        let cf = cfRunLoop
+        runLoop = nil
+        cfRunLoop = nil
+        thread = nil
+        os_unfair_lock_unlock(&lock)
+        guard let cf else { return }
+        CFRunLoopStop(cf)
+    }
+
+    deinit { stop() }
+}
+
+/// Trampoline that runs `link.add(to:forMode:)` on the tick thread. A
+/// CADisplayLink's run-loop sources are safest mutated from the owning thread;
+/// `perform(_:on:)` needs an `@objc` selector, so this small NSObject carries
+/// the operands across.
+private final class LinkRunLoopAdd: NSObject {
+    let link: CADisplayLink
+    let runLoop: RunLoop
+    init(link: CADisplayLink, runLoop: RunLoop) {
+        self.link = link
+        self.runLoop = runLoop
+    }
+    @objc func run() {
+        link.add(to: runLoop, forMode: .common)
+    }
+}

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -75,9 +75,12 @@
 //  ---------
 //  * `submit` runs on the VT decode queue (any thread). It only touches the
 //    lock-guarded FIFO + counters.
-//  * The CADisplayLink `@objc` tick fires on the main run loop. It does the
-//    minimum on main (read targetTimestamp/duration, snapshot isStreaming) and
-//    dispatches the dequeue+enqueue to `pacingQueue`.
+//  * The CADisplayLink `@objc` tick fires on a private high-QoS run loop (the
+//    `pacerTickOffMain` default; `.main` in fallback) so a busy main thread
+//    can't starve it. It does the minimum there (read targetTimestamp/duration,
+//    roll the lock-guarded telemetry), hops the lone main-affine touch (the
+//    floor re-apply) to the main actor, and dispatches the dequeue+enqueue to
+//    `pacingQueue`. The link bind/unbind themselves stay on the main actor.
 //  * `start`/`stop`/`screenDidChange` run on the main actor (lifecycle).
 //  All shared mutable state is guarded by a single `os_unfair_lock`, the same
 //  discipline StatsCollector uses. The lock is held only for a handful of
@@ -453,6 +456,26 @@ final class FramePacer: @unchecked Sendable {
     let pacingQueue = DispatchQueue(
         label: "io.ugfugl.Glimmer.video.pacer", qos: .userInteractive)
 
+    // MARK: - Present tick run loop (off-main, default)
+
+    /// The private run loop the tick fires on when `tickOffMain` is set. Created
+    /// lazily in `installLink` (off-main path) and stopped on teardown/`deinit`
+    /// so no thread leaks across a reconnect / screen-change rebuild. Assigned
+    /// only from the main actor (install/teardown); read from `deinit`. NOT
+    /// main-actor isolated so `deinit` can stop it without an actor hop - safe
+    /// because deinit runs only when no other reference (so no thread) survives,
+    /// and `PacerTickThread` is itself `Sendable` with idempotent, locked teardown.
+    /// Nil while the main-runloop fallback is active. The `tickOffMain` flag +
+    /// key live in FramePacer+TickThread.swift with the thread they gate.
+    var pacerTickThread: PacerTickThread?
+
+    deinit {
+        // The link retains its proxy, not us, so deinit means the session is
+        // fully torn down; stop the thread so it can never outlive us. stop()
+        // is idempotent (stop() already ran on the normal teardown path).
+        pacerTickThread?.stop()
+    }
+
     // MARK: - Init
 
     init(stats: StatsCollector, configuredFps: Int32) {
@@ -576,6 +599,12 @@ final class FramePacer: @unchecked Sendable {
         displayLink = nil
         tickProxy = nil
         boundView = nil
+        // Stop the private tick run loop so the thread exits on full teardown.
+        // invalidate() above already detached the link from it. The rebind paths
+        // (screenDidChange / rebuildLink) deliberately KEEP the thread alive -
+        // they re-add through installLink - so only stop() and deinit tear it down.
+        pacerTickThread?.stop()
+        pacerTickThread = nil
         log.info("FramePacer stopped")
         // Mirror to the Diag/LogStore file sink: os_log-only pacer breadcrumbs
         // were structurally invisible postmortem (the glimmer-*.log sink records

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.31
-CURRENT_PROJECT_VERSION = 20260642
+MARKETING_VERSION = 2026.6.32
+CURRENT_PROJECT_VERSION = 20260643


### PR DESCRIPTION
~73% of pre-render frame drops on a pristine link are the macOS frame-rate governor starving the CADisplayLink callback (it was on the main run loop, delayed when main was busy; display_refresh_min_hz dipped to 48 while the panel held 120; o2p tail = integer vsync multiples). The present already runs off-main on pacingQueue; only the cheap timing-capture callback was main-bound.

Moves it to a dedicated high-QoS run loop (PacerTickThread), behind the pacerTickOffMain flag (default true; flip false for instant .main fallback). handleTick + DisplayLinkProxy de-@MainActor'd (telemetry/liveness lock-guarded; lastTickTargetTimestamp tick-thread-confined; the NSView-touching reapply hops to main, throttled 10Hz). Zero added latency. The 20Hz linkDead watchdog is vsync-independent so a non-firing off-main link self-heals. Does NOT touch the release/due-gate logic that caused .28. Build + 156 tests green.

Validate live: pacer_ticks_per_second / display_refresh_min_hz should RISE toward content fps WITHOUT o2p p99 (~48ms) or present_cadence_error (~0.5ms) regressing.