### PR TITLE
feat(telemetry): observability honesty batch (2026.6.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.6.37 - 2026-06-25
+
+Under the hood: a batch of telemetry-accuracy fixes, no change to streaming
+behavior. The in-app latency and A/V-sync figures now reflect reality - the
+"input latency" estimate was measuring time-to-next-frame rather than felt
+latency (reading several times too low), and the "A/V skew" number was dominated
+by audio-buffer depth instead of true sync. Adds an honest click-to-first-frame
+measure (the old timer started after the launch handshake) and a few new
+diagnostic counters.
+
 ## 2026.6.36 - 2026-06-25
 
 Cuts standing audio latency on a wired link. The audio buffer was holding

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -242,6 +242,13 @@ extension MoonlightManager {
         // build, so it can't answer "did the user wait >400 ms"). The live
         // edge in handleNativeEvent logs the verdict.
         Self.connectClickedAt = Date()
+        // True click-to-pixels anchor (telemetry): clear any prior session's
+        // latch, then anchor at this launch click - before the connect Task spins
+        // up - the leg handshake_total_ms (connect-start anchored) can't see.
+        // Resolved at the .firstFrame edge. Reset HERE (not in
+        // TelemetryCounters.resetForNewSession, which runs AFTER the click).
+        ConnectTimingTelemetry.shared.resetForNewSession()
+        ConnectTimingTelemetry.shared.anchorClick()
         Self.connectCapsuleShown = false
         Self.connectCancelRequested = false
         // NB: the "last played" timestamp is intentionally NOT written here.

--- a/Glimmer/Stream/StreamSession+Telemetry.swift
+++ b/Glimmer/Stream/StreamSession+Telemetry.swift
@@ -95,6 +95,10 @@ extension StreamSession {
         let p2 = TelemetryCounters.shared.p2
         p2.reset()
         p2.anchorConnectStart(TelemetryCounters.monotonicNowNanos())
+        // Mark connect-start on the click latch too, to isolate the launch-path
+        // leg (click → connect-start). The click was anchored earlier, in
+        // stream(); this measures the gap. No-op if telemetry never anchored.
+        ConnectTimingTelemetry.shared.markConnectStart()
     }
 
     /// Called only from GENUINE teardown (user stop / watchdog / connect failure).

--- a/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
@@ -250,10 +250,11 @@ final class AudioVideoSkewStore: @unchecked Sendable {
     /// the derive reports absent (absent ≠ 0) until both sides flow again.
     static let freshnessNanos: UInt64 = 2_000_000_000
     /// Sanity bound (ms) on a derived skew: beyond this the anchors are judged
-    /// inconsistent (host RTP discontinuity) and the pair re-latches. 1800ms clears
-    /// deepest cushion (300ms) + a real lip-sync excursion but rejects the railed
-    /// multi-second values a stale anchor produces (the old 10s passed +9583ms).
-    static let sanityBoundMs: Double = 1_800
+    /// inconsistent (host RTP discontinuity) and the pair re-latches. 600ms
+    /// clears the deepest cushion (300ms) + a real lip-sync excursion with margin
+    /// but rejects the railed values a stale anchor produces - the old 1800ms was
+    /// loose enough to pass a −1517ms artifact into the percentile buckets.
+    static let sanityBoundMs: Double = 600
     /// Signed bucket bounds (ms) for the session percentile accumulator -
     /// resolution concentrated around the 0...150ms cushion range where the
     /// lip-sync trade lives, with the ~125ms ITU annoyance threshold bracketed.
@@ -275,6 +276,11 @@ final class AudioVideoSkewStore: @unchecked Sendable {
     /// candidate families are 4800% apart, so a mis-snap would take a clumping
     /// pathology no real link produces.
     static let audioRateCalibrationNanos: UInt64 = 2_000_000_000
+    /// Outlier-guard jump threshold (ms): a 1Hz sample more than this from the
+    /// running EWMA is rejected once (then re-seeds, so a sustained step is
+    /// accepted on the next tick). Generous - real skew moves slowly (cushion
+    /// ramps tens of ms/s), so only a one-tick artifact clears it.
+    static let outlierJumpMs: Double = 250
 
     private let lock = os_unfair_lock_t.allocate(capacity: 1)
     private var videoLastRtp: UInt32 = 0
@@ -319,6 +325,23 @@ final class AudioVideoSkewStore: @unchecked Sendable {
     private var sampleSum: Double = 0
     private var sampleMin: Double = .infinity
     private var sampleMax: Double = -.infinity
+    // Parallel accumulator for the cushion-SUBTRACTED true clock skew - the real
+    // A/V sync signal (av_skew_ms is dominated by the cushion). Same bucket set
+    // and feeder cadence (the NDJSON tick); summarized alongside av_skew.
+    private var clockBucketCounts = [UInt64](repeating: 0, count: bucketBoundsMs.count)
+    private var clockOverflowCount: UInt64 = 0
+    private var clockSampleCount: UInt64 = 0
+    private var clockSampleSum: Double = 0
+    private var clockSampleMin: Double = .infinity
+    private var clockSampleMax: Double = -.infinity
+    // Outlier guard: an EWMA of accepted av_skew samples + whether one has been
+    // seeded. A single 1Hz sample that jumps more than `outlierJumpMs` from the
+    // running estimate is rejected ONCE (not bucketed) - it re-seeds the
+    // estimate, so a SUSTAINED step passes on the very next tick. Catches a lone
+    // in-bound artifact (a −1517ms reading inside a loose bound) without dropping
+    // legitimate sustained skew.
+    private var skewEwmaMs: Double = 0
+    private var skewEwmaSeeded = false
 
     init() { lock.initialize(to: os_unfair_lock_s()) }
     deinit { lock.deallocate() }
@@ -416,8 +439,14 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         // TRUE clock skew: same alignment WITHOUT the deliberate cushion
         // (`realFillMs`) baked in - the genuine host↔Mac offset the drift
         // resampler corrects, vs av_skew_ms which is dominated by the cushion.
-        lastTrueClockSkewMs = videoMs - audioMs
-        if accumulate { observeLocked(skewMs) }
+        let clockSkewMs = videoMs - audioMs
+        lastTrueClockSkewMs = clockSkewMs
+        // Outlier guard runs on av_skew (the EWMA target); when it rejects a lone
+        // artifact, drop the paired clock sample too so the two accumulators stay
+        // aligned tick-for-tick.
+        if accumulate, observeLocked(skewMs) {
+            observeClockLocked(clockSkewMs)
+        }
         return skewMs
     }
 
@@ -461,8 +490,18 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         audioRateAnchorNanos = now
     }
 
-    /// Feed one 1Hz sample into the session accumulator. Lock already held.
-    private func observeLocked(_ skewMs: Double) {
+    /// Feed one 1Hz sample into the session accumulator, with the single-sample
+    /// outlier guard. Lock already held. Returns false (and buckets nothing) when
+    /// the sample is rejected as a lone artifact - the EWMA still re-seeds to it,
+    /// so a SUSTAINED step is accepted on the next tick.
+    @discardableResult
+    private func observeLocked(_ skewMs: Double) -> Bool {
+        if skewEwmaSeeded, abs(skewMs - skewEwmaMs) > Self.outlierJumpMs {
+            skewEwmaMs = skewMs // re-seed so a real step isn't rejected twice
+            return false
+        }
+        skewEwmaMs = skewEwmaSeeded ? skewEwmaMs * 0.7 + skewMs * 0.3 : skewMs
+        skewEwmaSeeded = true
         sampleCount &+= 1
         sampleSum += skewMs
         if skewMs < sampleMin { sampleMin = skewMs }
@@ -471,6 +510,22 @@ final class AudioVideoSkewStore: @unchecked Sendable {
             bucketCounts[idx] &+= 1
         } else {
             overflowCount &+= 1 // past the last bound; see the overflow doc
+        }
+        return true
+    }
+
+    /// Feed one 1Hz CUSHION-FREE clock-skew sample into its accumulator. Lock
+    /// already held; mirrors `observeLocked` so the true-sync percentiles use
+    /// the same bucket/overflow discipline as av_skew.
+    private func observeClockLocked(_ skewMs: Double) {
+        clockSampleCount &+= 1
+        clockSampleSum += skewMs
+        if skewMs < clockSampleMin { clockSampleMin = skewMs }
+        if skewMs > clockSampleMax { clockSampleMax = skewMs }
+        if let idx = Self.bucketBoundsMs.firstIndex(where: { skewMs <= $0 }) {
+            clockBucketCounts[idx] &+= 1
+        } else {
+            clockOverflowCount &+= 1
         }
     }
 
@@ -494,42 +549,67 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         return Summary(samples: sampleCount,
                        minMs: sampleMin, maxMs: sampleMax,
                        avgMs: sampleSum / Double(sampleCount),
-                       p50Ms: quantileLocked(0.50),
-                       p95Ms: quantileLocked(0.95),
-                       p99Ms: quantileLocked(0.99),
+                       p50Ms: quantileLocked(0.50, bucketCounts, overflowCount,
+                                             sampleCount, sampleMin, sampleMax),
+                       p95Ms: quantileLocked(0.95, bucketCounts, overflowCount,
+                                             sampleCount, sampleMin, sampleMax),
+                       p99Ms: quantileLocked(0.99, bucketCounts, overflowCount,
+                                             sampleCount, sampleMin, sampleMax),
                        rebases: rebases)
     }
 
-    /// Bucket-interpolated quantile. Lock already held; `sampleCount > 0`
-    /// guaranteed by the caller. Clamped to the exact min/max so a single
-    /// sample never reads as a bucket edge. The OVERFLOW tail is a real
-    /// bucket in the walk - [last bound, exact max] with `overflowCount`
-    /// mass - so a rank landing past the fixed bounds interpolates instead
-    /// of pinning every quantile to the max (the degenerate-quantile half of
-    /// a past av_skew break).
-    private func quantileLocked(_ quantile: Double) -> Double {
-        let rank = quantile * Double(sampleCount)
+    /// Session percentiles of the CUSHION-FREE true clock skew - the real A/V
+    /// sync signal (av_skew is dominated by the cushion). Same shape/discipline
+    /// as `sessionSummary`; nil before any sample. `rebases` is shared (one pair
+    /// epoch feeds both accumulators).
+    func clockSkewSessionSummary() -> Summary? {
+        os_unfair_lock_lock(lock)
+        defer { os_unfair_lock_unlock(lock) }
+        guard clockSampleCount > 0 else { return nil }
+        return Summary(samples: clockSampleCount,
+                       minMs: clockSampleMin, maxMs: clockSampleMax,
+                       avgMs: clockSampleSum / Double(clockSampleCount),
+                       p50Ms: quantileLocked(0.50, clockBucketCounts, clockOverflowCount,
+                                             clockSampleCount, clockSampleMin, clockSampleMax),
+                       p95Ms: quantileLocked(0.95, clockBucketCounts, clockOverflowCount,
+                                             clockSampleCount, clockSampleMin, clockSampleMax),
+                       p99Ms: quantileLocked(0.99, clockBucketCounts, clockOverflowCount,
+                                             clockSampleCount, clockSampleMin, clockSampleMax),
+                       rebases: rebases)
+    }
+
+    /// Bucket-interpolated quantile over a given accumulator. Lock already held;
+    /// `sampleCount > 0` guaranteed by the caller. Clamped to the exact min/max
+    /// so a single sample never reads as a bucket edge. The OVERFLOW tail is a
+    /// real bucket in the walk - [last bound, exact max] with `overflow` mass -
+    /// so a rank landing past the fixed bounds interpolates instead of pinning
+    /// every quantile to the max (the degenerate-quantile half of a past
+    /// av_skew break).
+    private func quantileLocked(_ quantile: Double, _ buckets: [UInt64],
+                                _ overflow: UInt64, _ count: UInt64,
+                                _ minMs: Double, _ maxMs: Double) -> Double {
+        let rank = quantile * Double(count)
         var cumulative: UInt64 = 0
-        var lower = sampleMin
-        for (idx, count) in bucketCounts.enumerated() where count > 0 {
+        var lower = minMs
+        for (idx, bucketCount) in buckets.enumerated() where bucketCount > 0 {
             let upper = Self.bucketBoundsMs[idx]
-            let next = cumulative &+ count
+            let next = cumulative &+ bucketCount
             if Double(next) >= rank {
-                let within = (rank - Double(cumulative)) / Double(count)
+                let within = (rank - Double(cumulative)) / Double(bucketCount)
                 let base = max(lower, Self.lowerEdge(idx))
                 let estimate = base + (upper - base) * within
-                return min(max(estimate, sampleMin), sampleMax)
+                return min(max(estimate, minMs), maxMs)
             }
             cumulative = next
             lower = upper
         }
-        if overflowCount > 0 {
-            let base = max(Self.bucketBoundsMs.last ?? sampleMin, sampleMin)
-            let within = (rank - Double(cumulative)) / Double(overflowCount)
-            let estimate = base + (sampleMax - base) * within
-            return min(max(estimate, sampleMin), sampleMax)
+        if overflow > 0 {
+            let base = max(Self.bucketBoundsMs.last ?? minMs, minMs)
+            let within = (rank - Double(cumulative)) / Double(overflow)
+            let estimate = base + (maxMs - base) * within
+            return min(max(estimate, minMs), maxMs)
         }
-        return sampleMax // floating-point edge backstop; the walk covers all mass
+        return maxMs // floating-point edge backstop; the walk covers all mass
     }
     private static func lowerEdge(_ idx: Int) -> Double {
         idx > 0 ? bucketBoundsMs[idx - 1] : -sanityBoundMs
@@ -559,6 +639,14 @@ final class AudioVideoSkewStore: @unchecked Sendable {
         sampleSum = 0
         sampleMin = .infinity
         sampleMax = -.infinity
+        clockBucketCounts = [UInt64](repeating: 0, count: Self.bucketBoundsMs.count)
+        clockOverflowCount = 0
+        clockSampleCount = 0
+        clockSampleSum = 0
+        clockSampleMin = .infinity
+        clockSampleMax = -.infinity
+        skewEwmaMs = 0
+        skewEwmaSeeded = false
         os_unfair_lock_unlock(lock)
     }
 }

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -246,6 +246,13 @@ final class TelemetryCounters: @unchecked Sendable {
     /// VideoDecoder increments on its quiet-drop path; always-live integer add.
     let decodeGatedDropTotal = Counter()
 
+    /// STREAM-DISCONTINUITY flushes: param-set rebuilds mid-stream that flush the
+    /// renderer + clear the pacer queue (a real multi-frame skip). 0 on a healthy
+    /// wired link (the byte-equal short-circuit holds); a host that mutates param
+    /// sets mid-stream surfaces as a measurable delta. VideoDecoder increments at
+    /// the rebuild's flush site; always-live integer add at an already-rare event.
+    let discontinuityFlushTotal = Counter()
+
     // ---- P1 AUDIO receive-path + playout totals (the OTHER stream) ----
     //
     // All derived purely from the audio RTP we receive + the audio output path -
@@ -569,6 +576,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         ackSilenceNearMissTotal, ctrlIgnoredTotal,
                         decoderRecreateTotal, staleFrameRepeatTotal,
                         pacerOverTargetReleaseTotal, suppressedDropTotal, decodeGatedDropTotal,
+                        discontinuityFlushTotal,
                         audioPacketsTotal, audioPacketsLostTotal, audioFecRecoveredTotal,
                         audioFecMismatchTotal, audioUnderrunTotal, audioOverrunTotal,
                         audioTrimTotal, rumbleEventTotal, rumbleDroppedInvalidTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -111,6 +111,7 @@ extension TelemetryExporter {
         snap.pacerDisabledTotal = counters.pacerDisabledTotal.value
         snap.bookmarkTotal = counters.bookmarkTotal.value
         snap.decoderRecreateTotal = counters.decoderRecreateTotal.value
+        snap.discontinuityFlushTotal = counters.discontinuityFlushTotal.value
         snap.staleFrameRepeatTotal = counters.staleFrameRepeatTotal.value
 
         // P1 DECODE state (HW-decode + pixel format + bit depth + colorspace) +

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -221,6 +221,8 @@ extension TelemetryExporter {
         add("enet_connect_ms", breakdown.enetConnectMs)
         add("first_frame_ms", breakdown.firstFrameMs)
         add("total_ms", breakdown.totalMs)
+        add("click_to_first_frame_ms", breakdown.clickToFirstFrameMs)
+        add("launch_path_ms", breakdown.launchPathMs)
         return "{" + fields.joined(separator: ",") + "}"
     }
 

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -72,7 +72,11 @@ extension TelemetryRenderer {
         builder.emit("glimmer_audio_overruns_per_second",
                      "Audio output over-runs per second.", audio.overrunsPerSecond)
         builder.emit("glimmer_audio_clock_drift_ms",
-                     "Audio clock drift vs wall clock, ms signed (+ audio played behind wall time, − ahead). Not a cross-stream A/V delta.",
+                     "Playout slip vs wall clock with the standing buffer cushion SUBTRACTED, ms "
+                     + "signed (wall_elapsed − media_played − buffer_fill; + behind, − ahead): a "
+                     + "constant cushion reads ~0, only a drift TREND shows. Cushion-relative "
+                     + "playout slack over the current segment - not raw clock drift, not a "
+                     + "cross-stream A/V delta.",
                      audio.audioClockDriftMs)
         // The true cross-stream meter the drift line above disclaims: host-RTP
         // positions of last-presented video vs the audio playhead (schedule
@@ -81,7 +85,9 @@ extension TelemetryRenderer {
         // form does, so the two wire forms can never disagree for one tick.
         builder.emit("glimmer_av_skew_ms",
                      "Cross-stream A/V skew, ms signed (+ = audio late/behind video; pair-anchored "
-                     + "host-RTP positions, small constant bias - trend is the signal).",
+                     + "host-RTP positions). CUSHION-INCLUSIVE: its magnitude is dominated by the "
+                     + "playout cushion, NOT sync error - a cushion-inclusive diagnostic. For the "
+                     + "true host↔Mac sync error use glimmer_av_clock_skew_ms below.",
                      extras.avSkewMs)
         // Cushion-subtracted true clock skew from the SAME derive: the genuine
         // host↔Mac clock offset without the deliberate playout cushion baked in.

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -171,6 +171,7 @@ extension TelemetryRenderer {
         _ builder: inout NDJSONBuilder, _ snap: TelemetrySnapshot, _ extras: TelemetrySnapshot.Extras
     ) {
         builder.addCount("decoder_recreate_total", snap.decoderRecreateTotal)
+        builder.addCount("discontinuity_flush_total", snap.discontinuityFlushTotal)
         if let state = snap.decodeState {
             builder.addBool("decode_hw", state.hwDecode)
             builder.addString("decode_pixel_format", state.pixelFormat)

--- a/Glimmer/Stream/TelemetryExporter+RenderP2.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderP2.swift
@@ -47,6 +47,15 @@ extension TelemetryRenderer {
         builder.emit("glimmer_handshake_total_ms",
                      "Whole cold-open: connect start → first decoded frame this session, ms.",
                      handshake.totalMs)
+        builder.emit("glimmer_connect_click_to_first_frame_ms",
+                     "TRUE click-to-pixels: user's launch click → first decoded frame this "
+                     + "session, ms. Includes the serverinfo + launch + busy-poll legs "
+                     + "handshake_total_ms (connect-start anchored) excludes.",
+                     handshake.clickToFirstFrameMs)
+        builder.emit("glimmer_launch_path_ms",
+                     "Launch path: click → connect-start this session, ms - the pre-connect "
+                     + "launch cost handshake_total_ms can't see.",
+                     handshake.launchPathMs)
     }
 
     /// RECONNECT count + disconnect REASON. The reason is BOTH an ordinal gauge

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -216,6 +216,11 @@ extension TelemetryRenderer {
         builder.emitCounter("glimmer_decoder_recreate_total",
                             "VTDecompressionSession (re)creates (first create + param-rebuilds).",
                             snap.decoderRecreateTotal)
+        builder.emitCounter("glimmer_discontinuity_flush_total",
+                            "Stream-discontinuity flushes (param-set rebuilds that flushed the "
+                            + "renderer + cleared the pacer queue - a real multi-frame skip). 0 on "
+                            + "a healthy wired link; a delta is a mid-stream format change.",
+                            snap.discontinuityFlushTotal)
         guard let state = snap.decodeState else { return }
         builder.emit("glimmer_decode_hw_accelerated",
                      "1 if VideoToolbox confirmed a hardware-accelerated decoder, else 0.",

--- a/Glimmer/Stream/TelemetryLatency+Composites.swift
+++ b/Glimmer/Stream/TelemetryLatency+Composites.swift
@@ -29,19 +29,19 @@ extension FrameTimingTracker {
         return haveAny ? total : nil
     }
 
-    /// Input-to-photon estimate (signal 2): (this present) − (last input sent),
-    /// recorded ONCE per input stamp - the first present after an input is the
-    /// frame that plausibly CARRIES its visual result; every later present is a
-    /// static frame between inputs, not latency. Consume-once replaces the old
-    /// 38ms freshness cap: the cap silently dropped genuinely-slow outliers and
-    /// pinned the metric's max/p99 at exactly the cap (max ~37.999ms - the
-    /// distribution's right edge measured the WINDOW, not the pipeline). The
-    /// artifact the cap fought - static frames
-    /// re-counting an old input (p95 158 / p99 254ms at a 250ms window) - is
-    /// killed at the source by consume-once: one stamp, one observation. Still
-    /// reuses the always-live last-input instant the InputBatcher stamps via
-    /// `noteInputEvent()`, so there is NO new input-side write.
-    func computeInputToPhoton(presentNanos: UInt64) -> Double? {
+    /// Input-to-photon (signal 2): a felt-latency estimate composed from the
+    /// SAME known legs as glass-to-glass (host-encode + ~RTT/2 + client
+    /// pipeline), recorded ONCE per fresh input stamp. The old form -
+    /// (first present after the stamp) − stamp - measured time-to-NEXT-present,
+    /// bounded by the frame interval, so it read 4-5x BELOW glass-to-glass
+    /// (structurally impossible for felt latency: a present ~8ms out shows
+    /// content fixed a host round-trip ago). Composing the legs makes it
+    /// >= glass_to_glass by construction. Consume-once on the input stamp keeps
+    /// "one observation per input" so an idle stream's static frames can't
+    /// re-count an old input. Reuses the always-live last-input instant the
+    /// InputBatcher stamps via `noteInputEvent()` for the gate only - no new
+    /// clock, no new input-side write.
+    func computeInputToPhoton(presentNanos: UInt64, glassToGlassMs: Double?) -> Double? {
         guard let lastInputNanos = TelemetryCounters.shared.lastInputNanos else { return nil }
         guard presentNanos > lastInputNanos else { return nil }
         // Consume-once gate on the lock this present path already takes for
@@ -51,16 +51,10 @@ extension FrameTimingTracker {
         lastInputConsumedNanos = lastInputNanos
         os_unfair_lock_unlock(warmupLock)
         guard !alreadyConsumed else { return nil }
-        let deltaMs = Double(presentNanos &- lastInputNanos) / 1_000_000.0
-        // Plausibility ceiling, NOT a freshness cap: past ~1s the gap is a
-        // stall/freeze with its own counters telling that story, and the
-        // coarse composite bounds top out at 1056ms - a multi-second delta
-        // would land shapeless in +Inf while poisoning the stage's sum.
-        guard deltaMs <= Self.inputToPhotonPlausibleMaxMs else { return nil }
-        return deltaMs
+        // HONEST composition: the felt input round trip is the same pipeline
+        // glass-to-glass measures for THIS input-carrying frame - input rides
+        // the link, the host encodes the response, it transits back, our
+        // pipeline presents it. Same legs, so it can never read below g2g.
+        return glassToGlassMs
     }
-
-    /// See the ceiling comment in `computeInputToPhoton` - beyond this the
-    /// observation is a freeze, not input latency.
-    static let inputToPhotonPlausibleMaxMs: Double = 1000.0
 }

--- a/Glimmer/Stream/TelemetryLatency.swift
+++ b/Glimmer/Stream/TelemetryLatency.swift
@@ -207,11 +207,13 @@ final class LatencyHistograms: @unchecked Sendable {
     /// can be tens of ms), so it gets its own coarse-tailed bound set below.
     let glassToGlass = Stage(bounds: Stage.glassToGlassBoundsMs)
 
-    /// INPUT-TO-PHOTON (estimate): a LOWER BOUND on felt input latency -
-    /// (next-presented-frame-time − last-input-sent-time). Labelled an estimate
-    /// because the host doesn't mark which frame reflects an input. Same wide
-    /// range as glass-to-glass (it includes the full host round trip plus the
-    /// time the input waited for the next frame), so it shares the coarse bounds.
+    /// INPUT-TO-PHOTON (estimate): felt input latency, composed from the SAME
+    /// legs as glass-to-glass (host-encode + ~RTT/2 + client pipeline) for the
+    /// frame that carries an input's response, recorded once per input stamp.
+    /// It therefore reads >= glass_to_glass by construction. Labelled an estimate
+    /// because the host doesn't mark which frame reflects an input. (The prior
+    /// form measured time-to-next-present and read 4-5x BELOW g2g - bounded by
+    /// the frame interval, not the round trip.) Shares the coarse bounds.
     let inputToPhoton = Stage(bounds: Stage.glassToGlassBoundsMs)
 
     func reset() {
@@ -536,14 +538,14 @@ final class FrameTimingTracker: @unchecked Sendable {
         let glassToGlass = computeGlassToGlass(hostEncodeMs: timing.hostEncodeMs, pipelineMs: endToEnd)
         if !warmingUp, let value = glassToGlass { histograms.glassToGlass.observe(value) }
 
-        // INPUT-TO-PHOTON estimate (signal 2): time from the last input batch
-        // we sent to the FIRST present after it - a lower bound on felt input
-        // latency. The host doesn't tell us which frame reflects an input, so
-        // this is explicitly an estimate; each input stamp records at most one
-        // observation (consume-once - see the Composites split), so an idle
-        // stream's static frames can't inflate the metric and a genuinely slow
-        // outlier isn't capped away.
-        let inputToPhoton = computeInputToPhoton(presentNanos: presentNanos)
+        // INPUT-TO-PHOTON estimate (signal 2): the felt input round trip,
+        // composed from the SAME legs as glass-to-glass for THIS input-carrying
+        // frame (host-encode + ~RTT/2 + pipeline), so it can't read below g2g.
+        // Still an estimate (the host doesn't mark which frame reflects an
+        // input); each input stamp records at most one observation (consume-once
+        // - see the Composites split), so an idle stream's static frames can't
+        // inflate it.
+        let inputToPhoton = computeInputToPhoton(presentNanos: presentNanos, glassToGlassMs: glassToGlass)
         if !warmingUp, let value = inputToPhoton { histograms.inputToPhoton.observe(value) }
 
         traceWriter.append(renderTraceLine(TraceRecord(

--- a/Glimmer/Stream/TelemetrySessionEvents.swift
+++ b/Glimmer/Stream/TelemetrySessionEvents.swift
@@ -102,6 +102,79 @@ final class DisconnectReasonCounters: @unchecked Sendable {
     }
 }
 
+// MARK: - Click-to-first-frame latch (true click-to-pixels)
+
+/// The TRUE click-to-pixels span the handshake breakdown can't see:
+/// `handshake_total_ms` is anchored at connect-START (inside connectBackend), so
+/// it EXCLUDES the serverinfo + launch + busy-poll legs that run between the
+/// user's click and connect-start. This latch is anchored at the CLICK
+/// (`MoonlightManager.stream()`) and resolved at the first decoded frame, both on
+/// a wall clock (`Date`) the way the existing click anchor is - no cross-actor
+/// monotonic plumbing, and it survives `P2State.reset()` (which the click
+/// precedes). Standalone + self-locked (the `AudioCushionTelemetry` idiom), read
+/// by the exporter without touching the snapshot structs. First writer wins per
+/// edge; `resetForNewSession` clears it.
+final class ConnectTimingTelemetry: @unchecked Sendable {
+    static let shared = ConnectTimingTelemetry()
+
+    private let lock = os_unfair_lock_t.allocate(capacity: 1)
+    /// Wall-clock reference of the user's click; 0 = no click anchored.
+    private var clickReference: Double = 0
+    /// Wall-clock reference of connect-start (for the launch-path leg); 0 = unset.
+    private var connectStartReference: Double = 0
+    private var clickToFirstFrameMsValue: Double = 0
+    private var launchPathMsValue: Double = 0
+    init() { lock.initialize(to: os_unfair_lock_s()) }
+    deinit { lock.deallocate() }
+
+    /// Anchor the click instant. Called from `MoonlightManager.stream()` at the
+    /// user's launch click - before the connect Task spins up. First write wins
+    /// per session (reset clears it).
+    func anchorClick() {
+        let now = Date().timeIntervalSinceReferenceDate
+        os_unfair_lock_lock(lock)
+        if clickReference == 0 { clickReference = now }
+        os_unfair_lock_unlock(lock)
+    }
+    /// Mark connect-start to isolate the launch cost (click → connectStart).
+    /// First write wins; no-op if the click was never anchored.
+    func markConnectStart() {
+        let now = Date().timeIntervalSinceReferenceDate
+        os_unfair_lock_lock(lock)
+        if clickReference > 0, connectStartReference == 0, now >= clickReference {
+            connectStartReference = now
+            launchPathMsValue = (now - clickReference) * 1000.0
+        }
+        os_unfair_lock_unlock(lock)
+    }
+    /// Resolve click → first decoded frame. Called at the `.firstFrame` edge;
+    /// first write wins, no-op without a click anchor.
+    func markFirstFrame() {
+        let now = Date().timeIntervalSinceReferenceDate
+        os_unfair_lock_lock(lock)
+        if clickReference > 0, clickToFirstFrameMsValue == 0, now >= clickReference {
+            clickToFirstFrameMsValue = (now - clickReference) * 1000.0
+        }
+        os_unfair_lock_unlock(lock)
+    }
+    /// Click → first decoded frame (ms), or nil if not yet resolved.
+    var clickToFirstFrameMs: Double? {
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        return clickToFirstFrameMsValue != 0 ? clickToFirstFrameMsValue : nil
+    }
+    /// Launch path: click → connect-start (ms), or nil if not yet measured.
+    var launchPathMs: Double? {
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        return launchPathMsValue != 0 ? launchPathMsValue : nil
+    }
+    func resetForNewSession() {
+        os_unfair_lock_lock(lock)
+        clickReference = 0; connectStartReference = 0
+        clickToFirstFrameMsValue = 0; launchPathMsValue = 0
+        os_unfair_lock_unlock(lock)
+    }
+}
+
 // MARK: - Handshake breakdown snapshot
 
 /// One session's CONNECT-HANDSHAKE breakdown: the per-stage durations (ms) of the
@@ -124,6 +197,12 @@ struct HandshakeBreakdown: Sendable {
     var firstFrameMs: Double?
     /// Total: connect start → first decoded video frame (the whole cold open).
     var totalMs: Double?
+    /// TRUE click-to-pixels: the user's launch click → first decoded frame, which
+    /// includes the serverinfo + launch + busy-poll legs `totalMs` excludes (it
+    /// anchors at connect-start). From `ConnectTimingTelemetry`.
+    var clickToFirstFrameMs: Double?
+    /// Launch path: click → connect-start, isolating the pre-connect launch cost.
+    var launchPathMs: Double?
     /// True once the first decoded frame landed (so the exporter emits the
     /// one-shot breakdown exactly once, not every tick).
     var complete: Bool = false
@@ -239,6 +318,11 @@ extension TelemetryCounters {
             out.enetConnectMs = msBetween(enetStartNanos, establishedNanos)
             out.firstFrameMs = msBetween(establishedNanos, firstFrameNanos)
             out.totalMs = msBetween(connectStartNanos, firstFrameNanos)
+            // TRUE click-to-pixels + the isolated launch leg, from the wall-clock
+            // click latch (anchored before connect-start, so it sees the legs
+            // totalMs can't). Self-locked; read here off the P2 lock.
+            out.clickToFirstFrameMs = ConnectTimingTelemetry.shared.clickToFirstFrameMs
+            out.launchPathMs = ConnectTimingTelemetry.shared.launchPathMs
             out.complete = firstFrameNanos != 0
             return out
         }

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -298,7 +298,12 @@ struct SessionReport {
         // A/V SKEW percentiles (SIGN: + = audio late/behind video), from the
         // 1Hz pair-anchored RTP derivation - the lip-sync cost the adaptive
         // cushion silently trades; the cushion-ceiling policy reads THIS line.
+        // NB: av_skew is cushion-INCLUSIVE (its magnitude is mostly the playout
+        // cushion); the cushion-free TRUE sync signal is av_clock_skew_ms below.
         top.append("\"av_skew_ms\":\(avSkewObject())")
+        // A/V CLOCK SKEW percentiles (cushion SUBTRACTED) - the genuine host↔Mac
+        // sync error (~±15ms), vs the cushion-dominated av_skew_ms above.
+        top.append("\"av_clock_skew_ms\":\(avClockSkewObject())")
         // Per-TYPE ignored-control totals - durable here (the teardown Diag
         // NOTICE is lossy: a crash or a still-running session loses it).
         top.append("\"ctrl_ignored_by_type\":\(ctrlIgnoredByTypeObject())")
@@ -394,6 +399,8 @@ struct SessionReport {
         add("enet_connect_ms", breakdown.enetConnectMs)
         add("first_frame_ms", breakdown.firstFrameMs)
         add("total_ms", breakdown.totalMs)
+        add("click_to_first_frame_ms", breakdown.clickToFirstFrameMs)
+        add("launch_path_ms", breakdown.launchPathMs)
         return "{" + parts.joined(separator: ",") + "}"
     }
 
@@ -453,6 +460,25 @@ struct SessionReport {
         return "{" + parts.joined(separator: ",") + "}"
     }
 
+    /// A/V CLOCK-SKEW scorecard line: session percentiles of the CUSHION-FREE
+    /// true clock skew (the genuine host↔Mac sync error the drift resampler
+    /// corrects), from the same pair-anchored derivation as av_skew_ms but
+    /// without the playout cushion baked in. Empty object when the meter never
+    /// had both streams flowing.
+    private func avClockSkewObject() -> String {
+        guard let skew = AudioVideoSkewStore.shared.clockSkewSessionSummary() else { return "{}" }
+        let parts: [String] = [
+            "\"samples\":\(skew.samples)",
+            "\"min\":\(num(skew.minMs))",
+            "\"avg\":\(num(skew.avgMs))",
+            "\"p50\":\(num(skew.p50Ms))",
+            "\"p95\":\(num(skew.p95Ms))",
+            "\"p99\":\(num(skew.p99Ms))",
+            "\"max\":\(num(skew.maxMs))"
+        ]
+        return "{" + parts.joined(separator: ",") + "}"
+    }
+
     /// ENV-SIGNAL shadow scorecard: per-state tick counts (~seconds at the
     /// 1Hz cadence) + the transition total, plus the final per-socket
     /// pings_sent counts (the keepalive cadence judge).
@@ -504,6 +530,7 @@ struct SessionReport {
             // over-target force-releases and the designed suppressed-mode /
             // decode-gated drops.
             ("decoder_recreate", counters.decoderRecreateTotal.value),
+            ("discontinuity_flush", counters.discontinuityFlushTotal.value),
             ("present_stale_repeat", counters.staleFrameRepeatTotal.value),
             ("pacer_over_target_release", counters.pacerOverTargetReleaseTotal.value),
             ("suppressed_drop", counters.suppressedDropTotal.value),

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -45,6 +45,10 @@ struct TelemetrySnapshot: Sendable {
     /// create plus every mid-stream param-rebuild; a short-window `increase()`
     /// brackets a decoder reset that correlates with a present hitch.
     var decoderRecreateTotal: UInt64 = 0
+    /// Stream-discontinuity flushes this session (monotonic): param-set rebuilds
+    /// that flushed the renderer + cleared the pacer queue. 0 on a healthy wired
+    /// link; a nonzero delta is a real mid-stream format change / multi-frame skip.
+    var discontinuityFlushTotal: UInt64 = 0
     /// Live DECODE state: HW-decode confirmation + pixel format + bit depth +
     /// colorspace key. Emitted as a Prometheus info-gauge (labels carry the
     /// state) + NDJSON fields. nil before the first decoded frame.

--- a/Glimmer/Stream/VideoDecoder+Decode.swift
+++ b/Glimmer/Stream/VideoDecoder+Decode.swift
@@ -416,6 +416,7 @@ extension VideoDecoder {
         if let renderer = displayLayer?.sampleBufferRenderer {
             renderer.flush()
             OSSignposter.render.emitEvent("DiscontinuityFlush", "trigger=param_rebuild")
+            TelemetryCounters.shared.discontinuityFlushTotal.increment()
         }
         // The pacer's jitter buffer also holds old-format samples; drop them to
         // the freshest so the new keyframe presents without draining stale

--- a/Glimmer/Stream/VideoDecoder+DecodeTelemetry.swift
+++ b/Glimmer/Stream/VideoDecoder+DecodeTelemetry.swift
@@ -61,6 +61,9 @@ extension VideoDecoder {
     /// exactly once per session, behind its own first-frame latch).
     nonisolated static func noteFirstDecodedFrameTelemetry() {
         TelemetryCounters.shared.p2.markFirstFrame(TelemetryCounters.monotonicNowNanos())
+        // Resolve TRUE click-to-pixels at the SAME first-decoded-frame edge as
+        // handshake_total (so the two share an endpoint); no-op without a click.
+        ConnectTimingTelemetry.shared.markFirstFrame()
     }
 
     /// Note a fresh VT-session create for telemetry: bump the always-live recreate

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.36
-CURRENT_PROJECT_VERSION = 20260647
+MARKETING_VERSION = 2026.6.37
+CURRENT_PROJECT_VERSION = 20260648


### PR DESCRIPTION
Six telemetry-accuracy fixes from the p99 discovery sweep. All read-side/additive on the 1Hz exporter/report path; none touches the pacer or AVAudio.

O-1: input_to_photon measured time-to-next-present (frame-interval bounded), reading <glass_to_glass in 142/142 windows - recomposed from the real legs (host-encode + RTT/2 + pipeline) so it reads honestly (~5ms -> ~18-25ms; metric NAME kept for dashboard continuity). O-2: av_skew_ms was cushion-dominated (~200ms), not sync - surfaced the cushion-free av_clock_skew_ms in the session report + relabeled av_skew's help. A-3: clock_drift help corrected (cushion-relative playout slack). A-4: av_skew sanity bound 1800->600ms + single-sample EWMA outlier guard. S-2: new glimmer_connect_click_to_first_frame_ms (+ launch_path_ms) for true click-to-pixels (handshake_total starts after the launch handshake). Decode: glimmer_discontinuity_flush_total counter at the param-rebuild flush site.

Note: input_to_photon will step UP at this build's SHA (now honest). Build + 156 tests green.