### PR TITLE
feat(telemetry): classify present-tick misses - descheduled vs coalesced (2026.6.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.6.46 - 2026-06-26
+
+Under the hood: a diagnostic that pinpoints why the present-timing tick
+occasionally fires late on a high-refresh display - distinguishing the timing
+thread being preempted from the OS coalescing the callback. No behavior change;
+it tells the next release which fix is the right one.
+
 ## 2026.6.45 - 2026-06-26
 
 Under the hood: new diagnostics, no change to behavior. Breaks stream-launch

--- a/Glimmer/Stream/FramePacer+Tick.swift
+++ b/Glimmer/Stream/FramePacer+Tick.swift
@@ -29,6 +29,16 @@ extension FramePacer {
     /// just produces one delta the plausibility bounds in `handleTick` discard.
     nonisolated(unsafe) static var lastTickTargetTimestamp: CFTimeInterval = .nan
 
+    /// Previous `handleTick` WALL-CLOCK entry time (`hostNow`), so a stretched
+    /// realized tick can be split by cause: a wall-clock gap as large as the
+    /// realized stretch means `handleTick` itself ran late (the tick thread was
+    /// DESCHEDULED); an on-time entry against a jumped `targetTimestamp` means
+    /// macOS COALESCED the callback delivery. Tick-thread confined exactly like
+    /// `lastTickTargetTimestamp` (one reader/writer, one run loop at a time); NaN
+    /// until the second tick, suspension-sized after a backgrounded window - the
+    /// same plausibility bounds the realized delta uses exclude both.
+    nonisolated(unsafe) static var lastTickEntryHostTime: CFTimeInterval = .nan
+
     /// Ceiling for a plausible realized tick delta (seconds). Above this the
     /// gap is a link suspension (backgrounded window), a rebuild, or a stale
     /// cross-instance timestamp - not panel cadence - and folding it in would
@@ -134,6 +144,31 @@ extension FramePacer {
         // emitted off-lock below.
         let deficitEvents = serviceTickDeficitLocked(now: hostNow)
         os_unfair_lock_unlock(&lock)
+
+        // DIAGNOSTIC tick-miss classifier (metric-only, no behavior change). A
+        // stretched realized tick (>1.5 vsyncs between successive targetTimestamps)
+        // has two opposite causes needing opposite fixes; split them by whether
+        // `handleTick`'s OWN wall-clock entry stretched the same amount:
+        //   - entry gap also >1.5 vsyncs -> the tick thread was DESCHEDULED
+        //     (handleTick ran late; the CPU starved it).
+        //   - entry on time but the vsync delta jumped -> macOS COALESCED the
+        //     callback delivery on a near-static layer.
+        // All values are tick-thread-local; off-lock, only the counter add (its
+        // own lock) crosses threads. Reuses hostNow/realizedInterval/vsyncInterval -
+        // no extra clock read. `entryGap` shares the realized delta's plausibility
+        // bounds (NaN/first-tick + suspension-sized gaps excluded).
+        let entryGap = hostNow - Self.lastTickEntryHostTime
+        Self.lastTickEntryHostTime = hostNow
+        if realizedInterval.isFinite, realizedInterval > 0,
+           realizedInterval <= Self.maxRealizedTickDeltaSeconds,
+           realizedInterval > 1.5 * vsyncInterval {
+            if entryGap.isFinite, entryGap > 0, entryGap <= Self.maxRealizedTickDeltaSeconds,
+               entryGap > 1.5 * vsyncInterval {
+                TelemetryCounters.shared.tickMissDescheduledTotal.increment()
+            } else {
+                TelemetryCounters.shared.tickMissCoalescedTotal.increment()
+            }
+        }
 
         handleTickDeficitEvents(deficitEvents)
 

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -255,6 +255,18 @@ final class TelemetryCounters: @unchecked Sendable {
     /// always-live (a sub-µs integer op, far below the per-vsync budget at 240Hz).
     let pacerOverTargetReleaseTotal = Counter()
 
+    /// Present-tick MISS split by ROOT CAUSE (signal: PRESENT, diagnostic). A
+    /// stretched present tick (>1.5 vsyncs between successive CADisplayLink
+    /// targetTimestamps - the residual ~3.8% present gap) is classified on the
+    /// tick path: DESCHEDULED = `handleTick`'s own wall-clock entry stretched the
+    /// same amount, so the tick thread didn't get the CPU; COALESCED = entry on
+    /// time but the vsync delta jumped, so macOS coalesced the callback delivery.
+    /// The two need OPPOSITE fixes, so the split picks which to ship. Bumped on the
+    /// tick path (sub-µs integer add, far below the per-vsync budget); per-session
+    /// like the sibling present counters.
+    let tickMissDescheduledTotal = Counter()
+    let tickMissCoalescedTotal = Counter()
+
     /// Frames dropped-to-NEWEST while presentation is SUPPRESSED (signal:
     /// PRESENT): the window is backgrounded/occluded, the display link is
     /// deliberately suspended, and the pacer keeps only the newest frame ready
@@ -623,7 +635,9 @@ final class TelemetryCounters: @unchecked Sendable {
                         decoderRecreateTotal, decoderRecreateFirstTotal,
                         decoderRecreateResolutionTotal, decoderRecreateColorspaceTotal,
                         staleFrameRepeatTotal,
-                        pacerOverTargetReleaseTotal, suppressedDropTotal, decodeGatedDropTotal,
+                        pacerOverTargetReleaseTotal,
+                        tickMissDescheduledTotal, tickMissCoalescedTotal,
+                        suppressedDropTotal, decodeGatedDropTotal,
                         discontinuityFlushTotal,
                         audioPacketsTotal, audioPacketsLostTotal, audioFecRecoveredTotal,
                         audioFecMismatchTotal, audioUnderrunTotal, audioOverrunTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -118,6 +118,8 @@ extension TelemetryExporter {
         snap.vtSessionCreateMs = counters.vtSessionCreateMs
         snap.discontinuityFlushTotal = counters.discontinuityFlushTotal.value
         snap.staleFrameRepeatTotal = counters.staleFrameRepeatTotal.value
+        snap.tickMissDescheduledTotal = counters.tickMissDescheduledTotal.value
+        snap.tickMissCoalescedTotal = counters.tickMissCoalescedTotal.value
 
         // P1 DECODE state (HW-decode + pixel format + bit depth + colorspace) +
         // PRESENT/DISPLAY (EDR trend + HDR/screen/ProMotion). Both read off the

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -191,6 +191,9 @@ extension TelemetryRenderer {
         builder.addCount("pacer_over_target_release_total", extras.pacerOverTargetReleaseTotal)
         builder.add("pacer_over_target_releases_per_s", extras.pacerOverTargetReleasesPerSecond)
         builder.add("pacer_over_target_release_ratio", extras.pacerOverTargetReleaseRatio)
+        // Present-tick miss split by cause (descheduled thread vs coalesced callback).
+        builder.addCount("tick_miss_descheduled_total", snap.tickMissDescheduledTotal)
+        builder.addCount("tick_miss_coalesced_total", snap.tickMissCoalescedTotal)
         builder.add("edr_headroom_min", snap.edrHeadroomMin)
         builder.add("edr_headroom_avg", snap.edrHeadroomAvg)
         builder.add("edr_headroom_max", snap.edrHeadroomMax)

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -283,6 +283,14 @@ extension TelemetryRenderer {
                      "Over-target force-releases ÷ total releases this window "
                      + "(<0.1 steady-state; sustained-high = fps≈refresh self-oscillation).",
                      extras.pacerOverTargetReleaseRatio)
+        builder.emitCounter("glimmer_tick_miss_descheduled_total",
+                            "Stretched present ticks where handleTick itself ran late "
+                            + "(the tick thread was descheduled - the CPU starved it).",
+                            snap.tickMissDescheduledTotal)
+        builder.emitCounter("glimmer_tick_miss_coalesced_total",
+                            "Stretched present ticks where handleTick ran on time but the "
+                            + "vsync delta jumped (macOS coalesced the callback delivery).",
+                            snap.tickMissCoalescedTotal)
         builder.emit("glimmer_display_edr_headroom_min",
                      "EDR headroom min this window (1.0 = SDR, >1.0 = HDR engaged).",
                      snap.edrHeadroomMin)

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -534,6 +534,8 @@ struct SessionReport {
             ("discontinuity_flush", counters.discontinuityFlushTotal.value),
             ("present_stale_repeat", counters.staleFrameRepeatTotal.value),
             ("pacer_over_target_release", counters.pacerOverTargetReleaseTotal.value),
+            ("tick_miss_descheduled", counters.tickMissDescheduledTotal.value),
+            ("tick_miss_coalesced", counters.tickMissCoalescedTotal.value),
             ("suppressed_drop", counters.suppressedDropTotal.value),
             ("drops_decode_gated", counters.decodeGatedDropTotal.value),
             // Per-socket GAP-EVENT tallies (the honest link-health counts the

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -75,6 +75,11 @@ struct TelemetrySnapshot: Sendable {
     /// Stale-frame repeats per second this window - a SPIKE while fps≈refresh is a
     /// real micro-judder (at fps<refresh a steady rate is the normal cadence).
     var staleRepeatsPerSecond: Double?
+    /// Present-tick MISS totals split by root cause (DESCHEDULED = the tick thread
+    /// didn't get the CPU; COALESCED = macOS delayed the CADisplayLink callback).
+    /// The split picks which of two opposite fixes the residual present gap needs.
+    var tickMissDescheduledTotal: UInt64 = 0
+    var tickMissCoalescedTotal: UInt64 = 0
 
     // P1 PRESENT/DISPLAY: EDR-headroom trend + HDR-engaged + screen + ProMotion.
     /// EDR headroom (NSScreen.maximumEDR) min/avg/max over this window. 1.0 = SDR;

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.45
-CURRENT_PROJECT_VERSION = 20260656
+MARKETING_VERSION = 2026.6.46
+CURRENT_PROJECT_VERSION = 20260657


### PR DESCRIPTION
A 38-agent workflow settled that the residual ~3.8% present gap on a 120Hz panel is missed present-tick callbacks (B): the panel stays pinned at 120 (refresh_max never sags, zero mode changes, queue empty at the dips so buffering can't recover it), on AC+cool (not the battery governor). No display knob exists or would help. The miss is in callback DELIVERY - but two causes need opposite fixes: (A) the .32 tick thread is descheduled (-> real-time scheduling) vs (B) macOS coalesced the callback on a static layer (-> a layer-liveness nudge; priority won't help).

This diagnostic splits them: in handleTick (off-lock, tick-thread-local, reusing the existing hostNow/realizedInterval/vsyncInterval - no new clock read), on a stretched tick (realizedInterval > 1.5*vsync) it classifies descheduled (handleTick entry-gap ALSO stretched) vs coalesced (entry-gap normal, only the vsync targetTimestamp jumped). Exports glimmer_tick_miss_{descheduled,coalesced}_total. Measurement-only, no pacing/present behavior change. One short stream then picks the correct .47 fix first try. Build + 156 tests green.