### PR TITLE
fix(ux): badge false-fires at fps<refresh - judge cadence not stale count (2026.6.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026.6.39 - 2026-06-25
+
+Fixes the "Stream stuttering" badge firing constantly at high refresh. When the
+display refreshes faster than the host can send frames - e.g. a 240Hz panel with
+a host that can only encode ~130fps at 4K - the panel re-shows each frame to
+fill the idle refreshes. That's normal and looks smooth, but the badge counted
+those structural repeats as stutter and lit nonstop. It now judges smoothness by
+how EVENLY frames actually reach the screen (present cadence), so it stays dark
+on an even stream at any frame-rate-to-refresh ratio, and still catches real
+judder and dropped frames. (If your stream looks soft at 4K 240, the host likely
+can't encode it - try 4K 120 or a lower resolution; the picture is genuinely
+smooth at the rate it's delivering.)
+
 ## 2026.6.38 - 2026-06-25
 
 Launcher polish, and the Wi-Fi helper now stays out of the way on Ethernet.

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -673,10 +673,12 @@ private final class PerceivedHitchBox {
     /// the instant a game starts. ~6s covers the launch transient.
     private let graceSeconds: CFTimeInterval = 6.0
 
-    /// True when the PRESENT path is hitching enough to feel. Thresholds sit WELL
-    /// above the fps==refresh structural floor (a bookmarked false positive showed
-    /// late~6/s, render-gap~0.05, zero real loss) so only a clear burst shows; the
-    /// banner's leaky integrator debounces flaps. Deltas guard a reconnect reset.
+    /// True when the PRESENT path is hitching enough to feel. Fires on real frame
+    /// loss (render-gap / late-drops) or JUDDER (presents landing off the ideal
+    /// grid). It deliberately does NOT key on the raw stale-repeat count: when
+    /// content fps < refresh, a panel re-shows each frame to fill idle vsyncs
+    /// (~102/s at 129fps on 240Hz) - that's by design, not a hitch. The banner's
+    /// leaky integrator debounces flaps; deltas guard a reconnect reset.
     func perceivedHitch(snap: StreamStatsSnapshot) -> Bool {
         let now = CACurrentMediaTime()
         if firstTime == 0 { firstTime = now }
@@ -684,7 +686,8 @@ private final class PerceivedHitchBox {
         prevTime = now
 
         // Advance the rate baselines every tick (incl. during the grace) so the
-        // first post-grace delta isn't a spurious spike.
+        // first post-grace delta isn't a spurious spike. staleRate feeds the
+        // present-tick estimate below (rendered + stale fills), not a fire term.
         let stale = TelemetryCounters.shared.staleFrameRepeatTotal.value
         let staleRate = (dt > 0 && stale >= prevStale) ? Double(stale - prevStale) / dt : 0
         prevStale = stale
@@ -695,11 +698,20 @@ private final class PerceivedHitchBox {
         if now - firstTime < graceSeconds { return false }
 
         var hitch = false
+        // Real frame loss: decoded but never rendered.
         if let decoded = snap.decodedFps, let rendered = snap.renderedFps, decoded > 0 {
             if (decoded - rendered) / decoded > 0.18 { hitch = true }
         }
-        if staleRate > 6.0 { hitch = true }
+        // Late drops.
         if lateRate > 12.0 { hitch = true }
+        // Judder: average present landing more than one present-tick off the PTS
+        // grid. Refresh-aware (the tick interval scales with the realized present
+        // rate), so a smooth stream sits well under it at any fps-vs-refresh ratio.
+        if let cad = snap.avgPresentCadenceErrorMs, let rendered = snap.renderedFps {
+            let presentRate = rendered + staleRate
+            let tickMs = presentRate > 1 ? 1000.0 / presentRate : 8.3
+            if cad > tickMs { hitch = true }
+        }
         return hitch
     }
 }

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -68,6 +68,7 @@ extension TelemetryExporter {
         snap.presentCadenceErrorMs = stats.avgPresentCadenceErrorMs
         // on-time/late split: derive counts from the on-time percent if present.
         if let onTimePct = stats.onTimePresentPercent, let rendered = stats.renderedFps {
+            snap.presentOnTimePercent = onTimePct
             let approxPresents = max(rendered, 0)
             snap.presentOnTimeCount = UInt64((approxPresents * onTimePct / 100.0).rounded())
             snap.presentLateCount = UInt64((approxPresents * (100.0 - onTimePct) / 100.0).rounded())

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -26,6 +26,9 @@ extension TelemetryRenderer {
         builder.emit("glimmer_decode_time_ema_ms", "Decode wall-clock EMA, ms.", snap.decodeEmaMs)
         builder.emit("glimmer_present_cadence_error_ms",
                      "Mean |present-vs-PTS| cadence error this window, ms.", snap.presentCadenceErrorMs)
+        builder.emit("glimmer_present_on_time_percent",
+                     "% of new-frame presents on-cadence (excl. stale fills) - the judder signal.",
+                     snap.presentOnTimePercent)
         if let onTime = snap.presentOnTimeCount {
             builder.emitCounter("glimmer_present_on_time_total", "Presents that landed on-cadence.", onTime)
         }

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -39,6 +39,10 @@ struct TelemetrySnapshot: Sendable {
     var presentCadenceErrorMs: Double?
     var presentOnTimeCount: UInt64?
     var presentLateCount: UInt64?
+    /// % of NEW-frame presents that landed on-cadence (on-time / (on-time+late)).
+    /// Excludes structural stale fills, so it reads smoothness independent of
+    /// content-fps vs refresh - the clean judder signal.
+    var presentOnTimePercent: Double?
 
     // P1 DECODE/VT state + counters.
     /// VTDecompressionSession (re)creates this session (monotonic). The first

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.38
-CURRENT_PROJECT_VERSION = 20260649
+MARKETING_VERSION = 2026.6.39
+CURRENT_PROJECT_VERSION = 20260650


### PR DESCRIPTION
Live report: consistent 'Stream stuttering' badge at 4K 240 wired. Telemetry verdict: pipeline is CLEAN - zero drops (late/decoder/backpressure/frame-loss all 0), present cadence error 1.65ms avg / 2.77ms max (sub-vsync = even). The host only encodes ~129fps at 4K (encode limit), and the 240Hz panel re-shows each frame ~1.9x to fill idle vsyncs -> stale_repeats ~102/s. The badge's stale-repeats>6/s term mistook that STRUCTURAL repeat rate for stutter.

FIX: drop the raw stale-repeats fire term (it's structural when content fps < refresh, and redundant with render-gap at fps==refresh). Replace with a refresh-aware JUDDER term: avgPresentCadenceErrorMs > one present-tick interval (derived from rendered + stale fills). A smooth stream sits well under it at any fps-vs-refresh (1.65ms << 4.5ms here). Keeps render-gap>0.18 + late>12. Also adds glimmer_present_on_time_percent gauge (was only a counter). Build + 156 tests green.