### PR TITLE
fix(ui): spec chip shows codec-aware bitrate (2026.6.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.6.34 - 2026-06-25
+
+Fixes the bitrate shown under the hero. The spec chip displayed the nominal
+H.264 quality figure, but on AV1/HEVC the stream actually sends ~20% fewer bits
+(the codec-aware budget from 2026.6.22) - so it read e.g. 84 Mbps while the wire
+carried 67. The chip and the spec summary now show the real codec-aware bitrate
+the engine sends.
+
 ## 2026.6.33 - 2026-06-25
 
 Stops the in-stream "Stream stuttering" pill from crying wolf. It had no startup

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -24,18 +24,36 @@ extension MoonlightManager {
     // → HEVC), so showing it risks displaying a value that's simply wrong. Users
     // care that it looks good, not which encoder produced it.
     var streamSpecSummary: String {
-        let mbps = effectiveBitrateKbps / 1000
+        let mbps = displayBitrateKbps / 1000
         let hdrTag = effectiveHDR ? " · HDR" : ""
         return "\(effectiveWidth) × \(effectiveHeight) · \(effectiveFPS) Hz\(hdrTag) · \(mbps) Mbps"
     }
 
     var streamSpecChips: [String] {
-        let mbps = effectiveBitrateKbps / 1000
+        let mbps = displayBitrateKbps / 1000
         var chips = [Self.resolutionLabel(width: effectiveWidth, height: effectiveHeight),
                      "\(effectiveFPS) Hz"]
         if effectiveHDR { chips.append("HDR") }
         chips.append("\(mbps) Mbps")
         return chips
+    }
+
+    /// Codec-aware bitrate the spec surfaces show: what the engine actually sends
+    /// for the selected host (AV1/HEVC spend ~20% fewer bits), so the chip/summary
+    /// match the wire. Falls back to the H.264 dial when no host is selected.
+    var displayBitrateKbps: Int {
+        guard let host = selectedHost else { return effectiveBitrateKbps }
+        let formats = HostCodecPreference.load(for: host.id).apply(to: .probedSupported)
+        return wireBitrateKbps(forFormats: formats)
+    }
+
+    /// The H.264-anchored quality dial (`effectiveBitrateKbps`) scaled by the
+    /// negotiated codec's efficiency. The spec UI and `nativeStreamConfig` both read
+    /// this so the shown bitrate can't drift from what's sent. Custom is verbatim.
+    func wireBitrateKbps(forFormats formats: VideoFormats) -> Int {
+        if case .custom = qualityPreset { return effectiveBitrateKbps }
+        let mult = Self.codecBudgetMultiplier(for: formats)
+        return max(5_000, Int((Double(effectiveBitrateKbps) * mult).rounded()))
     }
 
     // MARK: Streaming
@@ -127,16 +145,10 @@ extension MoonlightManager {
         cfg.coversNotch = streamCoversNotch
         let codecPref = HostCodecPreference.load(for: host.id)
         cfg.videoFormats = codecPref.apply(to: .probedSupported)
-        // Codec-aware WIRE budget: `bitrateKbps` is H.264-anchored, so AV1/HEVC waste
-        // bytes at equal quality. Scale the host-bound budget by codec efficiency;
-        // effectiveBitrateKbps stays the H.264-equivalent quality dial the UI shows.
-        // Custom carries the user's explicit cap verbatim.
-        if case .custom = qualityPreset {
-            // explicit user cap → leave cfg.bitrateKbps == effectiveBitrateKbps
-        } else {
-            let mult = Self.codecBudgetMultiplier(for: cfg.videoFormats)
-            cfg.bitrateKbps = max(5_000, Int((Double(effectiveBitrateKbps) * mult).rounded()))
-        }
+        // Codec-aware wire budget (see wireBitrateKbps): the H.264-anchored dial
+        // scaled by the negotiated codec's efficiency. The spec chip reads the same
+        // path so what's shown matches what's sent.
+        cfg.bitrateKbps = wireBitrateKbps(forFormats: cfg.videoFormats)
         return cfg
     }
 

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.33
-CURRENT_PROJECT_VERSION = 20260644
+MARKETING_VERSION = 2026.6.34
+CURRENT_PROJECT_VERSION = 20260645


### PR DESCRIPTION
The bitrate chip under the hero showed the nominal H.264 quality dial (effectiveBitrateKbps), but since 2026.6.22 the engine sends a codec-aware budget (AV1/HEVC x0.80) - so it read 84 Mbps while the wire carried 67. The chip + spec summary computed the bitrate separately from nativeStreamConfig, so they diverged.

Fix routes all three through one shared helper: wireBitrateKbps(forFormats:) applies the codec multiplier + custom exemption; displayBitrateKbps resolves the selected host's codec; nativeStreamConfig now reads the same helper. So the displayed bitrate can't drift from what's sent again. No engine behavior change (same wire bitrate) - only the display now matches. Build + 156 tests green.