### PR TITLE
feat(resilience): wake-from-sleep fast reconnect (2026.6.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.6.44 - 2026-06-26
+
+Recovers fast when you wake the Mac mid-stream. Before, waking on a different
+Wi-Fi network left the stream's connection stale with no wake handling at all -
+and because the dead-connection timer pauses during sleep, recovery didn't even
+start for ~10 seconds (the black-screen hang). Now, on wake, the app immediately
+re-checks the link and - if the connection has gone silent - reconnects in place
+within about two seconds instead of waiting it out. A healthy wake on the same
+network is untouched.
+
 ## 2026.6.43 - 2026-06-26
 
 Lowers standing audio latency on a clean wired link. Audio kept roughly 150ms

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		D1000F10 /* TelemetryLatency+Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000F11 /* TelemetryLatency+Trace.swift */; };
 		D1000FA0 /* TelemetryLatency+Composites.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000FA1 /* TelemetryLatency+Composites.swift */; };
 		D1000FB1 /* StreamSession+Reconnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000FB0 /* StreamSession+Reconnect.swift */; };
+		D1000FC1 /* StreamSession+Wake.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000FC0 /* StreamSession+Wake.swift */; };
 		D1A00002 /* MoonlightManager+HostRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A00001 /* MoonlightManager+HostRoute.swift */; };
 		D1A00004 /* MoonlightManager+SessionReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A00003 /* MoonlightManager+SessionReceipt.swift */; };
 		D2000021 /* EnetWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000020 /* EnetWireTests.swift */; };
@@ -401,6 +402,7 @@
 		D1000F11 /* TelemetryLatency+Trace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/TelemetryLatency+Trace.swift"; sourceTree = "<group>"; };
 		D1000FA1 /* TelemetryLatency+Composites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/TelemetryLatency+Composites.swift"; sourceTree = "<group>"; };
 		D1000FB0 /* StreamSession+Reconnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamSession+Reconnect.swift"; sourceTree = "<group>"; };
+		D1000FC0 /* StreamSession+Wake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamSession+Wake.swift"; sourceTree = "<group>"; };
 		D1A00001 /* MoonlightManager+HostRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoonlightManager+HostRoute.swift"; sourceTree = "<group>"; };
 		D1A00003 /* MoonlightManager+SessionReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoonlightManager+SessionReceipt.swift"; sourceTree = "<group>"; };
 		D2000019 /* GlimmerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlimmerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -567,6 +569,7 @@
 				D1000B74 /* StreamSession+StartSetup.swift */,
 				D1000047 /* StreamSession+Watchdog.swift */,
 				D1000FB0 /* StreamSession+Reconnect.swift */,
+				D1000FC0 /* StreamSession+Wake.swift */,
 				D1000B04 /* StreamSession+PresentTrip.swift */,
 				D10000A2 /* StreamSession+PresentMetric.swift */,
 				D1000080 /* TelemetryExporter.swift */,
@@ -898,6 +901,7 @@
 				D1000B73 /* StreamSession+StartSetup.swift in Sources */,
 				D1000048 /* StreamSession+Watchdog.swift in Sources */,
 				D1000FB1 /* StreamSession+Reconnect.swift in Sources */,
+				D1000FC1 /* StreamSession+Wake.swift in Sources */,
 				D1000B03 /* StreamSession+PresentTrip.swift in Sources */,
 				D10000A1 /* StreamSession+PresentMetric.swift in Sources */,
 				D1000081 /* TelemetryExporter.swift in Sources */,

--- a/Glimmer/Stream/Native/EnetControlChannel+ControlLoop.swift
+++ b/Glimmer/Stream/Native/EnetControlChannel+ControlLoop.swift
@@ -177,6 +177,17 @@ extension EnetControlChannel {
         }
     }
 
+    /// WAKE re-anchor + solicited ping. The dead-peer clock (`lastAckRecvMs`) is
+    /// the service clock, which PAUSES during system sleep, so a post-sleep
+    /// `sinceLastAck` measures from before the nap and would falsely read fresh.
+    /// Re-anchor it to NOW so the silence probe measures awake-silence-from-wake,
+    /// then send an immediate transport ping to solicit a fresh ACK.
+    func reanchorAckAndPing() {
+        withState { lastAckRecvMs = serviceTimeMs }
+        guard !interrupted.isSet, !withState({ disconnected }) else { return }
+        sendEnetPing()
+    }
+
     /// (B) Transport ENet PING (enet_peer_ping, peer.c:446): command
     /// PING|FLAG_ACKNOWLEDGE = 0x85, channel 0xFF, peer-counter relSeq, empty
     /// body. RELIABLE - tracked in sentReliable for ACK/retransmit.

