### PR TITLE
fix(audio): audio dies on reconnect - reset isShutdown on re-init (2026.6.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.6.42 - 2026-06-26
+
+Fixes audio dying after a mid-stream reconnect. When the stream silently
+reconnected (a network blip - e.g. waking on a different Wi-Fi network - drops
+and re-establishes the connection underneath you), the audio decoder's shutdown
+flag was set during teardown and never cleared on the rebuild, so audio came
+back muted: the picture resumed but sound didn't, with packets arriving and
+nowhere to play. The flag is now reset on every rebuild, the audio graph
+re-initializes cleanly, and a new diagnostic surfaces a silent-audio state at a
+glance.
+
 ## 2026.6.41 - 2026-06-25
 
 Two controller/overlay fixes.

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -435,6 +435,7 @@ extension AudioDecoder {
         let anchorFramesPlayed = driftAnchorFramesPlayed
         let playedFrames = framesPlayed
         let rePrimes = rePrimeCount
+        let engineUp = engineRunning
         // The adaptive cushion target rides the same gauge: its VALUE only moves
         // on the cold grow/decay edges, but carrying it here (one load under the
         // lock already held) is what lets every exported row judge fill AGAINST
@@ -490,7 +491,10 @@ extension AudioDecoder {
                 rePrimeTotal: rePrimes,
                 // The resampler's applied rate offset (read on this same ~4Hz single-
                 // caller path, no extra lock) - makes the loop visible vs av_skew noise.
-                resamplerPpm: resamplerEpsPpm))
+                resamplerPpm: resamplerEpsPpm,
+                // Engine-running mirror: 1 = AVAudioEngine up. Catches the post-
+                // reconnect "packets flow but playout dead" latch in one query.
+                engineRunning: engineUp))
     }
 
     // MARK: - Audio OUTPUT route (under-run attribution breadcrumbs)

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -133,6 +133,11 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `isShutdown`; this flag is its only honest view of teardown. Guarded by
     /// `audioMeterLock`.
     var meterShutdown = false
+    /// Mirror of `engine.isRunning` for the `glimmer_audio_engine_running` gauge,
+    /// set under `audioMeterLock` at engine start (initDecoderCore) and cleared in
+    /// shutdown() - so the meter thread reads engine state without touching AVAudio
+    /// off-thread. Proves "packets arriving but playout dead" at a glance.
+    var engineRunning = false
     /// True once at least one buffer has been scheduled (gates under-run detection
     /// so the initial empty state isn't an under-run).
     var playoutStarted = false
