### PR TITLE
fix(ux): badge startup grace + recalibrated thresholds (2026.6.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026.6.33 - 2026-06-25
+
+Stops the in-stream "Stream stuttering" pill from crying wolf. It had no startup
+grace, so a game's brief launch stutter (loading + display-mode negotiation)
+flashed it immediately, and its thresholds sat close enough to the normal
+high-refresh floor that an occasional dip could trip it. It now waits out the
+launch transient and only shows for hitching clearly above that floor - so it
+stays dark on a healthy session and means something when it appears.
+
 ## 2026.6.32 - 2026-06-25
 
 Drops fewer frames on high-refresh displays. The present-timing tick ran on the

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -670,26 +670,40 @@ private final class PerceivedHitchBox {
     private var prevStale: UInt64 = 0
     private var prevLate: UInt64 = 0
     private var prevTime: CFTimeInterval = 0
+    private var firstTime: CFTimeInterval = 0
 
-    /// True when the PRESENT path is hitching enough for the user to feel it.
-    /// Composite of render-gap ratio, stale-repeats/s, and late-drops/s; the
-    /// banner's own leaky integrator debounces flaps. Counter deltas guard
-    /// against a reconnect resetting the totals (delta only when total >= prev).
+    /// Stream seconds before the pill may show. A title's launch (loading +
+    /// display-mode negotiation) stutters briefly; without this the pill flashes
+    /// the instant a game starts. ~6s covers the launch transient.
+    private let graceSeconds: CFTimeInterval = 6.0
+
+    /// True when the PRESENT path is hitching enough to feel. Thresholds sit WELL
+    /// above the fps==refresh structural floor (a bookmarked false positive showed
+    /// late~6/s, render-gap~0.05, zero real loss) so only a clear burst shows; the
+    /// banner's leaky integrator debounces flaps. Deltas guard a reconnect reset.
     func perceivedHitch(snap: StreamStatsSnapshot) -> Bool {
         let now = CACurrentMediaTime()
+        if firstTime == 0 { firstTime = now }
         let dt = prevTime > 0 ? now - prevTime : 0.25
         prevTime = now
 
-        var hitch = false
-        if let decoded = snap.decodedFps, let rendered = snap.renderedFps, decoded > 0 {
-            if (decoded - rendered) / decoded > 0.12 { hitch = true }
-        }
+        // Advance the rate baselines every tick (incl. during the grace) so the
+        // first post-grace delta isn't a spurious spike.
         let stale = TelemetryCounters.shared.staleFrameRepeatTotal.value
-        if dt > 0, stale >= prevStale, Double(stale - prevStale) / dt > 3.0 { hitch = true }
+        let staleRate = (dt > 0 && stale >= prevStale) ? Double(stale - prevStale) / dt : 0
         prevStale = stale
         let late = snap.presentationLateDrops ?? 0
-        if dt > 0, late >= prevLate, Double(late - prevLate) / dt > 5.0 { hitch = true }
+        let lateRate = (dt > 0 && late >= prevLate) ? Double(late - prevLate) / dt : 0
         prevLate = late
+
+        if now - firstTime < graceSeconds { return false }
+
+        var hitch = false
+        if let decoded = snap.decodedFps, let rendered = snap.renderedFps, decoded > 0 {
+            if (decoded - rendered) / decoded > 0.18 { hitch = true }
+        }
+        if staleRate > 6.0 { hitch = true }
+        if lateRate > 12.0 { hitch = true }
         return hitch
     }
 }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.32
-CURRENT_PROJECT_VERSION = 20260643
+MARKETING_VERSION = 2026.6.33
+CURRENT_PROJECT_VERSION = 20260644


### PR DESCRIPTION
Follow-up to .32: a bookmarked false positive + the .32 launch report showed the Stream-stuttering pill fires on (a) a game's launch transient (no startup grace) and (b) the residual occasional governor dip (late/s hit 5.22 vs a threshold of 5). The .32 tick-thread fix is validated good (pacer_ticks rose 116.7->120, refresh_min holds 120 vs frequent 48-dips, o2p/cadence flat) - this just stops the BADGE over-firing on what's left.

Adds a 6s startup grace (rate baselines keep advancing so no post-grace spike) and raises thresholds well above the high-refresh structural floor: render-gap 0.12->0.18, stale/s 3->6, late/s 5->12. Dark on the .32 residual (late~5, gap~0.05, stale~1); fires only on a clear burst. Build + 156 tests green.