--- a/Glimmer/Stream/NativeBackend+Input.swift
+++ b/Glimmer/Stream/NativeBackend+Input.swift
@@ -25,6 +25,10 @@ extension NativeBackend {
         withState { enetChannel }?.requestIdrFrame()
     }
 
+    public func wakeReanchorAndPing() {
+        withState { enetChannel }?.reanchorAckAndPing()
+    }
+
     public func hdrMetadata() -> HdrMetadata? { withState { enetChannel }?.hdrMetadata() }
 
     public func launchUrlQueryParameters() -> String { "" }

--- a/Glimmer/Stream/StreamSession+Lifecycle.swift
+++ b/Glimmer/Stream/StreamSession+Lifecycle.swift
@@ -48,6 +48,11 @@ extension StreamSession {
         stopInProgress = true
         isStreaming = false
 
+        // Remove the sleep/wake observers + cancel any in-flight wake probe FIRST,
+        // so a wake landing mid-teardown can't arm a probe against a dying session
+        // (the probe also re-checks the lifecycle flags, but this is the clean cut).
+        teardownWakeObservers()
+
         log.info("Stream session stopping (cause=\(cause.label, privacy: .public))")
         Diag.notice("Stream session stopping (cause: \(cause.label))", "Stream")
 

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -476,5 +476,10 @@ extension StreamSession {
         guard isStreaming, !stopInProgress else { return }
         // `host` label = the Sunshine server, latched at the connect anchor.
         startTelemetryExporter(decoder: decoder, serverName: telemetryServerName)
+
+        // Arm the sleep/wake fast-reconnect observers now the stream is live;
+        // torn down in stop(). Only armed during a live stream (see +Wake).
+        guard isStreaming, !stopInProgress else { return }
+        armWakeObservers()
     }
 }

