### PR TITLE
fix: quit-chord opens host OSK on Xbox + badge too sensitive (2026.6.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026.6.41 - 2026-06-25
+
+Two controller/overlay fixes.
+
+The controller exit chord no longer pops the host's on-screen keyboard. The old
+default (L1+R1+L2+R2) leaks the partial combo to the host as you press into it,
+and Steam Big Picture reads that as its show-keyboard shortcut. The default is
+now L3 + R3 (click both sticks) - native on every controller, and its partials
+collide with nothing. (The old chord is still selectable in Settings.)
+
+The "Stream stuttering" pill is now conservative: it lights only on real dropped
+or late frames, not on the normal frame-repeats a high-refresh display does when
+the host sends fewer fps than the panel refreshes - which was lighting it
+constantly at 4K 240 where the picture was actually smooth.
+
 ## 2026.6.40 - 2026-06-25
 
 Under the hood, no change to streaming behavior: added diagnostics for the

--- a/Glimmer/MoonlightManager.swift
+++ b/Glimmer/MoonlightManager.swift
@@ -293,12 +293,12 @@ final class MoonlightManager {
     }
     /// Controller-side quit chord - fires the same path as `quitHotkey`
     /// from the keyboard, but driven by a multi-button hold on the
-    /// gamepad. Defaults to L1 + R1 + L2 + R2 (hold all four shoulders/triggers):
-    /// every button is GameController-native on every pad - no Create/Share/Mute,
-    /// which macOS drops on a DualSense - so the default fires without the raw-HID
-    /// reader, and the 4-button + 400ms dwell keeps mid-combat trips unlikely.
-    /// Users who prefer keyboard-only can pick "None" in Settings.
-    var controllerQuitChord: ControllerQuitChord = .l1r1l2r2 {
+    /// gamepad. Defaults to L3 + R3 (click both sticks): native on every pad (no
+    /// Create/Share/Mute, which macOS drops on a DualSense), and - unlike a
+    /// shoulder+trigger chord - its partials don't leak a host combo as you press
+    /// in (L1+R1+L2+R2 assembles through LB+RB+LT, which Steam Big Picture reads
+    /// as Show-Keyboard). The 400ms dwell guards a mid-game trip; "None" disables.
+    var controllerQuitChord: ControllerQuitChord = .l3r3 {
         didSet {
             UserDefaults.standard.set(controllerQuitChord.rawValue, forKey: "controllerQuitChord")
         }

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -663,7 +663,6 @@ extension StreamSession {
 /// 4Hz overlay ticks. MainActor-isolated: only ever touched from the timer body.
 @MainActor
 private final class PerceivedHitchBox {
-    private var prevStale: UInt64 = 0
     private var prevLate: UInt64 = 0
     private var prevTime: CFTimeInterval = 0
     private var firstTime: CFTimeInterval = 0
@@ -673,24 +672,17 @@ private final class PerceivedHitchBox {
     /// the instant a game starts. ~6s covers the launch transient.
     private let graceSeconds: CFTimeInterval = 6.0
 
-    /// True when the PRESENT path is hitching enough to feel. Fires on real frame
-    /// loss (render-gap / late-drops) or JUDDER (presents landing off the ideal
-    /// grid). It deliberately does NOT key on the raw stale-repeat count: when
-    /// content fps < refresh, a panel re-shows each frame to fill idle vsyncs
-    /// (~102/s at 129fps on 240Hz) - that's by design, not a hitch. The banner's
-    /// leaky integrator debounces flaps; deltas guard a reconnect reset.
+    /// True when the PRESENT path is dropping frames the user would feel - keyed
+    /// ONLY on unambiguous loss (render-gap + late-drops). NOT on stale-repeats
+    /// or cadence error: at content fps < refresh the panel re-shows frames to
+    /// fill idle vsyncs (smooth by design) and cadence tracks the vsync grid, so
+    /// both mis-fire. The banner's leaky integrator debounces; delta guards a reset.
     func perceivedHitch(snap: StreamStatsSnapshot) -> Bool {
         let now = CACurrentMediaTime()
         if firstTime == 0 { firstTime = now }
         let dt = prevTime > 0 ? now - prevTime : 0.25
         prevTime = now
 
-        // Advance the rate baselines every tick (incl. during the grace) so the
-        // first post-grace delta isn't a spurious spike. staleRate feeds the
-        // present-tick estimate below (rendered + stale fills), not a fire term.
-        let stale = TelemetryCounters.shared.staleFrameRepeatTotal.value
-        let staleRate = (dt > 0 && stale >= prevStale) ? Double(stale - prevStale) / dt : 0
-        prevStale = stale
         let late = snap.presentationLateDrops ?? 0
         let lateRate = (dt > 0 && late >= prevLate) ? Double(late - prevLate) / dt : 0
         prevLate = late
@@ -704,14 +696,6 @@ private final class PerceivedHitchBox {
         }
         // Late drops.
         if lateRate > 12.0 { hitch = true }
-        // Judder: average present landing more than one present-tick off the PTS
-        // grid. Refresh-aware (the tick interval scales with the realized present
-        // rate), so a smooth stream sits well under it at any fps-vs-refresh ratio.
-        if let cad = snap.avgPresentCadenceErrorMs, let rendered = snap.renderedFps {
-            let presentRate = rendered + staleRate
-            let tickMs = presentRate > 1 ? 1000.0 / presentRate : 8.3
-            if cad > tickMs { hitch = true }
-        }
         return hitch
     }
 }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.40
-CURRENT_PROJECT_VERSION = 20260651
+MARKETING_VERSION = 2026.6.41
+CURRENT_PROJECT_VERSION = 20260652


### PR DESCRIPTION
Two user-reported bugs.

QUIT-CHORD: on Xbox the .l1r1l2r2 default 'brings up the on-screen keyboard' instead of quitting. Root cause (workflow-verified): the full chord IS suppressed (ControllerForwarder.swift:445 returns false), but as the user PRESSES INTO it the partial combo (LB -> LB+RB -> LB+RB+LT) leaks to the host every frame until all four cross threshold; Steam Big Picture reads that shoulder+trigger combo as Show-Keyboard. Can't mask those buttons (core gameplay). FIX: default chord -> .l3r3 (stick clicks) - already fully implemented, GC-native on every pad (no raw-HID), and its only partial (one stick click) collides with nothing. .l1r1l2r2 stays selectable.

BADGE: 'Stream stuttering' still too sensitive (fired constantly at 4K 240 where the pipeline is verified clean - host encodes ~129fps, the 240Hz panel repeats frames to fill idle vsyncs). The .39 cadence-error judder term over-fired. FIX: drop the cadence + stale terms; the pill now keys ONLY on unambiguous loss (render-gap>0.18, late-drops>12/s). Conservative interim - a calibrated judder term can be re-added against live data. Build + 156 tests green.