### PR TITLE
fix: p99 batch 1 - 3 bugs + quit-chord/input/badge (2026.6.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026.6.35 - 2026-06-25
+
+Six fixes from a deep audit.
+
+The controller exit chord now works on every gamepad. The default leave-stream
+chord required a button (the DualSense Create button) that macOS doesn't expose,
+so on a DualSense it silently never fired. It's now a four-shoulder/trigger hold
+that's native to every controller, and the in-stream leave hint shows it.
+
+Three correctness fixes: the stream's network/RTT telemetry no longer goes blank
+after a silent reconnect; a rare main-thread stall when the present-timing
+thread is slow to start is closed; and an A/V-skew metric that could disagree
+between its two outputs is now computed once.
+
+Lower input latency - the controller-to-host send no longer lets macOS defer
+each flush by up to a full millisecond.
+
+The in-stream degradation pill is much harder to flicker: it shows only on
+sustained hitching and drains out cleanly.
+
 ## 2026.6.34 - 2026-06-25
 
 Fixes the bitrate shown under the hero. The spec chip displayed the nominal

--- a/Glimmer/MoonlightManager.swift
+++ b/Glimmer/MoonlightManager.swift
@@ -293,12 +293,12 @@ final class MoonlightManager {
     }
     /// Controller-side quit chord - fires the same path as `quitHotkey`
     /// from the keyboard, but driven by a multi-button hold on the
-    /// gamepad. Defaults to Options (≡) + L1 + R1 - the menu button isn't held
-    /// during action play, so it's awkward to trip mid-game, and (unlike
-    /// Moonlight's Start+Select+L1+R1) it needs no Share/Create button, which
-    /// macOS doesn't expose on a DualSense. Users who prefer keyboard-only can
-    /// pick "None" in Settings.
-    var controllerQuitChord: ControllerQuitChord = .startSelectL1R1 {
+    /// gamepad. Defaults to L1 + R1 + L2 + R2 (hold all four shoulders/triggers):
+    /// every button is GameController-native on every pad - no Create/Share/Mute,
+    /// which macOS drops on a DualSense - so the default fires without the raw-HID
+    /// reader, and the 4-button + 400ms dwell keeps mid-combat trips unlikely.
+    /// Users who prefer keyboard-only can pick "None" in Settings.
+    var controllerQuitChord: ControllerQuitChord = .l1r1l2r2 {
         didSet {
             UserDefaults.standard.set(controllerQuitChord.rawValue, forKey: "controllerQuitChord")
         }

--- a/Glimmer/Stream/FramePacer+Recovery.swift
+++ b/Glimmer/Stream/FramePacer+Recovery.swift
@@ -162,8 +162,14 @@ extension FramePacer {
         if Self.tickOffMain {
             let tickThread = pacerTickThread ?? PacerTickThread()
             pacerTickThread = tickThread
-            tickThread.start()
-            tickThread.add(link)
+            // Only route onto the tick thread once its loop is CONFIRMED running;
+            // otherwise add(_:) could block the main actor on an unstarted loop.
+            // Fall back to the main run loop - never to an unconfirmed perform().
+            if tickThread.start() {
+                tickThread.add(link)
+            } else {
+                link.add(to: .main, forMode: .common)
+            }
         } else {
             link.add(to: .main, forMode: .common)
         }

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -51,6 +51,12 @@ final class PacerTickThread: @unchecked Sendable {
     /// The CF handle for the same loop, so `stop()` can break CFRunLoopRun from
     /// the caller's thread (CFRunLoopStop is thread-safe).
     private var cfRunLoop: CFRunLoop?
+    /// Set true (under `lock`) by the thread body IMMEDIATELY before
+    /// `CFRunLoopRun()` - the REAL "the loop is servicing sources" flag. The
+    /// published `runLoop`/`thread` pointers are NOT proof: they're set before
+    /// the loop runs, so a `perform(waitUntilDone:true)` against them could block
+    /// forever on an unstarted loop. `add()` and `start()` gate on this instead.
+    private var loopRunning = false
     private var lock = os_unfair_lock_s()
     /// Released by the thread body once the loop is published, so `start()`
     /// returns only after the run loop can take the link.
@@ -60,11 +66,16 @@ final class PacerTickThread: @unchecked Sendable {
     /// rebuild that re-binds onto the same FramePacer reuses the live thread
     /// rather than spawning a second one. Blocks (briefly) until the run loop
     /// is ready so the immediately-following `add(_:)` lands on a live loop.
-    func start() {
+    /// Returns true only when the loop is CONFIRMED running (ready signalled AND
+    /// `loopRunning` set) - the caller falls back to the main-runloop tick if
+    /// false, never routing `perform(waitUntilDone:true)` onto an unconfirmed loop.
+    @discardableResult
+    func start() -> Bool {
         os_unfair_lock_lock(&lock)
         let alreadyUp = thread != nil
+        let alreadyRunning = loopRunning
         os_unfair_lock_unlock(&lock)
-        guard !alreadyUp else { return }
+        guard !alreadyUp else { return alreadyRunning }
 
         let tickThread = Thread { [weak self] in
             guard let self else { return }
@@ -78,6 +89,12 @@ final class PacerTickThread: @unchecked Sendable {
             // instead of spinning before the link binds. Added BEFORE signaling
             // ready so the loop is fully set up when the (waited-on) link add lands.
             RunLoop.current.add(Port(), forMode: .common)
+            // Mark the loop confirmed-running IMMEDIATELY before CFRunLoopRun, so
+            // `add()`/`start()` gate on a true "servicing sources" fact, not the
+            // pre-run published pointers. Signal ready after, so the waiter sees it.
+            os_unfair_lock_lock(&self.lock)
+            self.loopRunning = true
+            os_unfair_lock_unlock(&self.lock)
             self.ready.signal()
             // CFRunLoopRun blocks until CFRunLoopStop breaks it; RunLoop.run()'s
             // no-source early-return is the freeze this avoids.
@@ -90,9 +107,13 @@ final class PacerTickThread: @unchecked Sendable {
         os_unfair_lock_unlock(&lock)
         tickThread.start()
         // Bounded wait: the run loop comes up in microseconds. The timeout only
-        // guards a pathological scheduler stall - add(_:) no-ops on a nil loop
-        // and the caller stays on the main-runloop tick path.
-        _ = ready.wait(timeout: .now() + .seconds(2))
+        // guards a pathological scheduler stall; on a trip the caller falls back
+        // to the main-runloop tick rather than blocking on an unconfirmed loop.
+        let signalled = ready.wait(timeout: .now() + .seconds(2)) == .success
+        os_unfair_lock_lock(&lock)
+        let confirmed = signalled && loopRunning
+        os_unfair_lock_unlock(&lock)
+        return confirmed
     }
 
     /// Add the live link to this thread's run loop, ON that thread. Routed via
@@ -104,8 +125,12 @@ final class PacerTickThread: @unchecked Sendable {
         os_unfair_lock_lock(&lock)
         let runLoop = runLoop
         let thread = thread
+        let running = loopRunning
         os_unfair_lock_unlock(&lock)
-        guard let runLoop, let thread else { return }
+        // Gate on the CONFIRMED-running flag, not just the published pointers:
+        // a `perform(waitUntilDone:true)` onto an unstarted loop would block the
+        // caller (the main actor) with no timeout. Caller falls back to `.main`.
+        guard running, let runLoop, let thread else { return }
         let op = LinkRunLoopAdd(link: link, runLoop: runLoop)
         op.perform(
             #selector(LinkRunLoopAdd.run), on: thread,
@@ -121,6 +146,7 @@ final class PacerTickThread: @unchecked Sendable {
         runLoop = nil
         cfRunLoop = nil
         thread = nil
+        loopRunning = false
         os_unfair_lock_unlock(&lock)
         guard let cf else { return }
         CFRunLoopStop(cf)

--- a/Glimmer/Stream/Native/InputBatcher.swift
+++ b/Glimmer/Stream/Native/InputBatcher.swift
@@ -81,6 +81,10 @@ final class InputBatcher: @unchecked Sendable {
     private var relMouseDX: Int = 0
     private var relMouseDY: Int = 0
     private var relMouseDirty = false
+    /// Queue→wire latency stamp: the OLDEST unflushed entry per slot (set on the
+    /// clean→dirty edge, kept across accumulation/supersession, reset at flush) so
+    /// the flush observes the worst-case age, not the freshest survivor.
+    private var relMouseStamp = DispatchTime.now()
 
     /// currentAbsoluteMouseState (InputStream.c:93) - latest-only.
     private var absMouseX: Int16 = 0
@@ -88,6 +92,7 @@ final class InputBatcher: @unchecked Sendable {
     private var absMouseRefW: Int16 = 0
     private var absMouseRefH: Int16 = 0
     private var absMouseDirty = false
+    private var absMouseStamp = DispatchTime.now()
 
     /// currentQueuedControllerPacket[MAX_GAMEPADS] (InputStream.c:80). Per-slot
     /// latest multiController fields + the buttonFlags that batch is built on.
@@ -99,6 +104,9 @@ final class InputBatcher: @unchecked Sendable {
                                    leftStickX: 0, leftStickY: 0,
                                    rightStickX: 0, rightStickY: 0)
         var dirty = false
+        /// Oldest-unflushed stamp - set on the clean→dirty edge, kept on
+        /// supersession, reset at flush. See relMouseStamp.
+        var stamp = DispatchTime.now()
     }
     private var controllers = [ControllerSlot](repeating: ControllerSlot(),
                                                count: Enet.maxGamepads)
@@ -111,6 +119,8 @@ final class InputBatcher: @unchecked Sendable {
         var y: Float = 0
         var z: Float = 0
         var dirty = false
+        /// Oldest-unflushed stamp (set on clean→dirty, reset at flush).
+        var stamp = DispatchTime.now()
     }
     /// MAX_MOTION_EVENTS (InputStream.c) - accel + gyro.
     private static let motionTypeCount = 2
@@ -123,10 +133,13 @@ final class InputBatcher: @unchecked Sendable {
     init(enet: EnetControlChannel) {
         self.enet = enet
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        // Repeating 1ms tick; small leeway lets the OS coalesce timer fires.
+        // Repeating 1ms tick (the wire-rate cap that fixed the peer-reset - keep
+        // it). Leeway is 250us, not the full interval: ~1ms of slack let macOS
+        // defer each flush up to a tick, adding input latency; 250us trades a few
+        // more wakeups for a tighter queue→wire age.
         timer.schedule(deadline: .now() + .nanoseconds(Int(Self.batchIntervalNs)),
                        repeating: .nanoseconds(Int(Self.batchIntervalNs)),
-                       leeway: .nanoseconds(Int(Self.batchIntervalNs)))
+                       leeway: .nanoseconds(250_000))
         timer.setEventHandler { [weak self] in self?.flush() }
         self.timer = timer
         timer.resume()
@@ -153,6 +166,7 @@ final class InputBatcher: @unchecked Sendable {
         TelemetryCounters.shared.noteInputEvent()
         queue.async { [weak self] in
             guard let self else { return }
+            if !self.relMouseDirty { self.relMouseStamp = DispatchTime.now() }
             self.relMouseDX += Int(dx)
             self.relMouseDY += Int(dy)
             self.relMouseDirty = true
@@ -167,6 +181,9 @@ final class InputBatcher: @unchecked Sendable {
         TelemetryCounters.shared.noteInputEvent()
         queue.async { [weak self] in
             guard let self else { return }
+            // Latest-only: keep the oldest stamp (set on the clean→dirty edge);
+            // a superseding sample discards its own newer stamp.
+            if !self.absMouseDirty { self.absMouseStamp = DispatchTime.now() }
             self.absMouseX = x
             self.absMouseY = y
             self.absMouseRefW = refW
@@ -197,6 +214,9 @@ final class InputBatcher: @unchecked Sendable {
                 // Button-flag change ends the batch: emit the pending slot first.
                 self.flushController(slot)
             }
+            // Stamp the oldest unflushed state per slot (clean→dirty edge); a
+            // superseding update in the same batch keeps the older stamp.
+            if !self.controllers[slot].dirty { self.controllers[slot].stamp = DispatchTime.now() }
             self.controllers[slot].num = num
             self.controllers[slot].mask = mask
             self.controllers[slot].buttons = safeButtons
@@ -242,6 +262,7 @@ final class InputBatcher: @unchecked Sendable {
             if !self.motionStates[idx].dirty {
                 self.motionStates[idx].dirty = true
                 self.motionDirtyCount += 1
+                self.motionStates[idx].stamp = DispatchTime.now()  // oldest-unflushed
             }
             self.motionStates[idx].x = x
             self.motionStates[idx].y = y
@@ -346,6 +367,13 @@ final class InputBatcher: @unchecked Sendable {
             TelemetryCounters.shared.inputBatchFlushTotal.increment()
         }
 
+        // Client queue→wire age: observe the OLDEST unflushed entry per drained
+        // slot. Tracker is nil when telemetry is off (gate), so it's one optional
+        // load + (when on) two local DispatchTime reads + a subtract - no behavior
+        // change. Both clocks local (host/present-clock independent).
+        let latencyTracker = FrameTimingTracker.shared
+        let drainNow = latencyTracker != nil ? DispatchTime.now() : nil
+
         // (1) Relative mouse: send the accumulated delta, splitting into Int16
         //     chunks exactly like InputStream.c:379-422.
         if relMouseDirty {
@@ -373,6 +401,7 @@ final class InputBatcher: @unchecked Sendable {
                     channel: Enet.ctrlChannelMouse)
             }
             relMouseDirty = false
+            observeInputAge(from: relMouseStamp, to: drainNow, tracker: latencyTracker)
         }
 
         // (2) Absolute mouse: latest-only.
@@ -382,6 +411,7 @@ final class InputBatcher: @unchecked Sendable {
                                            refW: absMouseRefW, refH: absMouseRefH),
                 channel: Enet.ctrlChannelMouse)
             absMouseDirty = false
+            observeInputAge(from: absMouseStamp, to: drainNow, tracker: latencyTracker)
         }
 
         // (3) Controllers: latest state per dirty slot.
@@ -416,14 +446,26 @@ final class InputBatcher: @unchecked Sendable {
                 } else {
                     _ = enet.sendInputPacketUnreliable(plaintext, channel: channel)
                 }
+                observeInputAge(from: motionStates[idx].stamp, to: drainNow, tracker: latencyTracker)
                 motionStates[idx].dirty = false
             }
             motionDirtyCount = 0
         }
     }
 
+    /// Observe one merged slot's queue→wire age into the input-local-latency
+    /// histogram. No-op when telemetry is off (`drainNow`/`tracker` nil). Both
+    /// clocks are the local monotonic DispatchTime - no host/present clock.
+    private func observeInputAge(from stamp: DispatchTime, to drainNow: DispatchTime?,
+                                 tracker: FrameTimingTracker?) {
+        guard let drainNow, let tracker, drainNow >= stamp else { return }
+        let ageMs = Double(drainNow.uptimeNanoseconds &- stamp.uptimeNanoseconds) / 1_000_000.0
+        tracker.inputLocalLatency.observe(ageMs)
+    }
+
     /// Send the latest pending multiController for `slot` and clear its dirty
-    /// flag. MUST be called on `queue`.
+    /// flag. MUST be called on `queue`. Drain point for both the timer flush and
+    /// the button-change flush, so it resolves its own queue→wire age stamp.
     private func flushController(_ slot: Int) {
         guard let enet else { return }
         let pending = controllers[slot]
@@ -431,6 +473,9 @@ final class InputBatcher: @unchecked Sendable {
             InputEncoder.multiController(num: pending.num, mask: pending.mask,
                                         buttons: pending.buttons, analog: pending.analog),
             channel: Enet.ctrlChannelGamepadBase &+ UInt8(slot))
+        let tracker = FrameTimingTracker.shared
+        observeInputAge(from: pending.stamp,
+                        to: tracker != nil ? DispatchTime.now() : nil, tracker: tracker)
         controllers[slot].dirty = false
     }
 }

--- a/Glimmer/Stream/StreamBannerLayer.swift
+++ b/Glimmer/Stream/StreamBannerLayer.swift
@@ -100,14 +100,16 @@ public final class StreamBannerLayer {
         CATransaction.commit()
     }
 
-    /// Sustained-degradation gate for the network pill: a leaky integrator over the
-    /// caller's ticks (the 4Hz overlay timer) so a brief co-gap FLAP never flashes the
-    /// pill - only mostly-sustained caution shows it, and clearing drains it back out.
-    private var degradeLevel = 0
+    /// Sustained-degradation gate for the network pill: an ASYMMETRIC leaky
+    /// integrator over the caller's ticks (the 4Hz overlay timer). Attack +1.0,
+    /// decay −0.7 over a 0..16 band so a borderline link needs a degraded fraction
+    /// > ~0.41 to latch - isolated trips can't random-walk the pill up - while a
+    /// clean link still self-drains in ~2.5s.
+    private var degradeLevel = 0.0          // range 0..16
     public func setSustained(_ degraded: Bool, text: String) {
-        degradeLevel = max(0, min(12, degradeLevel + (degraded ? 1 : -1)))
-        if degradeLevel >= 8 { setText(text); setVisible(true) }   // ~2s sustained
-        else if degradeLevel <= 2 { setVisible(false) }            // hysteresis floor
+        degradeLevel = max(0, min(16, degradeLevel + (degraded ? 1.0 : -0.7)))
+        if degradeLevel >= 10 { setText(text); setVisible(true) }   // ~2.5s sustained @4Hz
+        else if degradeLevel <= 3 { setVisible(false) }             // self-drains in ~2.5s
     }
 
     /// Position the pill against the host's bounds, sizing width to the text.

--- a/Glimmer/Stream/StreamSession+StartSetup.swift
+++ b/Glimmer/Stream/StreamSession+StartSetup.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import AppKit
+import GameController
 import os
 
 extension StreamSession {
@@ -32,6 +33,35 @@ extension StreamSession {
         let controllerQuitChordProvider: @MainActor () -> ControllerQuitChord
         let customControllerChordProvider: @MainActor () -> Set<ControllerButton>
         let onBackgroundedChanged: (@MainActor (Bool) -> Void)?
+    }
+
+    /// Build the one-time leave-hint string: the keyboard hotkey, plus the
+    /// controller chord when one is set AND a controller is connected. Omits the
+    /// controller clause when its chord depends on a DualSense center button
+    /// macOS drops with raw-HID off - advertising a chord that can't fire is worse
+    /// than silence.
+    static func leaveHintText(
+        hotkey: HotkeyChord, chord: ControllerQuitChord,
+        customChord: Set<ControllerButton>
+    ) -> String {
+        let base = "Press \(hotkey.displayString)"
+        guard chord != .none, !GCController.controllers().isEmpty else {
+            return "\(base) to leave the stream"
+        }
+        // Honesty: a Create/Mute-based chord can't fire on a DualSense without
+        // the raw-HID reader; drop the clause rather than promise it.
+        let needsRawHID: Bool
+        switch chord {
+        case .startSelectL1R1: needsRawHID = true
+        case .custom: needsRawHID = !customChord.isDisjoint(with: [.create, .mute])
+        case .none, .l1r1, .l1r1l2r2, .l3r3: needsRawHID = false
+        }
+        if needsRawHID && !DualSenseHID.isEnabled {
+            return "\(base) to leave the stream"
+        }
+        let chordText = chord == .custom
+            ? ControllerButton.describe(customChord) : chord.displayName
+        return "\(base) (or hold \(chordText) on the controller) to leave"
     }
 
     /// Stand up the window + decoder + input on the main actor and return them.
@@ -91,16 +121,21 @@ extension StreamSession {
         // .streaming even if the one-shot .connectionEstablished edge was
         // lost. See the `onFirstDecodedFrame` re-wire in the post-bridge
         // MainActor block.)
-        let quitChordProvider = options.quitHotkeyProvider
+        let hotkeyProvider = options.quitHotkeyProvider
+        let chordProvider = options.controllerQuitChordProvider
+        let customChordProvider = options.customControllerChordProvider
         dec.onFirstDecodedFrame = { [weak win] in
             win?.fadeInOnFirstFrame()
             // One-time discoverability toast: Esc is a game input and the menu
             // bar is hidden, so the quit chord is otherwise undiscoverable. Show
-            // it once ever, on the first stream, with the LIVE chord string.
+            // it once ever, on the first stream, with the LIVE chord string(s).
             guard let win, !UserDefaults.standard.bool(forKey: Self.leaveHintShownKey) else { return }
             UserDefaults.standard.set(true, forKey: Self.leaveHintShownKey)
-            let chord = quitChordProvider().displayString
-            win.leaveHintBanner.setText("Press \(chord) to leave the stream")
+            let text = Self.leaveHintText(
+                hotkey: hotkeyProvider(),
+                chord: chordProvider(),
+                customChord: customChordProvider())
+            win.leaveHintBanner.setText(text)
             win.leaveHintBanner.setVisible(true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak win] in
                 win?.leaveHintBanner.setVisible(false)

--- a/Glimmer/Stream/StreamSession+Telemetry.swift
+++ b/Glimmer/Stream/StreamSession+Telemetry.swift
@@ -28,11 +28,11 @@ extension StreamSession {
         // without having gone through the anchor.
         SessionLogFileSink.startIfEnabled(enabled: TelemetryGate.isEnabled)
 
-        // Capture Sendable handles. `backend` is Sendable; `decoder` is a class
-        // whose telemetry accessors are all `nonisolated` + lock-guarded, so the
-        // exporter's utility queue can call them directly. We pass the decoder
-        // weakly so a teardown race can't keep it alive through the closures.
-        let backend = self.backend
+        // Capture the decoder weakly; its telemetry accessors are all
+        // `nonisolated` + lock-guarded, so the exporter's utility queue can call
+        // them directly. RTT / ENet health route through the decoder's LIVE
+        // backend (re-pointed on reconnect) - a by-value backend capture here
+        // went dead after a silent reconnect swapped the backend.
         let source = TelemetrySource(
             videoStats: { [weak decoder] in
                 decoder?.telemetryStatsSnapshot() ?? StreamStatsSnapshot()
@@ -40,8 +40,8 @@ extension StreamSession {
             decoderDrops: { [weak decoder] in decoder?.telemetryDecoderDrops() ?? 0 },
             backpressureDrops: { [weak decoder] in decoder?.telemetryBackpressureDrops() ?? 0 },
             presentationLateDrops: { [weak decoder] in decoder?.telemetryPresentationLateDrops() ?? 0 },
-            estimatedRtt: { backend.estimatedRtt() },
-            enetHealth: { backend.enetHealth() },
+            estimatedRtt: { [weak decoder] in decoder?.telemetryEstimatedRtt() },
+            enetHealth: { [weak decoder] in decoder?.telemetryEnetHealth() },
             pacingLiveness: { [weak decoder] in decoder?.telemetryPacingLiveness() },
             inFlightDecodeBacklog: { [weak decoder] in decoder?.inFlightDecodeBacklog() ?? 0 },
             refreshWindow: { [weak decoder] in decoder?.telemetryRefreshWindow() },

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -91,9 +91,6 @@ extension StreamSession {
         let dec = videoDecoder
         let win = window
         let inp = input
-        // Capture the backend so the overlay tick reads RTT through the
-        // protocol (was LiGetEstimatedRttInfo). StreamingBackend is Sendable.
-        let backend = self.backend
         await MainActor.run {
             self.statsOverlayTimer?.invalidate()
             // `Timer.scheduledTimer` registers the timer on the *current*
@@ -132,11 +129,10 @@ extension StreamSession {
                     // expensive enrichment + HUD render. The decoder's collectors
                     // keep ticking so a re-enable shows fresh numbers immediately.
                     guard dec.statsOverlayEnabled else { return }
-                    // estimatedRtt() returns nil if the engine isn't connected
-                    // (very old GFE versions, or a transient drop, or the native
-                    // stub). On nil we leave rtt nil and the row renders as "-".
-                    // Was LiGetEstimatedRttInfo.
-                    if let rttInfo = backend.estimatedRtt() {
+                    // Read RTT through the decoder's LIVE backend (re-pointed on
+                    // reconnect) so it survives a silent reconnect; nil when not
+                    // connected (transient drop / native stub) → row renders "-".
+                    if let rttInfo = dec.telemetryEstimatedRtt() {
                         // RTT is now measured from a HIGH-RES local monotonic clock
                         // (fractional ms, EWMA as Double) - no widen/truncation; the
                         // overlay shows true sub-ms latency uniformly with jitter.

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -158,6 +158,18 @@ extension TelemetryExporter {
         // renderers as one value.
         var extras = fillExtras(now: now, pacing: pacing, audioState: audioState)
 
+        // A/V skew is NON-IDEMPOTENT (it latches the pair epoch and reads its own
+        // clock), so derive it EXACTLY ONCE per tick and hand both renderers the
+        // same value - calling it twice (Prometheus + NDJSON) made one wire form
+        // see the anchor's nil and the other the post-anchor value for one tick.
+        // `accumulate:true` keeps the NDJSON percentile accumulator fed (the one
+        // feeder cadence). `lastTrueClockSkew`/`rebaseTotal` read the same derive.
+        let skewStore = AudioVideoSkewStore.shared
+        extras.avSkewMs = skewStore.deriveSkewMs(
+            bufferFillMs: snap.audio?.bufferFillMs, accumulate: true)
+        extras.avClockSkewMs = skewStore.lastTrueClockSkew()
+        extras.avSkewRebaseTotal = skewStore.rebaseTotal
+
         // ROLLING 60s latency window: fold this tick's cumulative bucket
         // snapshot into the per-session ring and carry the windowed difference
         // for the NDJSON `_60s` percentile fields. The cumulative fields stay

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -141,6 +141,9 @@ extension TelemetryExporter {
         // present; this is just a read on the exporter queue). Carries the
         // glass-to-glass + input-to-photon composite stages too.
         snap.latencyHistograms = FrameTimingTracker.shared?.histograms.snapshot()
+        // Client-side input latency (queue→wire age) - a standalone input-family
+        // stage, read off the same tracker on this queue.
+        snap.inputLocalLatency = FrameTimingTracker.shared?.inputLocalLatency.snapshotValue()
 
         // Wi-Fi radio (signal 3): one CoreWLAN read on this queue. Reads the
         // current association only - never a scan - so it cannot disturb the link.

--- a/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
@@ -195,6 +195,14 @@ extension TelemetrySnapshot {
         /// steered toward - fill vs target is the cushion judge (base 30 /
         /// cap 150 / ceiling 190). nil until the playout path stamps it.
         var audioPlayoutTargetMs: Double?
+        /// CROSS-STREAM A/V skew + its cushion-subtracted true clock skew +
+        /// rebase count, derived ONCE per capture tick (`deriveSkewMs` is
+        /// non-idempotent - it latches the epoch and reads its own clock), so the
+        /// Prometheus and NDJSON forms of one tick carry identical values. nil
+        /// while either stream is dark/stale or the pair is (re-)anchoring.
+        var avSkewMs: Double?
+        var avClockSkewMs: Double?
+        var avSkewRebaseTotal: UInt64 = 0
         /// Stream ROUTE (`stream_link`/`stream_if`): which interface the
         /// stream's packets actually traverse, from `StreamRouteProbe` - the
         /// PATH truth next to the wifi_* ASSOCIATION truth. nil only before

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -76,25 +76,24 @@ extension TelemetryRenderer {
                      audio.audioClockDriftMs)
         // The true cross-stream meter the drift line above disclaims: host-RTP
         // positions of last-presented video vs the audio playhead (schedule
-        // head minus buffer fill), pair-anchored. Derives WITHOUT feeding the
-        // session accumulator - the NDJSON 1Hz tick is the single feeder, so
-        // scrape cadence can never double-count the scorecard percentiles.
+        // head minus buffer fill), pair-anchored. Derived ONCE per tick in
+        // capture() and carried on `extras` - reading the same value the NDJSON
+        // form does, so the two wire forms can never disagree for one tick.
         builder.emit("glimmer_av_skew_ms",
                      "Cross-stream A/V skew, ms signed (+ = audio late/behind video; pair-anchored "
                      + "host-RTP positions, small constant bias - trend is the signal).",
-                     AudioVideoSkewStore.shared.deriveSkewMs(
-                        bufferFillMs: audio.bufferFillMs, accumulate: false))
-        // Cushion-subtracted true clock skew from the derive just above: the genuine
+                     extras.avSkewMs)
+        // Cushion-subtracted true clock skew from the SAME derive: the genuine
         // host↔Mac clock offset without the deliberate playout cushion baked in.
         builder.emit("glimmer_av_clock_skew_ms",
                      "Cross-stream A/V clock skew, ms signed, with the deliberate audio playout "
                      + "cushion SUBTRACTED (+ = audio clock behind video). The host↔Mac clock "
                      + "offset the drift resampler corrects, vs the cushion-inflated av_skew_ms.",
-                     AudioVideoSkewStore.shared.lastTrueClockSkew())
+                     extras.avClockSkewMs)
         builder.emitCounter("glimmer_av_skew_rebase_total",
                             "A/V-skew pair re-anchors after the first (stale stream or RTP "
                             + "discontinuity) - each one steps the skew baseline.",
-                            AudioVideoSkewStore.shared.rebaseTotal)
+                            extras.avSkewRebaseTotal)
         builder.emit("glimmer_audio_resampler_ppm",
                      "Drift resampler applied rate offset, ppm signed (varispeed rate − 1): "
                      + "0 = disengaged, ~the steady host↔Mac clock offset (tens of ppm) when "

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -140,23 +140,19 @@ extension TelemetryRenderer {
         builder.add("audio_clock_drift_ms", audio.audioClockDriftMs)
         // av_skew_ms - the true CROSS-STREAM A/V alignment, deliberately next
         // to the wall-clock drift it must never be confused with. SIGN: + =
-        // audio late (behind video). Derived per the formerly-deferred recipe
-        // (both streams ride the host capture clock; the two hot-path stores
-        // now exist - last-presented video RTP at the renderer-enqueue site,
-        // last-scheduled audio RTP at the decode hand-off) with the buffer
-        // fill converting schedule-head to playhead. Pair-anchored epoch: a
-        // small constant bias rides along - trend and steps are the signal.
-        // Absent (not 0) while either stream is dark/stale or re-anchoring;
-        // rebase_total makes every mid-session re-baseline countable. THIS
-        // call is the accumulating one (the scorecard percentiles feed at
-        // exactly this 1Hz cadence; the prom render derives without feeding).
-        builder.add("av_skew_ms", AudioVideoSkewStore.shared.deriveSkewMs(
-            bufferFillMs: audio.bufferFillMs, accumulate: true))
-        // The cushion-SUBTRACTED true clock skew from the SAME derive above (no
+        // audio late (behind video). Derived ONCE per tick in capture() (the
+        // accumulating derive that feeds the scorecard percentiles at this 1Hz
+        // cadence) and carried on `extras`, so the prom + NDJSON forms of one
+        // tick are byte-identical - calling deriveSkewMs again here re-latched
+        // the non-idempotent epoch and split the two wire forms. Absent (not 0)
+        // while either stream is dark/stale or re-anchoring; rebase_total makes
+        // every mid-session re-baseline countable.
+        builder.add("av_skew_ms", extras.avSkewMs)
+        // The cushion-SUBTRACTED true clock skew from the SAME derive (no
         // deliberate-cushion bias) - the genuine host↔Mac clock offset the drift
         // resampler corrects, vs av_skew_ms which reads ~cushion+single-digit ms.
-        builder.add("av_clock_skew_ms", AudioVideoSkewStore.shared.lastTrueClockSkew())
-        builder.addCount("av_skew_rebase_total", AudioVideoSkewStore.shared.rebaseTotal)
+        builder.add("av_clock_skew_ms", extras.avClockSkewMs)
+        builder.addCount("av_skew_rebase_total", extras.avSkewRebaseTotal)
         // The live learned LOSS FLOOR under the playout target (the decay
         // limit-cycle fix) - absent until first learned, so a floor-held
         // target is legible against the evidence holding it.

--- a/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
@@ -28,6 +28,15 @@ extension TelemetryRenderer {
                             snap.inputIdleToActiveTotal)
         builder.emit("glimmer_input_since_last_ms",
                      "Milliseconds since the last input event.", snap.timeSinceLastInputMs)
+        // Client-side input latency: queue→wire age of merged input on the batcher
+        // (oldest unflushed entry → flush). The local half of the input path,
+        // independent of host/present clock.
+        if let inputLocal = snap.inputLocalLatency {
+            builder.emitHistogram(
+                "glimmer_latency_input_local_ms",
+                "Client input queue→wire age histogram (batcher enqueue→flush), ms.",
+                stage: inputLocal)
+        }
         // Host rumble dispatched to pad actuators - same Extras sample as the
         // NDJSON rumble fields, riding the input family it correlates with.
         builder.emitCounter("glimmer_rumble_events_total",

--- a/Glimmer/Stream/TelemetryLatency.swift
+++ b/Glimmer/Stream/TelemetryLatency.swift
@@ -156,6 +156,16 @@ final class LatencyHistograms: @unchecked Sendable {
             return (bucketCounts, sumMs, totalCount)
         }
 
+        /// Snapshot as the renderer's value type. Used by standalone stages (e.g.
+        /// the input-local-latency histogram) that aren't part of the composite
+        /// `LatencyHistogramSnapshot`.
+        func snapshotValue() -> LatencyHistogramSnapshot.Stage {
+            let captured = snapshot()
+            return LatencyHistogramSnapshot.Stage(
+                buckets: captured.buckets, boundsMs: bounds,
+                sumMs: captured.sumMs, observationCount: captured.count)
+        }
+
         func reset() {
             os_unfair_lock_lock(lock)
             for index in bucketCounts.indices { bucketCounts[index] = 0 }
@@ -292,6 +302,12 @@ final class FrameTimingTracker: @unchecked Sendable {
     // ---- Instance state (only exists when enabled) ----
 
     let histograms = LatencyHistograms()
+    /// CLIENT-SIDE input latency: the queue→wire age of merged input - how long
+    /// an event waited on the batcher between enqueue and flush. Standalone (not in
+    /// `histograms`) so it stays a Prometheus-only input-family signal without
+    /// threading through the composite-snapshot plumbing. Observed off the present
+    /// path on the batcher queue; the Stage is self-locked, so cross-thread is safe.
+    let inputLocalLatency = LatencyHistograms.Stage()
     /// Both internal (not private): the trace renderer + drop-stub emitter in
     /// TelemetryLatency+Trace.swift are the only cross-file consumers.
     let traceWriter = FrameTraceWriter()

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -156,6 +156,10 @@ struct TelemetrySnapshot: Sendable {
     /// Milliseconds since the last input event. Climbs while idle, snaps to ~0 on
     /// resume - pairs with the edge counter to bracket the idle window.
     var timeSinceLastInputMs: Double?
+    /// CLIENT-SIDE input latency histogram: queue→wire age of merged input on the
+    /// batcher (oldest unflushed entry → flush). A standalone stage, not part of
+    /// `latencyHistograms`; rendered in the input family.
+    var inputLocalLatency: LatencyHistogramSnapshot.Stage?
 
     // display refresh / cadence (ProMotion ramp-down detector)
     var refreshMinHz: Double?

--- a/Glimmer/Stream/VideoDecoder+API.swift
+++ b/Glimmer/Stream/VideoDecoder+API.swift
@@ -160,6 +160,12 @@ extension VideoDecoder {
         }
         return snap
     }
+    /// RTT / ENet health through the LIVE backend slot (re-pointed by
+    /// `setBackend` on a silent reconnect) - so the overlay + exporter never read
+    /// a dead pre-reconnect backend (the by-value-capture staleness bug).
+    nonisolated func telemetryEstimatedRtt() -> (rttMs: Double, varianceMs: Double)? { backend?.estimatedRtt() }
+    nonisolated func telemetryEnetHealth()
+        -> (sentReliable: Int, oldestUnackedMs: UInt32, sinceLastAckMs: UInt32)? { backend?.enetHealth() }
     nonisolated func telemetryDecoderDrops() -> UInt64 { statsCollector.decoderDropCount() }
     nonisolated func telemetryBackpressureDrops() -> UInt64 { statsCollector.backpressureDropCount() }
     nonisolated func telemetryPresentationLateDrops() -> UInt64 {

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.34
-CURRENT_PROJECT_VERSION = 20260645
+MARKETING_VERSION = 2026.6.35
+CURRENT_PROJECT_VERSION = 20260646


### PR DESCRIPTION
From the wide p99 + discovery analysis. Six verified fixes, all outside the .28 pacer blast radius.

BUGS: (1) RTT/enetHealth telemetry went dead after a silent reconnect (by-value backend capture in the overlay timer + exporter) - now read through VideoDecoder's live backend slot that reconnect re-points. (2) PacerTickThread.add() could block the main actor with no timeout if the 2s ready-wait tripped (pointers published before CFRunLoopRun) - now gated on a lock-guarded loopRunning flag set immediately before CFRunLoopRun; installLink falls back to .main on an unconfirmed loop. (3) av_skew derived twice/tick (non-idempotent) so Prometheus and NDJSON disagreed on anchor/rebase ticks - now derived once, both sinks read the sampled value.

ASKS: quit-chord default .startSelectL1R1 needed the DualSense Create button (GameController drops it) so it silently never fired on a DualSense -> default now .l1r1l2r2 (GC-native on every pad) + the leave-hint banner shows the controller chord. Input flush-timer leeway 1ms->250us (trims up to ~1ms controller->host) + new glimmer_latency_input_local_ms histogram. Badge anti-flap: asymmetric widened integrator (0..16, +1.0/-0.7, show>=10/hide<=3).

Build + 156 tests green.