--- a/Glimmer/Stream/StreamSession+Wake.swift
+++ b/Glimmer/Stream/StreamSession+Wake.swift
@@ -1,0 +1,113 @@
+//
+//  StreamSession+Wake.swift
+//
+//  WAKE RESILIENCE. Waking the Mac on a different Wi-Fi AP leaves a live stream's
+//  connection stale, and the ENet dead-peer envelope measures silence from the
+//  monotonic service clock - which PAUSES during sleep - so post-wake a fresh
+//  ~10s of AWAKE silence would have to elapse before recovery even starts (a
+//  ~10-12s black hang). We hook NSWorkspace wake: re-anchor the silence baseline
+//  to NOW, solicit a fresh ACK, and run a BOUNDED liveness probe. If the peer is
+//  silent within the budget we drive the EXISTING silent-reconnect episode
+//  immediately via `handleHostTerminate(deadPeerTerminationCode)` instead of
+//  waiting out the 10s envelope. We do NOT shorten that envelope (it protects
+//  recoverable blips) and we do NOT write a new reconnect/teardown - everything
+//  routes through the proven path, whose isStreaming/!stopInProgress/!isReconnecting
+//  guards collapse a concurrent real dead-peer terminate + this wake terminate
+//  into one episode.
+//
+
+import Foundation
+import AppKit
+
+extension StreamSession {
+
+    /// Arm the sleep/wake observers for the LIVE session. Called once the stream
+    /// is up (StreamSession+Start). On NSWorkspace's OWN notification center, not
+    /// the default - sleep/wake live there. Removed in `stop()`.
+    func armWakeObservers() {
+        let wsnc = NSWorkspace.shared.notificationCenter
+        wakeObservers.append(wsnc.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.handleSystemWake() }
+        })
+        wakeObservers.append(wsnc.addObserver(
+            forName: NSWorkspace.willSleepNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.handleSystemWillSleep() }
+        })
+    }
+
+    /// Remove the sleep/wake observers and cancel any in-flight probe. Called from
+    /// `stop()`; idempotent (a second call sees an empty list / nil task).
+    func teardownWakeObservers() {
+        let wsnc = NSWorkspace.shared.notificationCenter
+        for token in wakeObservers { wsnc.removeObserver(token) }
+        wakeObservers.removeAll()
+        wakeProbeTask?.cancel()
+        wakeProbeTask = nil
+    }
+
+    /// On willSleep, stamp the session wake-suspect so a disconnect that surfaces
+    /// across the nap with no more specific cause is attributed to system sleep
+    /// (the latch keeps the FIRST concrete reason, so a host terminate still wins).
+    func handleSystemWillSleep() async {
+        guard isStreaming, !stopInProgress else { return }
+        noteTelemetryDisconnect(.systemSleep)
+    }
+
+    /// On wake: if the session is live and idle of any teardown/episode, count the
+    /// wake, re-anchor the silence clock + solicit a ping, and start the bounded
+    /// liveness probe. Everything downstream routes through `handleHostTerminate`.
+    func handleSystemWake() async {
+        guard isStreaming, reachedLiveState, !stopInProgress, !isReconnecting else { return }
+        TelemetryCounters.shared.wakeTotal.increment()
+        Diag.notice("Woke from sleep mid-stream - re-anchoring the dead-peer clock "
+            + "and probing the link (it may be stale on a new AP).", "Stream")
+
+        // (a)+(b) Solicit a fresh ACK AND re-anchor the dead-peer silence baseline
+        // to NOW (the clock paused during sleep). One backend call into the live
+        // control channel.
+        backend.wakeReanchorAndPing()
+
+        // (c) Bounded liveness probe: budget = max(750ms, N·RTT). If the peer is
+        // still silent after the budget, drive the existing reconnect episode now.
+        startWakeProbe()
+    }
+
+    /// Start (replacing any prior) the bounded probe Task. After the RTT-relative
+    /// budget it hops to the actor and checks ENet liveness once: if the peer has
+    /// NOT ACKed since the wake re-anchor (silence ≥ budget), it self-terminates
+    /// through the EXISTING dead-peer path. The guards in `handleHostTerminate`
+    /// make a concurrent real terminate + this one collapse to a single episode.
+    private func startWakeProbe() {
+        wakeProbeTask?.cancel()
+        let rtt = backend.estimatedRtt()?.rttMs ?? Double(Self.wakeProbeFloorMs)
+        let budgetMs = max(Self.wakeProbeFloorMs,
+                           UInt64(Double(Self.wakeProbeRttMultiple) * rtt))
+        wakeProbeTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: budgetMs * 1_000_000)
+            guard !Task.isCancelled, let self else { return }
+            await self.finishWakeProbe(budgetMs: budgetMs)
+        }
+    }
+
+    /// Probe verdict: if the link is still silent past the budget (no fresh ACK
+    /// since the wake re-anchor), the post-wake pipe is stale - terminate through
+    /// the existing reconnect path. Re-check the lifecycle flags first (an episode
+    /// may already be running, in which case `handleHostTerminate` no-ops anyway).
+    private func finishWakeProbe(budgetMs: UInt64) async {
+        wakeProbeTask = nil
+        guard isStreaming, reachedLiveState, !stopInProgress, !isReconnecting else { return }
+        // sinceLastAck is measured from the wake re-anchor (handleSystemWake reset
+        // it to NOW), so silence ≥ budget means the peer never answered the probe.
+        guard let health = backend.enetHealth() else { return }
+        if UInt64(health.sinceLastAckMs) >= budgetMs {
+            Diag.notice("Wake probe: no ACK in \(health.sinceLastAckMs)ms (budget "
+                + "\(budgetMs)ms) - link is stale, reconnecting in place.", "Stream")
+            await handleHostTerminate(code: Self.deadPeerTerminationCode)
+        }
+    }
+}

