### PR TITLE
fix(audio): converge the wired cushion to base (~135ms latency) (2026.6.43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.6.43 - 2026-06-26
+
+Lowers standing audio latency on a clean wired link. Audio kept roughly 150ms
+more buffer than a good wired connection needs - around a quarter-second of
+avoidable lip-sync lag - because the buffer seeded deep whenever the network
+came up "unknown" (e.g. right after waking on a new network) and never converged
+back down. On a clean wired link whose clock is well-behaved, the buffer now
+walks down to a tight, low-latency depth; a link that's actually struggling
+(real underruns or large clock skew) keeps its deeper buffer untouched.
+
 ## 2026.6.42 - 2026-06-26
 
 Fixes audio dying after a mid-stream reconnect. When the stream silently

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -256,8 +256,15 @@ extension AudioDecoder {
                 .compactMap { readCushionMemory(key: cushionMemoryKey(host: host, link: $0)) }
                 .max { $0.targetMs < $1.targetMs }
             if let borrowed {
+                // COLD-SEED SANITY: an UNKNOWN link (probe dark on an AP switch) must
+                // not borrow the tunnel-depth of the deepest record - that cold-seeds a
+                // fresh wired session at ~200ms and welds the floor there. Cap the
+                // borrow to the WIRED cap so the unknown bring-up starts in the wired
+                // region; resolveCushionLink re-keys to the real link's record after.
+                let cap = playoutCushionMaxMs
                 return CushionSeed(key: key, host: host, link: link,
-                                   targetMs: borrowed.targetMs, floorMs: borrowed.floorMs,
+                                   targetMs: min(borrowed.targetMs, cap),
+                                   floorMs: min(borrowed.floorMs, cap),
                                    fromMemory: true)
             }
         }
@@ -333,7 +340,12 @@ extension AudioDecoder {
                 // the ~10min floor clock (skew under-runs keep re-arming it, so it
                 // never releases). Same quiet window + near-miss evidence the target
                 // decay uses; wifi/tunnel/unknown keep the slow clock untouched.
-                if EnvSignalController.shared.streamLink == "wired" {
+                // GATE (Change 3): only release while the resampler is CARRYING the
+                // skew (|integral| + drift bounded). If it's railing, the standing
+                // skew is draining the cushion - that depth is load-bearing, so hold
+                // it and let the slow floor clock govern as before.
+                if EnvSignalController.shared.streamLink == "wired",
+                   resamplerSkewConverged {
                     learnedFloorMs = max(learnedFloorMs - Self.playoutCushionStepMs,
                                          Self.playoutCushionBaseMs)
                     playoutTargetMs = max(candidate, Self.playoutCushionBaseMs)
@@ -451,6 +463,20 @@ extension AudioDecoder {
         playoutTargetMs = max(Self.playoutCushionBaseMs,
                               min(playoutTargetMs, effectiveCushionMaxMs))
         learnedFloorMs = min(learnedFloorMs, effectiveCushionMaxMs)
+        // CONFIRMED-WIRED FLOOR DROP (gated): the min()-with-cap above only lowers to
+        // the wired CEILING (150); a session that cold-seeded deep under the unknown
+        // window (probe dark on an AP switch) then welded the floor into that ceiling
+        // via skew under-runs lands here with a ~150ms floor it never EARNED on wire.
+        // With NO real under-run evidence this session, that borrowed depth is
+        // unproven on this link - drop the floor to base NOW (the wired region) so the
+        // ladder re-earns real depth instead of holding a quarter-second of borrowed
+        // lag until the next session's read-time weld repair. A floor already at/under
+        // base is unchanged; real evidence (cushionHadUnderrun) is left untouched.
+        // GATE (Change 3): only when the resampler is carrying the skew - if it's
+        // railing, the deep cushion is LOAD-BEARING and the existing behavior stands.
+        if link == "wired", resamplerSkewConverged, !cushionHadUnderrun {
+            learnedFloorMs = min(learnedFloorMs, Self.playoutCushionBaseMs)
+        }
         let target = playoutTargetMs
         let floor = learnedFloorMs
         let cap = effectiveCushionMaxMs

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -479,6 +479,16 @@ extension AudioDecoder {
                 driftMs = wallElapsedMs - mediaPlayedMs - bufferFillMs
             }
         }
+        // MIRROR the resampler-converged verdict into the meter-lock domain so the
+        // cushion shallow-release (completion thread, under the lock) reads it safely
+        // instead of touching this lockless publish-path state. Converged = the loop
+        // is carrying the skew within its real envelope (|integral| bounded AND drift
+        // bounded, or drift not yet measured). Railing ⇒ deep cushion is load-bearing.
+        let driftBounded = driftMs.map { abs($0) <= Self.cushionReleaseDriftBoundMs } ?? true
+        let converged = abs(resamplerIntegralPpm) <= Self.cushionReleaseSkewPpm && driftBounded
+        audioMeterLock.lock()
+        resamplerSkewConverged = converged
+        audioMeterLock.unlock()
         TelemetryCounters.shared.setAudioState(
             TelemetryCounters.AudioState(
                 bufferFillMs: bufferFillMs,

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -109,6 +109,13 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `driveResampler`) fires per decoded packet (~200Hz), so the loop rate-limits
     /// itself to ~4Hz off this; drift is ppm-slow and a fast loop only adds noise.
     var lastResamplerUpdateNanos: UInt64 = 0
+    /// METER-LOCK MIRROR of "the resampler is carrying the skew within its real
+    /// envelope" - |integral ppm| <= bound AND clock drift bounded. The resampler PI
+    /// state lives lockless on the publish path, so the cushion SHALLOW-RELEASE (the
+    /// wired floor/target drop) can't read it directly off the completion thread;
+    /// `publishAudioState` snapshots this Bool under the lock. False (railing skew) ⇒
+    /// the deep cushion is LOAD-BEARING ⇒ leave it alone. Guarded by `audioMeterLock`.
+    var resamplerSkewConverged = false
     /// Drift-resampler PI tuning. Conservative starting values: the SLEW limit and the
     /// BOUND are the safety guards (the varispeed rate can never step audibly nor run
     /// away), so the gains can be tuned up in an A/B with no warble risk. The drift to
@@ -124,6 +131,17 @@ public final class AudioDecoder: @unchecked Sendable {
     /// drain, so keep most of it (slow ×0.97 bleed only while packets flow) and
     /// re-engage with it already learned rather than re-converging from 0.
     static let resamplerIntegralHoldFactor = 0.97
+    /// SHALLOW-RELEASE gate: the |integral ppm| ceiling under which the resampler is
+    /// deemed to be CARRYING the skew (not railing), so the wired cushion may converge.
+    /// Real host skews seen ~450ppm; above ~500 the loop is at/near its rail and the
+    /// deep cushion is load-bearing - leave it. (`resamplerBoundPpm` 1500 is the rate
+    /// guard; this lower 500 is the "within real envelope" line.)
+    static let cushionReleaseSkewPpm = 500.0
+    /// SHALLOW-RELEASE gate: the |audio clock drift ms| ceiling under which drift is
+    /// "bounded". A converged link reads ~0; a railing resampler sawtooths to -90..-140ms
+    /// extremes. 60ms sits clear of converged noise yet well under the rail. Drift
+    /// UNKNOWN (pre-anchor) counts as bounded - the ppm gate alone then governs.
+    static let cushionReleaseDriftBoundMs = 60.0
     /// Mirror of `isShutdown` in the METER lock's domain, raised by `shutdown()`
     /// BEFORE `playerNode.stop()`. Stopping a node with a standing cushion fires
     /// the completion handler of EVERY queued buffer (.dataConsumed semantics:

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.42
-CURRENT_PROJECT_VERSION = 20260653
+MARKETING_VERSION = 2026.6.43
+CURRENT_PROJECT_VERSION = 20260654


### PR DESCRIPTION
Biggest felt-latency win in the p100 pass. On a clean wired link the audio cushion stood at ~200ms and never converged to the ~30ms base (the base is already near-floor + never reached - lowering it is the wrong lever). It cold-seeded ~209ms when the route came up 'unknown' (probe dark on an AP switch -> tunnel cap) borrowing the deepest record, and the floor only re-clamped at read-time on the NEXT session.

FIX (pure arithmetic on meter-lock cushion-policy fields; ZERO AVAudio calls): (1) cold-seed cap - an unknown-link bring-up caps target+floor to the wired cap, no tunnel-depth seed. (2) confirmed-wired resolve drops a borrowed/welded floor to base immediately. (3) the wired floor+target release is GATED on resamplerSkewConverged (|integral|<=500ppm + drift<=60ms, snapshotted under audioMeterLock) AND no real underruns - so a railing/skewed or lossy link KEEPS its deep cushion (load-bearing). On the actual wake event (resampler railing) it correctly stays deep; only a genuinely-clean wired link drains ~200->~50ms.

Needs a live clean-wired retest: buffer_fill_min/playout_target drop toward ~50-60ms with underrun_total FLAT. Build + 156 tests green.