@@ -369,6 +374,13 @@ public final class AudioDecoder: @unchecked Sendable {
         driftAnchorNanos = 0; driftAnchorFramesPlayed = 0
         resamplerIntegralPpm = 0; resamplerEpsPpm = 0; varispeed.rate = 1.0
         playoutStarted = false; playoutDrained = false; meterShutdown = false
+        // FIX: clear the teardown latch on RE-init. A reconnect's stopConnection →
+        // shutdown() set `isShutdown = true` and nothing reset it, so post-reconnect
+        // every decoded frame was dropped by the decode guards (packets flow, playout
+        // dead). Re-init under the lock is the honest "this decoder is live again" edge.
+        if isShutdown { Diag.info("audio decoder re-init - isShutdown reset (reconnect)", "Stream.Audio") }
+        isShutdown = false
+        engineRunning = false
         // Cushion / pre-roll state for this session: start paused (no play() at
         // engine start), at the SEEDED adaptive target, re-prime count reset. (The
         // reset-on-read MIN-fill window lives in TelemetryCounters and is cleared by
@@ -448,8 +460,11 @@ public final class AudioDecoder: @unchecked Sendable {
                                 channelLayout: layout)
         inputFormat = fmt
 
-        engine.attach(playerNode)
-        engine.attach(varispeed)
+        // Idempotent on a reconnect re-init: a node already on this engine must not
+        // be re-attached (AVAudio faults on a double-attach). `node.engine == nil`
+        // is the "not attached" test.
+        if playerNode.engine == nil { engine.attach(playerNode) }
+        if varispeed.engine == nil { engine.attach(varispeed) }
         // playerNode → varispeed → mixer. The varispeed resamples the player's
         // output by `rate=1+ε` (driveResampler), pulling the player's buffers at
         // the consumption rate - so completion timing (framesPlayed) still tracks
@@ -464,11 +479,17 @@ public final class AudioDecoder: @unchecked Sendable {
             // so the player starts with headroom instead of on the under-run floor.
             // The node is scheduled-into while paused; `play()` then drains the
             // already-queued cushion gapless.
-            try engine.start()
+            // Only start when not already running (idempotent across a reconnect
+            // re-init that left the engine up).
+            if !engine.isRunning { try engine.start() }
         } catch {
             log.error("AVAudioEngine.start: \(error.localizedDescription)")
+            Diag.error("audio engine start FAILED: \(error.localizedDescription)", "Stream.Audio")
             return -1
         }
+        // Engine-running mirror for the telemetry gauge, set under the meter lock
+        // (read there by publishAudioState) - a plain Bool, no AVAudio call.
+        audioMeterLock.lock(); engineRunning = engine.isRunning; audioMeterLock.unlock()
         // Seed + track the audio OUTPUT route for the under-run breadcrumbs.
         // Installed only after the engine is up, so a failed init never leaves a
         // listener behind; `shutdown()` removes it.
@@ -490,6 +511,7 @@ public final class AudioDecoder: @unchecked Sendable {
         // permanent-pin class). Gate details: `meterCompleteOnePlayout`.
         audioMeterLock.lock()
         meterShutdown = true
+        engineRunning = false   // gauge mirror; a Bool, not an AVAudio call
         audioMeterLock.unlock()
         playerNode.stop()
         engine.stop()

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -494,6 +494,11 @@ final class TelemetryCounters: @unchecked Sendable {
         /// offset (~tens of ppm) - the direct view of the resampler holding the fill
         /// it's steering (vs the av_skew that bounces with video-side timing).
         var resamplerPpm: Double = 0
+        /// AVAudioEngine running mirror (1 = up). Set under the audio meter lock at
+        /// engine start/stop, so a reconnect that re-inits the decoder but fails to
+        /// bring the engine back reads 0 here while packets still flow - the direct
+        /// "playout dead" signal. nil before the engine first starts.
+        var engineRunning: Bool?
     }
     // Module-internal (not private) so the audio accessors in
     // TelemetryCounters+AudioGauges.swift can reach these (and the min-window

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -90,6 +90,7 @@ extension TelemetryExporter {
             audio.audioClockDriftMs = state.audioClockDriftMs
             audio.rePrimeTotal = state.rePrimeTotal
             audio.resamplerPpm = state.resamplerPpm
+            audio.engineRunning = state.engineRunning
         }
         // Windowed MIN buffer-fill: pulled (and reset) directly off its own
         // reset-on-read window so each tick's min covers only that window's troughs

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -40,6 +40,10 @@ extension TelemetryRenderer {
         builder.emit("glimmer_audio_fec_recovery_rate",
                      "Audio FEC-recovery rate this window (recovered/(recovered+accepted)).",
                      audio.fecRecoveryRate)
+        builder.emit("glimmer_audio_engine_running",
+                     "AVAudioEngine running (1 = up). 0 with packets still flowing is the "
+                     + "post-reconnect playout-dead signature (the isShutdown-latch fix).",
+                     audio.engineRunning.map { $0 ? 1.0 : 0.0 })
         builder.emit("glimmer_audio_buffer_fill_ms",
                      "Decoded audio buffered ahead of the playhead, ms (output buffer level).",
                      audio.bufferFillMs)

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -122,6 +122,7 @@ extension TelemetryRenderer {
         builder.add("audio_pkts_per_s", audio.packetsPerSecond)
         builder.add("audio_loss_rate", audio.lossRate)
         builder.add("audio_fec_recovery_rate", audio.fecRecoveryRate)
+        builder.add("audio_engine_running", audio.engineRunning.map { $0 ? 1.0 : 0.0 })
         builder.add("audio_buffer_fill_ms", audio.bufferFillMs)
         builder.add("audio_resampler_ppm", audio.resamplerPpm)
         builder.add("audio_buffer_fill_min_ms", audio.bufferFillMinMs)

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -326,6 +326,10 @@ struct AudioSnapshot: Sendable {
     /// clock offset (tens of ppm) when converged - the direct view of the loop
     /// holding the fill, vs the av_skew that bounces with video-side timing.
     var resamplerPpm: Double?
+    /// AVAudioEngine running (1 = up). 0 with packets still flowing is the
+    /// post-reconnect "playout dead" signature the isShutdown-latch fix targets.
+    /// nil before the engine first starts.
+    var engineRunning: Bool?
     /// Windowed MINIMUM buffer fill this tick (ms) - the trough of the
     /// scheduled-ahead backlog, reset-on-read. The 1Hz `bufferFillMs` gauge can
     /// miss the instantaneous low that precedes an under-run; this is the field that

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.41
-CURRENT_PROJECT_VERSION = 20260652
+MARKETING_VERSION = 2026.6.42
+CURRENT_PROJECT_VERSION = 20260653


### PR DESCRIPTION
PRIORITY bug from a wake-on-different-AP session. 'Audio never started' = audio DIED on the silent reconnect and never came back. The AudioDecoder is one persistent instance/session; reconnect teardown sets isShutdown=true (AudioDecoder.swift:504) but it was reset NOWHERE - so after re-init the decode guards (guard !isShutdown) drop every frame: packets flow (~200pps) but playout is dead. Telemetry-reproduced (buffer_fill vanishes exactly when reconnect_total ticks; the long session survived only by timing luck).

FIX: reset isShutdown=false in initDecoderCore under stateLock (setup path; +breadcrumb). Idempotent graph bring-up (attach guarded on engine==nil, start on !isRunning). New glimmer_audio_engine_running gauge - engine_running==0 while packets>0 is the 'playout dead after reconnect' signature, one query. No AVAudio call added to any completion/teardown path. Build + 156 tests green.