### PR TITLE
feat(telemetry): hardening + observability tail (2026.6.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.6.40 - 2026-06-25
+
+Under the hood, no change to streaming behavior: added diagnostics for the
+hardware decoder's session-create time and the cause of any mid-stream decoder
+rebuilds, plus a debug-build safety check on the present-timing thread's
+shutdown.
+
 ## 2026.6.39 - 2026-06-25
 
 Fixes the "Stream stuttering" badge firing constantly at high refresh. When the

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -61,6 +61,12 @@ final class PacerTickThread: @unchecked Sendable {
     /// Released by the thread body once the loop is published, so `start()`
     /// returns only after the run loop can take the link.
     private let ready = DispatchSemaphore(value: 0)
+    /// Signalled by the thread body the instant `CFRunLoopRun()` returns (the
+    /// loop has exited). `stop()` does a bounded join on it - DEBUG ONLY - to
+    /// assert the high-QoS thread actually unwound (defense-in-depth; release
+    /// teardown never blocks on this). Fresh per spawn so a stale signal from a
+    /// prior run can't satisfy a later join. Guarded by `lock` like the pointers.
+    private var exited = DispatchSemaphore(value: 0)
 
     /// Spin up the thread + run loop if not already running. Idempotent: a
     /// rebuild that re-binds onto the same FramePacer reuses the live thread
@@ -74,6 +80,10 @@ final class PacerTickThread: @unchecked Sendable {
         os_unfair_lock_lock(&lock)
         let alreadyUp = thread != nil
         let alreadyRunning = loopRunning
+        // Fresh exit semaphore for this spawn so a prior run's signal can't
+        // satisfy this run's DEBUG join. Set under the same lock as the pointers.
+        if !alreadyUp { exited = DispatchSemaphore(value: 0) }
+        let exitSignal = exited
         os_unfair_lock_unlock(&lock)
         guard !alreadyUp else { return alreadyRunning }
 
@@ -99,6 +109,9 @@ final class PacerTickThread: @unchecked Sendable {
             // CFRunLoopRun blocks until CFRunLoopStop breaks it; RunLoop.run()'s
             // no-source early-return is the freeze this avoids.
             CFRunLoopRun()
+            // The loop has exited - signal the captured semaphore so a DEBUG join
+            // in stop() can confirm the high-QoS thread actually unwound.
+            exitSignal.signal()
         }
         tickThread.name = "Glimmer.pacerTick"
         tickThread.qualityOfService = .userInteractive
@@ -143,13 +156,24 @@ final class PacerTickThread: @unchecked Sendable {
     func stop() {
         os_unfair_lock_lock(&lock)
         let cf = cfRunLoop
+        let exitSignal = exited
         runLoop = nil
         cfRunLoop = nil
         thread = nil
         loopRunning = false
         os_unfair_lock_unlock(&lock)
+        // Idempotent: a second stop with no live loop has nothing to break or
+        // join - return before touching the (already-signalled-or-unused) exit.
         guard let cf else { return }
         CFRunLoopStop(cf)
+        // DEBUG-only bounded join: confirm the loop actually returned so a missed
+        // CFRunLoopStop (defense-in-depth - the cross-thread stop on this single-
+        // level loop is reliable) would trip the assert instead of silently
+        // orphaning a high-QoS thread. Release teardown SKIPS this entirely.
+        #if DEBUG
+        let r = exitSignal.wait(timeout: .now() + .milliseconds(50))
+        assert(r == .success, "pacer tick thread did not exit")
+        #endif
     }
 
     deinit { stop() }

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -140,6 +140,19 @@ extension TelemetryCounters {
         return rttMsValue
     }
 
+    /// Stamp the latest VTDecompressionSessionCreate wall-clock cost (ms).
+    /// Called by the decode queue at each create (rare) - never the hot path.
+    func setVtSessionCreateMs(_ ms: Double) {
+        os_unfair_lock_lock(vtSessionCreateLock); vtSessionCreateMsValue = ms
+        os_unfair_lock_unlock(vtSessionCreateLock)
+    }
+    /// Latest VT-session create cost (ms), 0 if none yet. Read by the exporter on
+    /// its 1Hz queue (never the hot path).
+    var vtSessionCreateMs: Double {
+        os_unfair_lock_lock(vtSessionCreateLock); defer { os_unfair_lock_unlock(vtSessionCreateLock) }
+        return vtSessionCreateMsValue
+    }
+
     /// Set/clear the present-suppression gauge. Called at the suppression edges
     /// (backgrounded/occluded ↔ visible) by the present path - never per frame.
     /// The CLEAR edge also arms the latency rig's resume-present tag: the first

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -203,6 +203,17 @@ final class TelemetryCounters: @unchecked Sendable {
     /// (≤ a handful per session under a healthy link).
     let decoderRecreateTotal = Counter()
 
+    /// Decoder (re)creates SPLIT BY CAUSE (signal: DECODE). Same already-rare
+    /// create site as `decoderRecreateTotal`; these three sum to it. The split
+    /// makes a recreate STORM legible as to cause - a colorspace/HDR flap vs a
+    /// real resolution change vs the one-time first create. Cause is read from
+    /// the format-description dimensions at the rebuild site (resolution change =
+    /// dims changed; otherwise a param-set rebuild that kept dims = colorspace/
+    /// profile/HDR-signaling). Always-live integer adds like their parent.
+    let decoderRecreateFirstTotal = Counter()
+    let decoderRecreateResolutionTotal = Counter()
+    let decoderRecreateColorspaceTotal = Counter()
+
     /// Stale-frame REPEAT count (signal: PRESENT). Bumped on each pacer tick that
     /// fires but presents NO new frame because none was due - the layer re-shows
     /// the last frame. This is the INVISIBLE stutter: at fps<refresh it is the
@@ -352,6 +363,17 @@ final class TelemetryCounters: @unchecked Sendable {
     /// path never touches it.
     let rttLock = os_unfair_lock_t.allocate(capacity: 1)
     var rttMsValue: Double = 0
+
+    // Module-internal (not private) so the gauge accessors in
+    // TelemetryCounters+Gauges.swift can reach these.
+    //
+    /// LATEST VTDecompressionSessionCreate wall-clock cost (ms). HW decoder
+    /// bring-up can't run until the first SPS/PPS, so it lands on the critical
+    /// first-frame leg - this surfaces that one-shot startup cost. Stamped by the
+    /// decode queue at each create (rare); read at 1Hz by the exporter. A plain
+    /// Double behind an unfair lock, last-writer-wins like the other gauges.
+    let vtSessionCreateLock = os_unfair_lock_t.allocate(capacity: 1)
+    var vtSessionCreateMsValue: Double = 0
 
     // Module-internal (not private) so the gauge accessors in
     // TelemetryCounters+Gauges.swift can reach these.
@@ -534,6 +556,7 @@ final class TelemetryCounters: @unchecked Sendable {
         jitterLock.initialize(to: os_unfair_lock_s())
         inputLock.initialize(to: os_unfair_lock_s())
         rttLock.initialize(to: os_unfair_lock_s())
+        vtSessionCreateLock.initialize(to: os_unfair_lock_s())
         gapLock.initialize(to: os_unfair_lock_s())
         decodeStateLock.initialize(to: os_unfair_lock_s())
         fecHealthLock.initialize(to: os_unfair_lock_s())
@@ -544,7 +567,8 @@ final class TelemetryCounters: @unchecked Sendable {
     }
     deinit {
         jitterLock.deallocate(); inputLock.deallocate()
-        rttLock.deallocate(); gapLock.deallocate()
+        rttLock.deallocate(); vtSessionCreateLock.deallocate()
+        gapLock.deallocate()
         decodeStateLock.deallocate(); fecHealthLock.deallocate()
         audioStateLock.deallocate(); audioFirstPacketLock.deallocate()
         presentSuppressedLock.deallocate(); decodeGatedLock.deallocate()
@@ -574,7 +598,9 @@ final class TelemetryCounters: @unchecked Sendable {
                         videoPacketsLostPreFecTotal, videoPacketsOutOfOrderTotal,
                         videoPacketsDuplicateTotal, enetRetransmitTotal,
                         ackSilenceNearMissTotal, ctrlIgnoredTotal,
-                        decoderRecreateTotal, staleFrameRepeatTotal,
+                        decoderRecreateTotal, decoderRecreateFirstTotal,
+                        decoderRecreateResolutionTotal, decoderRecreateColorspaceTotal,
+                        staleFrameRepeatTotal,
                         pacerOverTargetReleaseTotal, suppressedDropTotal, decodeGatedDropTotal,
                         discontinuityFlushTotal,
                         audioPacketsTotal, audioPacketsLostTotal, audioFecRecoveredTotal,
@@ -598,6 +624,7 @@ final class TelemetryCounters: @unchecked Sendable {
         // and the p2 anchor are called back-to-back at the same connect edge).
         setRecvJitterMs(0)
         setRttMs(0)
+        setVtSessionCreateMs(0)
         // Present-suppression + decode-gate gauges: a session starts with a
         // visible stream view, and the present/decode paths re-stamp these at
         // the next suppression/gate edge.

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -112,6 +112,10 @@ extension TelemetryExporter {
         snap.pacerDisabledTotal = counters.pacerDisabledTotal.value
         snap.bookmarkTotal = counters.bookmarkTotal.value
         snap.decoderRecreateTotal = counters.decoderRecreateTotal.value
+        snap.decoderRecreateFirstTotal = counters.decoderRecreateFirstTotal.value
+        snap.decoderRecreateResolutionTotal = counters.decoderRecreateResolutionTotal.value
+        snap.decoderRecreateColorspaceTotal = counters.decoderRecreateColorspaceTotal.value
+        snap.vtSessionCreateMs = counters.vtSessionCreateMs
         snap.discontinuityFlushTotal = counters.discontinuityFlushTotal.value
         snap.staleFrameRepeatTotal = counters.staleFrameRepeatTotal.value
 

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -171,6 +171,10 @@ extension TelemetryRenderer {
         _ builder: inout NDJSONBuilder, _ snap: TelemetrySnapshot, _ extras: TelemetrySnapshot.Extras
     ) {
         builder.addCount("decoder_recreate_total", snap.decoderRecreateTotal)
+        builder.addCount("decoder_recreate_first_total", snap.decoderRecreateFirstTotal)
+        builder.addCount("decoder_recreate_resolution_total", snap.decoderRecreateResolutionTotal)
+        builder.addCount("decoder_recreate_colorspace_total", snap.decoderRecreateColorspaceTotal)
+        if snap.vtSessionCreateMs > 0 { builder.add("vt_session_create_ms", snap.vtSessionCreateMs) }
         builder.addCount("discontinuity_flush_total", snap.discontinuityFlushTotal)
         if let state = snap.decodeState {
             builder.addBool("decode_hw", state.hwDecode)

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -219,6 +219,22 @@ extension TelemetryRenderer {
         builder.emitCounter("glimmer_decoder_recreate_total",
                             "VTDecompressionSession (re)creates (first create + param-rebuilds).",
                             snap.decoderRecreateTotal)
+        // Same recreates split by CAUSE (sums to the total above): the one-time
+        // first create, a real resolution change, or a colorspace/HDR/profile
+        // param-rebuild that kept the dimensions - so a recreate STORM names its
+        // driver. Cause read from the format-description dimensions at rebuild.
+        builder.emitCounterFamily(
+            "glimmer_decoder_recreate_by_cause_total",
+            "Decoder (re)creates by cause (sums to glimmer_decoder_recreate_total).",
+            key: "cause",
+            rows: [("first_create", snap.decoderRecreateFirstTotal),
+                   ("param_rebuild_resolution", snap.decoderRecreateResolutionTotal),
+                   ("param_rebuild_colorspace", snap.decoderRecreateColorspaceTotal)])
+        // VT-session create wall-clock (ms): the HW-decoder bring-up on the
+        // first-frame leg. 0 before the first create (the emit drops the 0).
+        builder.emit("glimmer_vt_session_create_ms",
+                     "VTDecompressionSessionCreate wall-clock cost, ms (first-frame-leg startup).",
+                     snap.vtSessionCreateMs > 0 ? snap.vtSessionCreateMs : nil)
         builder.emitCounter("glimmer_discontinuity_flush_total",
                             "Stream-discontinuity flushes (param-set rebuilds that flushed the "
                             + "renderer + cleared the pacer queue - a real multi-frame skip). 0 on "

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -57,6 +57,15 @@ struct TelemetrySnapshot: Sendable {
     /// colorspace key. Emitted as a Prometheus info-gauge (labels carry the
     /// state) + NDJSON fields. nil before the first decoded frame.
     var decodeState: TelemetryCounters.DecodeState?
+    /// Latest VTDecompressionSessionCreate wall-clock cost (ms): the HW-decoder
+    /// bring-up that lands on the first-frame leg. 0 before the first create.
+    var vtSessionCreateMs: Double = 0
+    /// Decoder (re)creates split by cause (monotonic; sum = decoderRecreateTotal):
+    /// the one-time first create, real resolution changes, and colorspace/HDR/
+    /// profile param-rebuilds that kept dims - so a recreate storm names its cause.
+    var decoderRecreateFirstTotal: UInt64 = 0
+    var decoderRecreateResolutionTotal: UInt64 = 0
+    var decoderRecreateColorspaceTotal: UInt64 = 0
 
     // P1 PRESENT stale-frame REPEAT (the invisible stutter: the layer re-showing
     // the last frame when no new frame was due this vsync).

--- a/Glimmer/Stream/VideoDecoder+Decode.swift
+++ b/Glimmer/Stream/VideoDecoder+Decode.swift
@@ -384,6 +384,14 @@ extension VideoDecoder {
             return true
         }
 
+        // Capture the prior session/dimensions BEFORE the rebuild tears them down
+        // (the format-description builders nil the session). The cause of the
+        // upcoming create is read off these: no prior session = first create;
+        // changed dims = a real resolution change; same dims = a colorspace/HDR/
+        // profile param-rebuild. The new dims are read back after the rebuild.
+        let hadPriorSession = decompressionSession != nil
+        let priorDims = formatDescription.map(CMVideoFormatDescriptionGetDimensions)
+
         if let sps = strippedSps { spsData = sps }
         if let pps = strippedPps { ppsData = pps }
         if let vps = strippedVps { vpsData = vps }
@@ -399,7 +407,17 @@ extension VideoDecoder {
             rebuilt = false
         }
         guard rebuilt else { return false }
-        guard ensureDecompressionSession() else { return false }
+        // Classify the create cause from the dimension delta (see the capture above).
+        let cause: SessionCreateCause
+        if !hadPriorSession {
+            cause = .firstCreate
+        } else if let priorDims, let newDims = formatDescription.map(CMVideoFormatDescriptionGetDimensions),
+                  priorDims.width != newDims.width || priorDims.height != newDims.height {
+            cause = .resolution
+        } else {
+            cause = .colorspace
+        }
+        guard ensureDecompressionSession(cause: cause) else { return false }
 
         // STREAM DISCONTINUITY FLUSH. A parameter-set rebuild means the format
         // genuinely changed mid-stream (resolution / codec profile / colorspace),

--- a/Glimmer/Stream/VideoDecoder+DecodeTelemetry.swift
+++ b/Glimmer/Stream/VideoDecoder+DecodeTelemetry.swift
@@ -66,12 +66,30 @@ extension VideoDecoder {
         ConnectTimingTelemetry.shared.markFirstFrame()
     }
 
+    /// The CAUSE of a fresh VT-session create, for the labeled recreate counters.
+    /// Determined at the rebuild site from the format-description dimensions:
+    /// `firstCreate` (no prior session), `resolution` (dims changed), or
+    /// `colorspace` (a param-set rebuild that kept dims - colorspace/HDR-signaling
+    /// or profile). Codec-profile-only changes that keep resolution fall under
+    /// `colorspace`; the SPS can't be field-split here without a full parse.
+    enum SessionCreateCause {
+        case firstCreate, resolution, colorspace
+    }
+
     /// Note a fresh VT-session create for telemetry: bump the always-live recreate
-    /// counter, and (gate-on only) publish the live DECODE state read back from the
-    /// just-created session. Called unconditionally from
-    /// `ensureDecompressionSession` so its branch stays out of that function.
-    nonisolated func noteSessionCreatedTelemetry(outputPixelFormat: OSType) {
-        TelemetryCounters.shared.decoderRecreateTotal.increment()
+    /// counter (total + the by-cause sibling), and (gate-on only) publish the live
+    /// DECODE state read back from the just-created session. Called unconditionally
+    /// from `ensureDecompressionSession` so its branch stays out of that function.
+    nonisolated func noteSessionCreatedTelemetry(
+        outputPixelFormat: OSType, cause: SessionCreateCause
+    ) {
+        let counters = TelemetryCounters.shared
+        counters.decoderRecreateTotal.increment()
+        switch cause {
+        case .firstCreate: counters.decoderRecreateFirstTotal.increment()
+        case .resolution: counters.decoderRecreateResolutionTotal.increment()
+        case .colorspace: counters.decoderRecreateColorspaceTotal.increment()
+        }
         // Gate: publish the richer state only when telemetry is on (the tracker
         // sentinel is the gate-on signal). Off-path is a single optional load.
         guard FrameTimingTracker.shared != nil else { return }

--- a/Glimmer/Stream/VideoDecoder+Session.swift
+++ b/Glimmer/Stream/VideoDecoder+Session.swift
@@ -19,7 +19,9 @@ extension VideoDecoder {
 
     // MARK: - Decompression session
 
-    nonisolated func ensureDecompressionSession() -> Bool {
+    nonisolated func ensureDecompressionSession(
+        cause: SessionCreateCause = .firstCreate
+    ) -> Bool {
         if decompressionSession != nil { return true }
         guard let formatDesc = formatDescription else { return false }
 
@@ -69,6 +71,11 @@ extension VideoDecoder {
             decompressionOutputCallback: VideoDecoder.decompressionOutputCallback,
             decompressionOutputRefCon: refcon.toOpaque())
 
+        // HW decoder bring-up can't run until the first SPS/PPS, so this create
+        // lands on the critical first-frame leg. Measure it: a signpost interval
+        // for Instruments + a wall-clock ms gauge (glimmer_vt_session_create_ms).
+        let createSignpostState = OSSignposter.decode.beginInterval("VTSessionCreate")
+        let createStart = CFAbsoluteTimeGetCurrent()
         var sessionOut: VTDecompressionSession?
         let status = VTDecompressionSessionCreate(
             allocator: kCFAllocatorDefault,
@@ -77,6 +84,11 @@ extension VideoDecoder {
             imageBufferAttributes: destImageBufferAttrs as CFDictionary,
             outputCallback: &callback,
             decompressionSessionOut: &sessionOut)
+        let createMs = (CFAbsoluteTimeGetCurrent() - createStart) * 1000.0
+        OSSignposter.decode.endInterval(
+            "VTSessionCreate", createSignpostState,
+            "status=\(status, privacy: .public) ms=\(createMs, privacy: .public)")
+        TelemetryCounters.shared.setVtSessionCreateMs(createMs)
 
         guard status == noErr, let session = sessionOut else {
             // No session means no callback will ever consume the refcon -
@@ -107,8 +119,8 @@ extension VideoDecoder {
 
         self.decompressionSession = session
         // Telemetry (opt-in): a fresh VT session was built - bump the recreate
-        // counter + publish the live DECODE state (gate-on). See the helper file.
-        noteSessionCreatedTelemetry(outputPixelFormat: outputPixelFormat)
+        // counter (total + by-cause) + publish the live DECODE state (gate-on).
+        noteSessionCreatedTelemetry(outputPixelFormat: outputPixelFormat, cause: cause)
         return true
     }
 

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.39
-CURRENT_PROJECT_VERSION = 20260650
+MARKETING_VERSION = 2026.6.40
+CURRENT_PROJECT_VERSION = 20260651


### PR DESCRIPTION
Final safe tail from the p99 discovery audit. All DEBUG-only or additive telemetry; nothing touches the pacer/present/AVAudio hot paths.

C-1: PacerTickThread (.32 off-main tick) gets a DEBUG-only exit-confirmation join - signals an 'exited' semaphore after CFRunLoopRun returns; stop() does a bounded 50ms wait+assert inside #if DEBUG so a missed CFRunLoopStop surfaces in testing. Release teardown never blocks (CFRunLoopStop unconditional; the join is #if DEBUG only). Defense-in-depth, not a known leak.
S-4: glimmer_vt_session_create_ms - wall-clock of VTDecompressionSessionCreate (the HW-decoder bring-up on the first-frame leg) + an OSSignpost interval. Measurement-only.
H-1: glimmer_decoder_recreate_by_cause_total{cause=first_create|param_rebuild_resolution|param_rebuild_colorspace} - splits the recreate counter by cause (dimensions captured pre-rebuild, compared post) so a recreate storm is attributable. Sums to the existing total.

Build + 156 tests green.