### PR TITLE
feat(telemetry): p100 instrumentation - launch sub-legs, route-change, input (2026.6.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.6.45 - 2026-06-26
+
+Under the hood: new diagnostics, no change to behavior. Breaks stream-launch
+time into its sub-steps (so a slow start is attributable to the right leg),
+counts network-route changes (e.g. waking on a new Wi-Fi network) and input-path
+backpressure, and adds a controller-delivery latency measure - making the next
+wake/launch hiccup a one-query diagnosis.
+
 ## 2026.6.44 - 2026-06-26
 
 Recovers fast when you wake the Mac mid-stream. Before, waking on a different

--- a/Glimmer/Stream/ControllerForwarder.swift
+++ b/Glimmer/Stream/ControllerForwarder.swift
@@ -610,6 +610,10 @@ extension InputForwarder {
         // GameController invokes this on the main queue; assume MainActor so
         // Swift 6 strict concurrency is satisfied.
         gamepad.extendedGamepad?.valueChangedHandler = { [weak self] (pad, _) in
+            // Stamp handler-entry FIRST (measurement-only): the batcher takes this
+            // to observe the pre-hop main-thread deliver→enqueue leg. No work moves.
+            InputDeliverStamp.shared.stamp(
+                slot: Int(slot), nanos: DispatchTime.now().uptimeNanoseconds)
             MainActor.assumeIsolated {
                 guard let self else { return }
                 self.sendGamepadUpdate(pad: pad, slot: slot)

--- a/Glimmer/Stream/Native/InputBatcher.swift
+++ b/Glimmer/Stream/Native/InputBatcher.swift
@@ -216,7 +216,11 @@ final class InputBatcher: @unchecked Sendable {
             }
             // Stamp the oldest unflushed state per slot (clean→dirty edge); a
             // superseding update in the same batch keeps the older stamp.
-            if !self.controllers[slot].dirty { self.controllers[slot].stamp = DispatchTime.now() }
+            let stampNow = DispatchTime.now()
+            if !self.controllers[slot].dirty { self.controllers[slot].stamp = stampNow }
+            // Observe the pre-hop deliver→enqueue leg (handler entry → here). Take
+            // is a no-op (returns 0) off the GameController path; measurement only.
+            self.observeInputDeliverAge(slot: slot, enqueued: stampNow)
             self.controllers[slot].num = num
             self.controllers[slot].mask = mask
             self.controllers[slot].buttons = safeButtons
@@ -356,7 +360,12 @@ final class InputBatcher: @unchecked Sendable {
     /// latest-state, so they must not drop.
     private func flushLocked() {
         guard let enet else { return }
-        if enet.sendBacklogged || enet.reliableBacklogged { return }
+        if enet.sendBacklogged || enet.reliableBacklogged {
+            // Telemetry: attribute the backpressure skip to which signal fired
+            // (the input p99 tail). Counter only - no behavior change.
+            countBackpressureSkip(enet)
+            return
+        }
 
         // Telemetry: count a flush only when this tick actually drains dirty
         // merged state to the wire (not the no-op ticks that dominate an idle
@@ -461,6 +470,29 @@ final class InputBatcher: @unchecked Sendable {
         guard let drainNow, let tracker, drainNow >= stamp else { return }
         let ageMs = Double(drainNow.uptimeNanoseconds &- stamp.uptimeNanoseconds) / 1_000_000.0
         tracker.inputLocalLatency.observe(ageMs)
+    }
+
+    /// Count a backpressure flush-skip, split by which signal fired (both when
+    /// both asserted). Counter-only telemetry; no behavior change.
+    private func countBackpressureSkip(_ enet: EnetControlChannel) {
+        if enet.sendBacklogged {
+            TelemetryCounters.shared.inputFlushSendBackloggedSkipTotal.increment()
+        }
+        if enet.reliableBacklogged {
+            TelemetryCounters.shared.inputFlushReliableBackloggedSkipTotal.increment()
+        }
+    }
+
+    /// Observe one slot's deliver→enqueue age (controller handler entry → this
+    /// enqueue) into the deliver histogram. ALWAYS takes the per-slot handler
+    /// stamp (clears it even when telemetry's off, so it can't go stale); a no-op
+    /// (0) off the GameController path. Observes only when the tracker exists.
+    private func observeInputDeliverAge(slot: Int, enqueued: DispatchTime) {
+        let entry = InputDeliverStamp.shared.take(slot: slot)
+        guard let tracker = FrameTimingTracker.shared,
+              entry != 0, enqueued.uptimeNanoseconds >= entry else { return }
+        tracker.inputDeliverLatency.observe(
+            Double(enqueued.uptimeNanoseconds &- entry) / 1_000_000.0)
     }
 
     /// Send the latest pending multiController for `slot` and clear its dirty

--- a/Glimmer/Stream/StreamSession+Lifecycle.swift
+++ b/Glimmer/Stream/StreamSession+Lifecycle.swift
@@ -233,6 +233,12 @@ extension StreamSession {
 
         func tryLaunch() async throws -> LaunchResponse {
             log.info("→ /launch (appID=\(appID))")
+            // Telemetry: stamp the /launch leg duration (launch sub-leg).
+            let t0 = Date().timeIntervalSinceReferenceDate
+            defer {
+                ConnectTimingTelemetry.shared.recordLaunchLeg(
+                    launchMs: (Date().timeIntervalSinceReferenceDate - t0) * 1000.0)
+            }
             return try await network.launch(appID: appID, config: config)
         }
 
@@ -247,9 +253,19 @@ extension StreamSession {
         // means the Do command from our subsequent /launch runs against a
         // settled state and wins.
         func waitForHostIdle(maxWait: TimeInterval) async {
-            let deadline = Date().addingTimeInterval(maxWait)
+            // Telemetry: time the whole busy-poll + count its /serverinfo polls so
+            // the up-to-5s wait is attributable (launch_busy_wait_ms / _poll_count).
+            let waitStart = Date()
+            var polls = 0
+            let deadline = waitStart.addingTimeInterval(maxWait)
+            defer {
+                ConnectTimingTelemetry.shared.recordLaunchLeg(
+                    launchBusyWaitMs: Date().timeIntervalSince(waitStart) * 1000.0,
+                    busyPollCount: polls)
+            }
             while Date() < deadline {
                 try? await Task.sleep(nanoseconds: 250_000_000)
+                polls += 1
                 if let info = try? await network.fetchServerInfo(),
                    info.currentGameID == 0 {
                     log.info("Host idle - Undo command completed")
@@ -261,7 +277,11 @@ extension StreamSession {
 
         func tryCancelThenLaunch() async throws -> LaunchResponse {
             log.info("→ /cancel then /launch (forced renegotiation)")
+            // Telemetry: stamp the /cancel leg duration (launch sub-leg).
+            let cancelStart = Date()
             try? await network.cancel()
+            ConnectTimingTelemetry.shared.recordLaunchLeg(
+                cancelMs: Date().timeIntervalSince(cancelStart) * 1000.0)
             // Sunshine's Undo command on Windows hosts can take 1-3s
             // (QRes.exe is synchronous; some user configs include a sleep
             // for display-driver settle time). 5s ceiling is generous but

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -97,7 +97,11 @@ extension StreamSession {
         // belt-and-braces overlap with stop() on the success / backend-failure
         // paths is harmless.
         defer { if !startHandedOff { shutdownOrphanedNetwork() } }
+        // Telemetry: stamp the /serverinfo leg (launch sub-leg, part of launch_path_ms).
+        let serverinfoStart = Date()
         serverInfo = try await network.fetchServerInfo()
+        ConnectTimingTelemetry.shared.recordLaunchLeg(
+            serverinfoMs: Date().timeIntervalSince(serverinfoStart) * 1000.0)
         // swiftlint:disable:next line_length
         log.info("fetchServerInfo done: pairStatus=\(String(describing: serverInfo.pairStatus), privacy: .public) currentGame=\(serverInfo.currentGameID) httpsPort=\(serverInfo.httpsPort) codecSupport=0x\(String(serverInfo.serverCodecSupport.rawValue, radix: 16))")
         if serverInfo.pairStatus != .paired {
@@ -137,6 +141,9 @@ extension StreamSession {
         // connection so the decoder's VideoSink has an
         // AVSampleBufferDisplayLayer to enqueue into the moment frames
         // start arriving.
+        // Telemetry: stamp the MainActor subsystem/window build leg, isolating it
+        // from the launch network legs above (build_ms).
+        let buildStart = Date()
         let setup: (StreamWindow, InputForwarder, VideoDecoder) =
             await buildStreamSubsystems(StreamSetupOptions(
                 config: config,
@@ -148,6 +155,8 @@ extension StreamSession {
                 controllerQuitChordProvider: controllerQuitChordProvider,
                 customControllerChordProvider: customControllerChordProvider,
                 onBackgroundedChanged: onBackgroundedChanged))
+        ConnectTimingTelemetry.shared.recordLaunchLeg(
+            buildMs: Date().timeIntervalSince(buildStart) * 1000.0)
         self.window = setup.0
         self.input = setup.1
         self.videoDecoder = setup.2

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -76,6 +76,12 @@ final class TelemetryCounters: @unchecked Sendable {
     let fecRecoveredFramesTotal = Counter()
     let inputEventsTotal = Counter()
     let inputBatchFlushTotal = Counter()
+    /// Input flush ticks that early-returned because the LOCAL outbound send count
+    /// was over cap (the radio draining slowly) - one cause of the input p99 tail.
+    let inputFlushSendBackloggedSkipTotal = Counter()
+    /// Input flush ticks that early-returned because the HOST stopped draining our
+    /// reliable backlog (ACK silence) - the other cause of the input p99 tail.
+    let inputFlushReliableBackloggedSkipTotal = Counter()
 
     // ---- P1 NETWORK receive-path totals (the exporter derives the per-second
     //      pre-FEC loss / out-of-order / duplicate RATES from deltas of these
@@ -179,6 +185,11 @@ final class TelemetryCounters: @unchecked Sendable {
     /// `reconnectTotal`); a climb here that precedes a reconnect/disconnect marks
     /// the wake-on-different-AP stale-link case.
     let wakeTotal = Counter()
+    /// ROUTE-CHANGE count (signal: lifecycle): incremented each time the stream's
+    /// egress route/link-class flips (the WiFiTelemetry route-change edge that
+    /// already fires an NDJSON event). Run-global (NOT reset per session) so a
+    /// wake-on-a-different-AP is visible in Prometheus, not just the NDJSON/Loki.
+    let routeChangeTotal = Counter()
     /// EXPLICIT REQUEST_IDR sends that started a round-trip measurement
     /// (signal: IDR-RTT). RE-BASELINE NOTE: RFI sends no longer arm round-trips
     /// (they ride `rfiTotal`) - conflating them made the pair unreadable (RFI
@@ -604,6 +615,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         presentStallTotal, frameLossTotal, unrecoverableFrameTotal,
                         pacerDisabledTotal, videoPacketsTotal, videoFramesTotal,
                         fecRecoveredFramesTotal, inputEventsTotal, inputBatchFlushTotal,
+                        inputFlushSendBackloggedSkipTotal, inputFlushReliableBackloggedSkipTotal,
                         inputIdleToActiveTotal, bookmarkTotal,
                         videoPacketsLostPreFecTotal, videoPacketsOutOfOrderTotal,
                         videoPacketsDuplicateTotal, enetRetransmitTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -150,6 +150,7 @@ extension TelemetryExporter {
         // Client-side input latency (queue→wire age) - a standalone input-family
         // stage, read off the same tracker on this queue.
         snap.inputLocalLatency = FrameTimingTracker.shared?.inputLocalLatency.snapshotValue()
+        snap.inputDeliverLatency = FrameTimingTracker.shared?.inputDeliverLatency.snapshotValue()
 
         // Wi-Fi radio (signal 3): one CoreWLAN read on this queue. Reads the
         // current association only - never a scan - so it cannot disturb the link.

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -132,6 +132,10 @@ extension TelemetryExporter {
 
         snap.reconnectTotal = counters.reconnectTotal.value
         snap.wakeTotal = counters.wakeTotal.value
+        snap.routeChangeTotal = counters.routeChangeTotal.value
+        // Input backpressure-skip totals (monotonic), split by signal.
+        snap.inputFlushSendBackloggedSkipTotal = counters.inputFlushSendBackloggedSkipTotal.value
+        snap.inputFlushReliableBackloggedSkipTotal = counters.inputFlushReliableBackloggedSkipTotal.value
         snap.disconnectReason = p2.disconnectReason
         // Process-global per-reason totals (survive session resets) - the durable
         // record the per-session ordinal can't carry past the <1ms exporter teardown.
@@ -225,6 +229,13 @@ extension TelemetryExporter {
         add("total_ms", breakdown.totalMs)
         add("click_to_first_frame_ms", breakdown.clickToFirstFrameMs)
         add("launch_path_ms", breakdown.launchPathMs)
+        // Launch sub-legs attributing launch_path_ms.
+        add("launch_serverinfo_ms", breakdown.launchServerinfoMs)
+        add("launch_cancel_ms", breakdown.launchCancelMs)
+        add("launch_busy_wait_ms", breakdown.launchBusyWaitMs)
+        add("launch_busy_poll_count", breakdown.launchBusyPollCount)
+        add("launch_ms", breakdown.launchMs)
+        add("launch_build_ms", breakdown.buildMs)
         return "{" + fields.joined(separator: ",") + "}"
     }
 

--- a/Glimmer/Stream/TelemetryExporter+RenderP2.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderP2.swift
@@ -56,6 +56,25 @@ extension TelemetryRenderer {
                      "Launch path: click → connect-start this session, ms - the pre-connect "
                      + "launch cost handshake_total_ms can't see.",
                      handshake.launchPathMs)
+        // Launch SUB-LEGS attributing launch_path_ms (each absent until stamped).
+        builder.emit("glimmer_launch_serverinfo_ms",
+                     "Launch sub-leg: /serverinfo fetch duration this session, ms.",
+                     handshake.launchServerinfoMs)
+        builder.emit("glimmer_launch_cancel_ms",
+                     "Launch sub-leg: /cancel duration this session, ms.",
+                     handshake.launchCancelMs)
+        builder.emit("glimmer_launch_busy_wait_ms",
+                     "Launch sub-leg: waitForHostIdle busy-poll duration this session, ms.",
+                     handshake.launchBusyWaitMs)
+        builder.emit("glimmer_launch_busy_poll_count",
+                     "Launch sub-leg: /serverinfo polls in waitForHostIdle this session.",
+                     handshake.launchBusyPollCount)
+        builder.emit("glimmer_launch_ms",
+                     "Launch sub-leg: /launch duration this session, ms.",
+                     handshake.launchMs)
+        builder.emit("glimmer_launch_build_ms",
+                     "Launch sub-leg: MainActor subsystem/window build duration this session, ms.",
+                     handshake.buildMs)
     }
 
     /// RECONNECT count + disconnect REASON. The reason is BOTH an ordinal gauge
@@ -68,6 +87,10 @@ extension TelemetryRenderer {
         builder.emitCounter("glimmer_wake_total",
                             "Wakes from sleep this run while a stream was live.",
                             snap.wakeTotal)
+        builder.emitCounter("glimmer_route_change_total",
+                            "Egress route/link-class changes this run (e.g. wake on a "
+                            + "different AP) - the route_change NDJSON event as a counter.",
+                            snap.routeChangeTotal)
         builder.emit("glimmer_disconnect_reason",
                      "Disconnect reason ordinal (0 none, 1 user, 2 host-clean, 3 host-error, "
                      + "4 watchdog-stall, 5 connect-failed, 6 consumer-dropped, 7 system-sleep).",

--- a/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
@@ -37,6 +37,24 @@ extension TelemetryRenderer {
                 "Client input queue→wire age histogram (batcher enqueue→flush), ms.",
                 stage: inputLocal)
         }
+        // Client input deliver→enqueue age histogram: the pre-hop main-thread leg
+        // (GameController handler entry → batcher slot stamp) the local-latency
+        // histogram above can't see (it starts at enqueue).
+        if let inputDeliver = snap.inputDeliverLatency {
+            builder.emitHistogram(
+                "glimmer_latency_input_deliver_ms",
+                "Client input deliver→enqueue age histogram (controller handler entry → "
+                + "batcher slot stamp), ms.",
+                stage: inputDeliver)
+        }
+        // Input flush ticks skipped by backpressure, split by which signal fired
+        // (the input p99 tail attribution).
+        builder.emitCounter("glimmer_input_flush_backpressure_skips_total",
+                            "Input flush ticks skipped: local outbound send backlog over cap.",
+                            snap.inputFlushSendBackloggedSkipTotal)
+        builder.emitCounter("glimmer_input_flush_backpressure_reliable_skips_total",
+                            "Input flush ticks skipped: host reliable-ACK backlog over cap.",
+                            snap.inputFlushReliableBackloggedSkipTotal)
         // Host rumble dispatched to pad actuators - same Extras sample as the
         // NDJSON rumble fields, riding the input family it correlates with.
         builder.emitCounter("glimmer_rumble_events_total",

--- a/Glimmer/Stream/TelemetryLatency.swift
+++ b/Glimmer/Stream/TelemetryLatency.swift
@@ -310,6 +310,11 @@ final class FrameTimingTracker: @unchecked Sendable {
     /// threading through the composite-snapshot plumbing. Observed off the present
     /// path on the batcher queue; the Stage is self-locked, so cross-thread is safe.
     let inputLocalLatency = LatencyHistograms.Stage()
+    /// CLIENT-SIDE input DELIVER latency: the pre-hop main-thread leg from the
+    /// GameController valueChangedHandler entry to the batcher slot stamp (the
+    /// deliver→enqueue age `inputLocalLatency` can't see - it starts at enqueue).
+    /// Same self-locked Stage; observed off the present path. Measurement only.
+    let inputDeliverLatency = LatencyHistograms.Stage()
     /// Both internal (not private): the trace renderer + drop-stub emitter in
     /// TelemetryLatency+Trace.swift are the only cross-file consumers.
     let traceWriter = FrameTraceWriter()

--- a/Glimmer/Stream/TelemetrySessionEvents.swift
+++ b/Glimmer/Stream/TelemetrySessionEvents.swift
@@ -131,6 +131,14 @@ final class ConnectTimingTelemetry: @unchecked Sendable {
     private var connectStartReference: Double = 0
     private var clickToFirstFrameMsValue: Double = 0
     private var launchPathMsValue: Double = 0
+    // Launch-path SUB-LEGS (ms), stamped at the real call sites in
+    // launchWithBusyRecovery so the opaque launch_path_ms is attributable.
+    private var serverinfoMsValue: Double = 0
+    private var cancelMsValue: Double = 0
+    private var launchBusyWaitMsValue: Double = 0
+    private var launchBusyPollCountValue: Double = 0
+    private var launchMsValue: Double = 0
+    private var buildMsValue: Double = 0
     init() { lock.initialize(to: os_unfair_lock_s()) }
     deinit { lock.deallocate() }
 
@@ -164,6 +172,31 @@ final class ConnectTimingTelemetry: @unchecked Sendable {
         }
         os_unfair_lock_unlock(lock)
     }
+    /// Record a launch sub-leg duration (ms). First non-zero write wins per leg
+    /// (the launch flow runs each leg once); off any hot path. `busyPollCount` is
+    /// the waitForHostIdle poll count for `launch_busy_wait_ms`.
+    func recordLaunchLeg(serverinfoMs: Double? = nil, cancelMs: Double? = nil,
+                         launchBusyWaitMs: Double? = nil, busyPollCount: Int? = nil,
+                         launchMs: Double? = nil, buildMs: Double? = nil) {
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        if let ms = serverinfoMs, serverinfoMsValue == 0 { serverinfoMsValue = ms }
+        if let ms = cancelMs, cancelMsValue == 0 { cancelMsValue = ms }
+        if let ms = launchBusyWaitMs, launchBusyWaitMsValue == 0 { launchBusyWaitMsValue = ms }
+        if let count = busyPollCount, launchBusyPollCountValue == 0 { launchBusyPollCountValue = Double(count) }
+        if let ms = launchMs, launchMsValue == 0 { launchMsValue = ms }
+        if let ms = buildMs, buildMsValue == 0 { buildMsValue = ms }
+    }
+    /// Apply the stamped launch sub-legs onto a HandshakeBreakdown (each nil until
+    /// its call site stamped it). Keeps the multi-value read in one lock take.
+    func applyLaunchLegs(to out: inout HandshakeBreakdown) {
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        out.launchServerinfoMs = serverinfoMsValue != 0 ? serverinfoMsValue : nil
+        out.launchCancelMs = cancelMsValue != 0 ? cancelMsValue : nil
+        out.launchBusyWaitMs = launchBusyWaitMsValue != 0 ? launchBusyWaitMsValue : nil
+        out.launchBusyPollCount = launchBusyPollCountValue != 0 ? launchBusyPollCountValue : nil
+        out.launchMs = launchMsValue != 0 ? launchMsValue : nil
+        out.buildMs = buildMsValue != 0 ? buildMsValue : nil
+    }
     /// Click → first decoded frame (ms), or nil if not yet resolved.
     var clickToFirstFrameMs: Double? {
         os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
@@ -178,7 +211,43 @@ final class ConnectTimingTelemetry: @unchecked Sendable {
         os_unfair_lock_lock(lock)
         clickReference = 0; connectStartReference = 0
         clickToFirstFrameMsValue = 0; launchPathMsValue = 0
+        serverinfoMsValue = 0; cancelMsValue = 0; launchBusyWaitMsValue = 0
+        launchBusyPollCountValue = 0; launchMsValue = 0; buildMsValue = 0
         os_unfair_lock_unlock(lock)
+    }
+}
+
+// MARK: - Input deliver-stamp (handler entry → batcher enqueue)
+
+/// MEASUREMENT-ONLY per-slot deliver stamp bridging the MainActor controller
+/// handler to the batcher queue WITHOUT threading a timestamp through the backend
+/// protocol. The GameController valueChangedHandler stamps its entry instant per
+/// slot; the batcher takes (clears) it when it sets the slot's enqueue stamp, so
+/// the delta is the pre-hop main-thread leg. Last-writer-wins per slot is correct
+/// (GC delivers serially per slot on main); a take that finds no stamp is a no-op.
+/// Self-locked standalone (the `ConnectTimingTelemetry` idiom). NO behavior change.
+final class InputDeliverStamp: @unchecked Sendable {
+    static let shared = InputDeliverStamp()
+    private static let maxSlots = 16  // matches Enet.maxGamepads
+    private let lock = os_unfair_lock_t.allocate(capacity: 1)
+    private var stamps = [UInt64](repeating: 0, count: maxSlots)
+    init() { lock.initialize(to: os_unfair_lock_s()) }
+    deinit { lock.deallocate() }
+
+    /// Stamp the handler-entry instant for `slot` (monotonic ns). First write wins
+    /// until taken, so a coalesced burst keeps the oldest delivered instant.
+    func stamp(slot: Int, nanos: UInt64) {
+        guard slot >= 0, slot < Self.maxSlots else { return }
+        os_unfair_lock_lock(lock)
+        if stamps[slot] == 0 { stamps[slot] = nanos }
+        os_unfair_lock_unlock(lock)
+    }
+    /// Take + clear the stamp for `slot`, or 0 if none is pending.
+    func take(slot: Int) -> UInt64 {
+        guard slot >= 0, slot < Self.maxSlots else { return 0 }
+        os_unfair_lock_lock(lock); defer { os_unfair_lock_unlock(lock) }
+        let stamped = stamps[slot]; stamps[slot] = 0
+        return stamped
     }
 }
 
@@ -210,6 +279,15 @@ struct HandshakeBreakdown: Sendable {
     var clickToFirstFrameMs: Double?
     /// Launch path: click → connect-start, isolating the pre-connect launch cost.
     var launchPathMs: Double?
+    /// Launch-path SUB-LEGS attributing launchPathMs: /serverinfo, /cancel, the
+    /// waitForHostIdle busy-poll (+ its poll count), /launch, and the MainActor
+    /// subsystem/window build. Each nil until its call site stamps it.
+    var launchServerinfoMs: Double?
+    var launchCancelMs: Double?
+    var launchBusyWaitMs: Double?
+    var launchBusyPollCount: Double?
+    var launchMs: Double?
+    var buildMs: Double?
     /// True once the first decoded frame landed (so the exporter emits the
     /// one-shot breakdown exactly once, not every tick).
     var complete: Bool = false
@@ -330,6 +408,7 @@ extension TelemetryCounters {
             // totalMs can't). Self-locked; read here off the P2 lock.
             out.clickToFirstFrameMs = ConnectTimingTelemetry.shared.clickToFirstFrameMs
             out.launchPathMs = ConnectTimingTelemetry.shared.launchPathMs
+            ConnectTimingTelemetry.shared.applyLaunchLegs(to: &out)
             out.complete = firstFrameNanos != 0
             return out
         }

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -177,6 +177,14 @@ struct TelemetrySnapshot: Sendable {
     /// batcher (oldest unflushed entry → flush). A standalone stage, not part of
     /// `latencyHistograms`; rendered in the input family.
     var inputLocalLatency: LatencyHistogramSnapshot.Stage?
+    /// CLIENT-SIDE input DELIVER latency histogram: the pre-hop main-thread leg
+    /// (controller handler entry → batcher slot stamp). Standalone stage, rendered
+    /// in the input family alongside inputLocalLatency.
+    var inputDeliverLatency: LatencyHistogramSnapshot.Stage?
+    /// Input flush ticks skipped by backpressure, split by signal (the input p99
+    /// tail attribution): local radio backlog vs host reliable-ACK silence.
+    var inputFlushSendBackloggedSkipTotal: UInt64 = 0
+    var inputFlushReliableBackloggedSkipTotal: UInt64 = 0
 
     // display refresh / cadence (ProMotion ramp-down detector)
     var refreshMinHz: Double?
@@ -279,6 +287,9 @@ struct TelemetrySnapshot: Sendable {
     var reconnectTotal: UInt64 = 0
     /// Wake-from-sleep count this run (monotonic) - wakes while a stream was live.
     var wakeTotal: UInt64 = 0
+    /// Route/link-class change count this run (monotonic) - the egress-route flip
+    /// (e.g. wake on a different AP) the NDJSON route_change event already marks.
+    var routeChangeTotal: UInt64 = 0
     /// Latest disconnect reason (the live default is `.none` until a terminate).
     var disconnectReason: DisconnectReason = .none
     /// PROCESS-GLOBAL per-reason disconnect totals (label, total), monotonic and

--- a/Glimmer/Stream/WiFiTelemetry.swift
+++ b/Glimmer/Stream/WiFiTelemetry.swift
@@ -330,6 +330,9 @@ final class StreamRouteProbe: @unchecked Sendable {
                     || fresh.interfaceName != previous.interfaceName {
             Diag.notice("Stream ROUTE CHANGE: \(previous.linkLabel)/\(previous.interfaceName ?? "?") "
                 + "→ \(fresh.linkLabel)/\(ifLabel)", TelemetryExporter.logCategory)
+            // Also bump the Prometheus counter so a wake-on-different-AP is visible
+            // in Prometheus, not only the NDJSON/Loki event below. Same detection.
+            TelemetryCounters.shared.routeChangeTotal.increment()
             TelemetryExporter.recordEvent([
                 "\"event\":\"route_change\"",
                 "\"stream_link\":\"\(fresh.linkLabel)\"",

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.44
-CURRENT_PROJECT_VERSION = 20260655
+MARKETING_VERSION = 2026.6.45
+CURRENT_PROJECT_VERSION = 20260656


### PR DESCRIPTION
Pure additive telemetry from the p100 pass; no behavior change (flushLocked early-return byte-identical, route detection untouched, no work moved off main). Makes the next wake/launch/input issue a one-query diagnosis.

1. Launch sub-legs: glimmer_launch_{serverinfo,cancel,busy_wait,ms,build}_ms + launch_busy_poll_count - attributes the stale-host launch chug (the 1.5s launch_path) to the right leg (the waitForHostIdle poll). 2. glimmer_route_change_total - Prometheus counter on the existing route/AP-change event (was NDJSON-only), so a wake-on-different-AP is visible. 3. glimmer_input_flush_backpressure_skips_total + _reliable_ - split the input p99 tail into local-radio vs host-ACK-silence backpressure. 4. glimmer_latency_input_deliver_ms - the previously-unmeasured pre-hop main-thread leg (GC handler->enqueue), via a per-slot stamp store (no protocol change). Build + 156 tests green.