### PR TITLE
fix(audio): release learned cushion floor on wired - drain standing latency (2026.6.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.6.36 - 2026-06-25
+
+Cuts standing audio latency on a wired link. The audio buffer was holding
+roughly 150ms more cushion than a clean wired connection needs - about a
+quarter-second of avoidable A/V lag - because its learned safety floor had been
+trained up to its ceiling by clock-skew corrections (not real audio loss) and
+then couldn't ease back down. On a quiet, healthy wired link the floor now walks
+back down so the buffer drains to a tight, low-latency depth; a link that's
+actually struggling keeps its cushion, and Wi-Fi is unchanged (it needs the
+deeper buffer).
+
 ## 2026.6.35 - 2026-06-25
 
 Six fixes from a deep audit.

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -213,6 +213,13 @@ extension AudioDecoder {
         let link = key.split(separator: "|").last.map(String.init) ?? "unknown"
         let cap = recordSeedCapMs(forLink: link)
         let clampedTarget = min(max(agedTarget, playoutCushionBaseMs), cap)
+        // WELD REPAIR: a floor at/above the cap (or at/above the target) is a
+        // poisoned record - skew under-runs welded the floor to the cap and froze
+        // the target one step above it. Drop the floor to base so the session
+        // re-learns from a healthy floor instead of re-seeding into the lock.
+        if floor >= cap || floor >= clampedTarget {
+            floor = min(playoutCushionBaseMs, clampedTarget)
+        }
         return (clampedTarget, min(max(floor, 0), clampedTarget))
     }
 
@@ -321,6 +328,20 @@ extension AudioDecoder {
             } else if learnedFloorMs > 0,
                       candidate < learnedFloorMs + Self.playoutCushionStepMs {
                 // FLOOR HOLD: below floor+step needs the floor to decay first.
+                // WIRED RELEASE: on a quiet, healthy resolved-wired link, walk the
+                // floor DOWN one step in step with the target instead of waiting on
+                // the ~10min floor clock (skew under-runs keep re-arming it, so it
+                // never releases). Same quiet window + near-miss evidence the target
+                // decay uses; wifi/tunnel/unknown keep the slow clock untouched.
+                if EnvSignalController.shared.streamLink == "wired" {
+                    learnedFloorMs = max(learnedFloorMs - Self.playoutCushionStepMs,
+                                         Self.playoutCushionBaseMs)
+                    playoutTargetMs = max(candidate, Self.playoutCushionBaseMs)
+                    floorQuietSinceNanos = now
+                    quietSinceNanos = now
+                    quietWindowMinFillMs = .infinity
+                    changed = true
+                }
             } else {
                 playoutTargetMs = max(candidate, Self.playoutCushionBaseMs)
                 quietSinceNanos = now
@@ -358,6 +379,11 @@ extension AudioDecoder {
             // Window over (telemetry off / probe dark): settle on the init
             // key. Not a give-up - learning continues, and the floor's slow
             // decay still walks any borrowed depth down if it was too deep.
+            // Set the link-aware cap from whatever the route reads NOW so a
+            // late/never resolve can't freeze at the tunnel-300 default (only
+            // ever equals-or-lowers the cap; pure field write under the lock).
+            effectiveCushionMaxMs = Self.cushionMaxMs(forLink: EnvSignalController.shared.streamLink)
+            effectiveOverrunCeilingMs = effectiveCushionMaxMs + Self.bufferOverrunCeilingSlackMs
             cushionLinkResolved = true
             audioMeterLock.unlock()
             return

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.35
-CURRENT_PROJECT_VERSION = 20260646
+MARKETING_VERSION = 2026.6.36
+CURRENT_PROJECT_VERSION = 20260647


### PR DESCRIPTION
Discovery flagged ~270ms standing audio cushion on wired; a focused investigation corrected the mechanism: NOT a route mislabel (the classifier is correct). On a confirmed-wired session the cushion pins ~160ms and never drains because clock-skew underruns (resampler +/-200-640ppm, not loss) trained the learned floor UP to the wired cap (150), then the floor-hold rule freezes the target one step above it permanently, and the floor's 10min escape clock is re-armed by every skew underrun so it never releases.

FIX (pure arithmetic on the meter-lock-guarded policy fields; ZERO new AVAudio calls - can't touch the teardown-deadlock surface): (1) on a quiet HEALTHY resolved-wired window (gated AFTER the near-miss hold, so a near-starve window keeps depth), walk the learned floor + target down one step together instead of waiting on the never-completing 10min clock; wifi/tunnel/unknown untouched. (2) deadline-expiry now sets the link-aware cap so a late/never route resolve can't freeze at tunnel-300. (3) readCushionMemory repairs a welded record (floor>=cap) on load so the poisoned per-host record self-heals.

Deferred follow-up: skew-aware floor learning (don't EWMA the floor up on a saturated-resampler underrun) so it can't re-weld. Build + 156 tests green. VALIDATE on a docked/wired session: buffer_fill drains ~160->~50-60 WITHOUT underrun_total rising.