### PR TITLE
fix(ux): UX polish + AWDL stays out of the way on wired (2026.6.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026.6.38 - 2026-06-25
+
+Launcher polish, and the Wi-Fi helper now stays out of the way on Ethernet.
+
+On a confirmed-wired connection the network helper no longer prompts you to
+enable it AND no longer parks the AirDrop/Continuity radio during a stream -
+which did nothing for a wired session but disabled AirDrop system-wide. Wi-Fi
+sessions are unchanged (that's where it helps).
+
+The bitrate chip and the codec checkmark now update immediately when you change
+a host's codec (they could lag the actual setting). A configured launch app that
+isn't on the selected host is labelled "(not on <host>)". Plus a telemetry
+cardinality cleanup for per-thread CPU.
+
 ## 2026.6.37 - 2026-06-25
 
 Under the hood: a batch of telemetry-accuracy fixes, no change to streaming

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -41,8 +41,12 @@ struct MainWindow: View {
             // so the prompt never fired.
             try? await Task.sleep(for: .seconds(1.0))
             AWDLHelperManager.shared.refresh()
+            // Parking awdl0 only smooths Wi-Fi; on a confirmed wired route it's
+            // a privileged-helper install for nothing. Suppress ONLY on .wired -
+            // Wi-Fi / tunnel / still-resolving unknown still prompt.
             guard !moonlight.hosts.isEmpty,
                   !moonlight.showRawHIDPrompt,
+                  moonlight.hostRoute.routeClass != .wired,
                   AWDLHelperManager.shared.shouldPromptToEnable else { return }
             showAWDLPrompt = true
         }
@@ -629,8 +633,14 @@ private struct HostContextMenu: ViewModifier {
                     Label("Codec", systemImage: "film.stack")
                 }
                 .pickerStyle(.menu)
+                // Two surfaces mount this menu; reload at present-time so a
+                // change on one is reflected in the other's checkmark.
+                .onAppear { codecPref = HostCodecPreference.load(for: host.id) }
                 .onChange(of: codecPref) { _, newValue in
                     HostCodecPreference.save(newValue, for: host.id)
+                    // Spec chip/summary read the codec via UserDefaults; bump
+                    // the observable sentinel so SwiftUI recomputes the Mbps.
+                    moonlight.displayInfoRevision &+= 1
                 }
                 Divider()
                 Button(role: .destructive) {

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -42,6 +42,7 @@ extension MoonlightManager {
     /// for the selected host (AV1/HEVC spend ~20% fewer bits), so the chip/summary
     /// match the wire. Falls back to the H.264 dial when no host is selected.
     var displayBitrateKbps: Int {
+        _ = displayInfoRevision  // codec override writes UserDefaults; bump re-evaluates the chip
         guard let host = selectedHost else { return effectiveBitrateKbps }
         let formats = HostCodecPreference.load(for: host.id).apply(to: .probedSupported)
         return wireBitrateKbps(forFormats: formats)

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -259,11 +259,14 @@ extension MoonlightManager {
         // lives in the single teardown cleanup site below, gated on
         // `wasStreaming` so it only stamps real sessions.
         isStreaming = true
-        // Park awdl0 for the life of the stream (a no-op unless the user enabled
-        // the network helper). AWDL contention on a single-radio Mac causes the
-        // multi-second Wi-Fi delivery gaps; the helper holds awdl0 down until
+        // Park awdl0 for the life of the stream - but ONLY off a confirmed-wired
+        // route. AWDL contention is a single-radio Wi-Fi problem; on Ethernet,
+        // parking awdl0 just disables AirDrop/Continuity system-wide for nothing.
+        // Wi-Fi/tunnel/unknown still engage (no-op unless the helper is enabled);
         // cleanupAfterStream releases it on every exit path.
-        AWDLHelperManager.shared.suppressForStream()
+        if hostRoute.routeClass != .wired {
+            AWDLHelperManager.shared.suppressForStream()
+        }
         // Cancel the chip poller while the stream is up - the native
         // engine reports its own RTT to the stats overlay, and polling
         // /serverinfo concurrently with the RTSP handshake confuses both

--- a/Glimmer/SettingsGeneralStreamingPanes.swift
+++ b/Glimmer/SettingsGeneralStreamingPanes.swift
@@ -128,6 +128,16 @@ struct GeneralPane: View {
         return out
     }
 
+    /// Display label for a launch option: a stored app that isn't on the selected
+    /// host (set on another PC) is annotated so the picker doesn't imply it'll
+    /// launch here. Display-only - the tag stays the raw name, so scoping is unchanged.
+    private func launchOptionLabel(_ name: String) -> String {
+        guard name != "Desktop",
+              let host = moonlight.selectedHost,
+              !host.apps.contains(where: { $0.name == name }) else { return name }
+        return "\(name) (not on \(host.displayName))"
+    }
+
     var body: some View {
         // @Bindable shim - surfaces $moonlight.x bindings from an @Observable
         // environment value (the macro replaces ObservableObject; @Environment
@@ -177,7 +187,7 @@ struct GeneralPane: View {
                 // is preserved in the list so we don't silently lose it.
                 Picker("On connect, launch", selection: $moonlight.defaultLaunchApp) {
                     ForEach(launchAppOptions, id: \.self) { name in
-                        Text(name).tag(name)
+                        Text(launchOptionLabel(name)).tag(name)
                     }
                 }
                 Text("Right-click the Stream button to pick a different app per connection.")

--- a/Glimmer/Stream/ResourceTelemetry.swift
+++ b/Glimmer/Stream/ResourceTelemetry.swift
@@ -84,10 +84,10 @@ struct ResourceSnapshot: Sendable {
     var batteryCharging: Bool?
 
     /// A stable, non-empty label for one thread's metric series: the thread name
-    /// when we have one, else `tid-<id>` so an unnamed worker is still a distinct,
-    /// attributable series rather than collapsing into one empty-name bucket.
+    /// when we have one, else "unnamed". Unnamed workers are folded into a single
+    /// aggregate upstream (`sampleThreads`), so per-tid labels never reach a series.
     func threadLabel(_ thread: ThreadResourceSample) -> String {
-        thread.name.isEmpty ? "tid-\(thread.tid)" : thread.name
+        thread.name.isEmpty ? "unnamed" : thread.name
     }
 }
 
@@ -158,12 +158,28 @@ enum ResourceTelemetry {
         }
         var samples: [ThreadResourceSample] = []
         samples.reserveCapacity(Int(threadCount))
+        // Unnamed workers churn a fresh tid each session, so per-tid labels are
+        // unbounded cardinality. Fold them into one "unnamed" aggregate instead.
+        var unnamedCpu = 0.0
+        var unnamedPeak = -1.0
+        var unnamedQoS: Int?
         for index in 0..<Int(threadCount) {
             guard let sample = sampleOne(thread: threads[index]) else { continue }
             // Keep a thread if it's drawing measurable CPU, OR it's one of our
             // named hot-path threads (so its QoS stays auditable even when idle).
             let named = sample.name.hasPrefix("io.ugfugl.Glimmer") || sample.name.hasPrefix("Glimmer.")
-            if sample.cpuPercent >= cpuFloorPercent || named { samples.append(sample) }
+            guard sample.cpuPercent >= cpuFloorPercent || named else { continue }
+            if sample.name.isEmpty {
+                unnamedCpu += sample.cpuPercent
+                if sample.cpuPercent > unnamedPeak { unnamedPeak = sample.cpuPercent; unnamedQoS = sample.qos }
+            } else {
+                samples.append(sample)
+            }
+        }
+        if let qos = unnamedQoS {
+            // One bounded series (qos = the hottest unnamed thread's tier).
+            samples.append(ThreadResourceSample(name: "unnamed", tid: 0,
+                                                cpuPercent: unnamedCpu, qos: qos, qosLabel: qosLabel(qos)))
         }
         samples.sort { $0.cpuPercent > $1.cpuPercent }
         if samples.count > maxThreadsEmitted { samples.removeLast(samples.count - maxThreadsEmitted) }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.37
-CURRENT_PROJECT_VERSION = 20260648
+MARKETING_VERSION = 2026.6.38
+CURRENT_PROJECT_VERSION = 20260649


### PR DESCRIPTION
From the p99 discovery sweep, plus a related AWDL fix.

AWDL/WIRED: the launch nudge (U-4) AND the suppression itself now skip a confirmed-wired route. suppressForStream() was called on every stream guarded only on isEnabled - so on a wired stream with the helper on, it parked awdl0 and disabled AirDrop/Continuity system-wide for zero benefit (the stream never touches Wi-Fi). Now gated on hostRoute.routeClass != .wired (Wi-Fi/tunnel/unknown still engage).

UX: U-1 codec-override stale bitrate chip (bump displayInfoRevision + sentinel read in displayBitrateKbps - same class as .34). U-2 codec menu wrong checkmark (reload pref at .onAppear, covers both mount surfaces). U-3 Settings launch-app picker annotates a game absent from the selected host (display-only). R-1 per-thread CPU cardinality collapsed to one thread=unnamed aggregate.

None touches the pacer/decode/AVAudio. Build + 156 tests green.