--- a/Glimmer/Stream/StreamSession.swift
+++ b/Glimmer/Stream/StreamSession.swift
@@ -248,6 +248,19 @@ public actor StreamSession {
     var reconnectConfig: StreamConfig?
     var reconnectAppID: Int?
 
+    // MARK: - Wake resilience (sleep/wake fast-reconnect - see +Wake)
+
+    /// NSWorkspace sleep/wake observer tokens, armed when a stream goes live and
+    /// removed in `stop()`. On the workspace notification center (NOT default).
+    var wakeObservers: [NSObjectProtocol] = []
+    /// The bounded post-wake liveness probe (one Task). Cancelled when it
+    /// completes, on stop, and before a new wake re-arms it. Actor-isolated: every
+    /// access (arm/cancel/nil) is on the session actor.
+    var wakeProbeTask: Task<Void, Never>?
+    /// Probe budget multiple of RTT, floored: budget = max(750ms, N·RTT).
+    static let wakeProbeRttMultiple = 4
+    static let wakeProbeFloorMs: UInt64 = 750
+
     /// Present-path self-heal watchdog. Runs at 20 Hz on the main run loop,
     /// INDEPENDENT of the decode-output watchdog above (which is structurally
     /// blind to a stall downstream of VT - a stopped CADisplayLink or a

--- a/Glimmer/Stream/StreamingBackend.swift
+++ b/Glimmer/Stream/StreamingBackend.swift
@@ -392,6 +392,11 @@ public protocol StreamingBackend: AnyObject, Sendable {
     /// has no control channel up. Surfaced ONLY by the opt-in telemetry
     /// exporter; the protocol default returns nil.
     func enetHealth() -> (sentReliable: Int, oldestUnackedMs: UInt32, sinceLastAckMs: UInt32)?
+    /// Re-anchor the ENet dead-peer silence clock to NOW and send an immediate
+    /// solicited ping. Called on wake-from-sleep: the silence clock paused during
+    /// the nap, so without this a post-wake probe reads false-fresh. No-op when
+    /// the backend has no control channel up; the protocol default is a no-op.
+    func wakeReanchorAndPing()
     /// = LiRequestIdrFrame.
     func requestIdrFrame()
     /// Host HDR10 mastering metadata. nil when unavailable.
@@ -434,6 +439,9 @@ public extension StreamingBackend {
     /// control channel (NativeBackend) override this; a future C backend would
     /// inherit nil rather than be forced to fabricate the numbers.
     func enetHealth() -> (sentReliable: Int, oldestUnackedMs: UInt32, sinceLastAckMs: UInt32)? { nil }
+
+    /// Default: no control channel to re-anchor/ping. NativeBackend overrides this.
+    func wakeReanchorAndPing() {}
 
     /// Default async connect: run blocking `startConnection` on a detached task so
     /// the caller isn't parked; cancelling interrupts the in-flight connect. The

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -174,6 +174,11 @@ final class TelemetryCounters: @unchecked Sendable {
     /// re-establishes its connection after a drop within the same run. The
     /// climb-then-recover pattern that a single "connected" gauge can't show.
     let reconnectTotal = Counter()
+    /// WAKE count (signal: lifecycle): incremented each time the Mac wakes from
+    /// sleep while a stream is live. Run-global (NOT reset per session, like
+    /// `reconnectTotal`); a climb here that precedes a reconnect/disconnect marks
+    /// the wake-on-different-AP stale-link case.
+    let wakeTotal = Counter()
     /// EXPLICIT REQUEST_IDR sends that started a round-trip measurement
     /// (signal: IDR-RTT). RE-BASELINE NOTE: RFI sends no longer arm round-trips
     /// (they ride `rfiTotal`) - conflating them made the pair unreadable (RFI

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -131,6 +131,7 @@ extension TelemetryExporter {
         }
 
         snap.reconnectTotal = counters.reconnectTotal.value
+        snap.wakeTotal = counters.wakeTotal.value
         snap.disconnectReason = p2.disconnectReason
         // Process-global per-reason totals (survive session resets) - the durable
         // record the per-session ordinal can't carry past the <1ms exporter teardown.

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -93,6 +93,7 @@ extension TelemetryRenderer {
             builder.add("handshake_total_ms", handshake.totalMs)
         }
         builder.addCount("reconnect_total", snap.reconnectTotal)
+        builder.addCount("wake_total", snap.wakeTotal)
         builder.addInt("disconnect_reason", snap.disconnectReason.rawValue)
         builder.addString("disconnect_reason_label", snap.disconnectReason.label)
         if let idr = snap.idrRoundTrip {

--- a/Glimmer/Stream/TelemetryExporter+RenderP2.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderP2.swift
@@ -65,9 +65,12 @@ extension TelemetryRenderer {
         builder.emitCounter("glimmer_reconnect_total",
                             "Reconnects this run (a connection re-established after a drop).",
                             snap.reconnectTotal)
+        builder.emitCounter("glimmer_wake_total",
+                            "Wakes from sleep this run while a stream was live.",
+                            snap.wakeTotal)
         builder.emit("glimmer_disconnect_reason",
                      "Disconnect reason ordinal (0 none, 1 user, 2 host-clean, 3 host-error, "
-                     + "4 watchdog-stall, 5 connect-failed).",
+                     + "4 watchdog-stall, 5 connect-failed, 6 consumer-dropped, 7 system-sleep).",
                      Double(snap.disconnectReason.rawValue))
         builder.emitInfo("glimmer_disconnect_reason_info",
                          "Disconnect reason as a label (value always 1).",

--- a/Glimmer/Stream/TelemetrySessionEvents.swift
+++ b/Glimmer/Stream/TelemetrySessionEvents.swift
@@ -68,6 +68,11 @@ enum DisconnectReason: Int, Sendable {
     /// behaviour masked exactly this case (a dropped consumer reading as
     /// "user_stopped" in the scorecard).
     case consumerDropped = 6
+    /// The Mac woke from sleep and the link was stale (e.g. woke on a different
+    /// Wi-Fi AP); the wake fast-reconnect probe found the peer gone. Stamped
+    /// wake-suspect on willSleep, attributed if the next disconnect has no more
+    /// specific cause.
+    case systemSleep = 7
 
     var label: String {
         switch self {
@@ -78,6 +83,7 @@ enum DisconnectReason: Int, Sendable {
         case .watchdogStall: return "watchdog_stall"
         case .connectFailed: return "connect_failed"
         case .consumerDropped: return "consumer_dropped"
+        case .systemSleep: return "system_sleep"
         }
     }
 }
@@ -93,7 +99,8 @@ enum DisconnectReason: Int, Sendable {
 final class DisconnectReasonCounters: @unchecked Sendable {
     private let counters: [DisconnectReason: TelemetryCounters.Counter] = [
         .userStopped: .init(), .hostClosedClean: .init(), .hostError: .init(),
-        .watchdogStall: .init(), .connectFailed: .init(), .consumerDropped: .init()
+        .watchdogStall: .init(), .connectFailed: .init(), .consumerDropped: .init(),
+        .systemSleep: .init()
     ]
     func increment(_ reason: DisconnectReason) { counters[reason]?.increment() }
     /// Snapshot of (label, total) for every non-zero-defined reason, for the export.

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -413,6 +413,7 @@ struct SessionReport {
             "\"disconnect_reason\":\(reason.rawValue)",
             "\"disconnect_reason_label\":\"\(reason.label)\"",
             "\"reconnects\":\(counters.reconnectTotal.value)",
+            "\"wakes\":\(counters.wakeTotal.value)",
             "\"idr_round_trip_requests\":\(counters.idrRoundTripRequestTotal.value)",
             "\"idr_round_trip_matched\":\(counters.idrRoundTripMatchedTotal.value)"
         ]
@@ -562,6 +563,7 @@ struct SessionReport {
             // P2 session tallies: the run's reconnect count + the corruption/
             // artifact heuristic total (the white/purple-flash-class tally).
             ("reconnect", counters.reconnectTotal.value),
+            ("wake", counters.wakeTotal.value),
             ("corruption_heuristic", counters.corruptionHeuristicTotal.value)
         ]
         let entries = pairs.map { "\"\($0.0)\":\($0.1)" }

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -277,6 +277,8 @@ struct TelemetrySnapshot: Sendable {
     var handshake: HandshakeBreakdown?
     /// Reconnect count this run (monotonic) - a second-or-later established edge.
     var reconnectTotal: UInt64 = 0
+    /// Wake-from-sleep count this run (monotonic) - wakes while a stream was live.
+    var wakeTotal: UInt64 = 0
     /// Latest disconnect reason (the live default is `.none` until a terminate).
     var disconnectReason: DisconnectReason = .none
     /// PROCESS-GLOBAL per-reason disconnect totals (label, total), monotonic and

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.43
-CURRENT_PROJECT_VERSION = 20260654
+MARKETING_VERSION = 2026.6.44
+CURRENT_PROJECT_VERSION = 20260655


### PR DESCRIPTION
Root-theme fix for the wake-on-different-AP event. There was NO sleep/wake hook on a live stream, and the ENet dead-peer envelope measures silence off the monotonic service clock which PAUSES during sleep - so post-wake a fresh ~10s of awake-silence had to elapse before recovery started (the ~10-12s black hang).

FIX (new StreamSession+Wake.swift): NSWorkspace didWake/willSleep observers armed for the live session (armSessionTimers) + torn down in stop(). On wake: re-anchor the dead-peer silence baseline to NOW (reanchorAckAndPing - the clock paused during sleep) + solicit a ping, then a bounded liveness probe (budget max(750ms, 4*RTT)). If the peer is still silent past the budget, drive the EXISTING silent-reconnect via handleHostTerminate(deadPeerTerminationCode) - resume in place in ~2s instead of ~12s. Reuses the proven path; its isStreaming/!stopInProgress/!isReconnecting guards collapse a concurrent real terminate + the wake terminate to ONE episode. A healthy wake (host ACKs the ping) is untouched - no spurious reconnect. The global ackSilenceDeadMs (10s) is unchanged.

Attribution: DisconnectReason.systemSleep + glimmer_wake_total. Scoped out (honest): the alive-but-degraded 'chug' over a changed route (peer still ACKs) - would need a fragile route reader on the session actor; deferred. Build + 156 tests green.