### PR TITLE
feat(pacer): real-time scheduling on the present-tick thread (2026.6.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.6.47 - 2026-06-26
+
+Kills the residual intermittent stutter on high-refresh displays. The
+present-timing thread (added in 2026.6.32) could still be preempted by the
+system under load, firing its display callback a couple of frames late - a brief
+judder that read as dropped frames even though the connection and decode were
+perfect (diagnosed precisely: the thread was being descheduled, not the panel
+changing refresh). It now runs with real-time scheduling - the same class
+CoreAudio's audio thread uses - so it gets a guaranteed slice every frame and
+can't be shoved off the CPU. No added latency, negligible CPU cost.
+
 ## 2026.6.46 - 2026-06-26
 
 Under the hood: a diagnostic that pinpoints why the present-timing tick

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -147,7 +147,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Fire the present tick on a private high-QoS run loop (not .main)
             // so a busy main thread can't starve the CADisplayLink callback.
             // Flip false for an instant fallback to the main-runloop tick.
-            FramePacer.tickOffMainDefaultsKey: true
+            FramePacer.tickOffMainDefaultsKey: true,
+            // Give that tick thread Mach time-constraint (real-time) scheduling
+            // so the CPU can't preempt it under load. Flip false to fall back to
+            // plain userInteractive (the pre-realtime behavior) without a rebuild.
+            PacerTickThread.realtimeDefaultsKey: true
         ])
         // Crash recovery: if a prior session died mid-stream with the pointer
         // acceleration linearized, restore the user's saved value now (no-op in

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -219,7 +219,9 @@ final class PacerTickThread: @unchecked Sendable {
         }
         var policy = thread_time_constraint_policy_data_t(
             period: toAbs(4_000_000),       // 4.0ms - covers up to 240Hz
-            computation: toAbs(500_000),    // 0.5ms - cheap timing capture
+            computation: toAbs(1_000_000),  // 1.0ms - tick uses ~0.2ms; headroom
+                                            // so a heavier tick can't overrun and
+                                            // get demoted (it's a ceiling, not spin)
             constraint: toAbs(4_000_000),   // 4.0ms - finish within the vsync
             preemptible: 0)                 // non-preemptible (tiny window)
         // THREAD_TIME_CONSTRAINT_POLICY_COUNT is a C sizeof macro the Swift

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -11,9 +11,13 @@
 //  that callback onto a private userInteractive run loop un-starves it at ZERO
 //  added latency. The link bind/unbind themselves stay on the main actor
 //  (installLink reads the NSView); we hand the live link to this thread to add.
+//  The thread also takes Mach time-constraint (real-time) scheduling so the CPU
+//  can't preempt it under load - residual judder was descheduled tick misses,
+//  and userInteractive is the top QoS class, so RT is the only lever left.
 //  Split out of FramePacer.swift to keep that file under the length limit.
 //
 
+import Darwin
 import Foundation
 import QuartzCore
 import os
@@ -41,6 +45,12 @@ extension FramePacer {
 /// thread via `perform(...)`, so they touch the loop from its owning thread;
 /// `CFRunLoopStop` is documented thread-safe to call from another thread.
 final class PacerTickThread: @unchecked Sendable {
+
+    /// UserDefaults key gating Mach time-constraint (real-time) scheduling on the
+    /// tick thread (`true`, the default; registered in GlimmerApp). False leaves
+    /// the thread at plain userInteractive - an instant fallback if RT ever
+    /// misbehaves, no rebuild needed.
+    static let realtimeDefaultsKey = "pacerTickRealtime"
 
     private var thread: Thread?
     /// The thread's own RunLoop object (the canonical one for that thread),
@@ -106,6 +116,13 @@ final class PacerTickThread: @unchecked Sendable {
             self.loopRunning = true
             os_unfair_lock_unlock(&self.lock)
             self.ready.signal()
+            // Real-time scheduling: the run loop is now servicing sources, so
+            // apply the Mach time-constraint policy from INSIDE the thread (once)
+            // before it blocks. Best-effort - on failure it continues at
+            // userInteractive (the pre-realtime path). Gated on the flag.
+            if UserDefaults.standard.bool(forKey: Self.realtimeDefaultsKey) {
+                Self.applyRealtimeScheduling()
+            }
             // CFRunLoopRun blocks until CFRunLoopStop breaks it; RunLoop.run()'s
             // no-source early-return is the freeze this avoids.
             CFRunLoopRun()
@@ -174,6 +191,52 @@ final class PacerTickThread: @unchecked Sendable {
         let r = exitSignal.wait(timeout: .now() + .milliseconds(50))
         assert(r == .success, "pacer tick thread did not exit")
         #endif
+    }
+
+    /// Pin the calling thread (the tick thread) to Mach THREAD_TIME_CONSTRAINT
+    /// scheduling - the same real-time class CoreAudio's IO render thread uses so
+    /// it can't be preempted under load. There is no QoS class above
+    /// userInteractive; this is the only mechanism that reserves the thread a
+    /// guaranteed slot per cadence, which is what kills the descheduled tick miss.
+    /// MUST be called from inside the thread body (uses `mach_thread_self()`).
+    /// Best-effort: a failed `thread_policy_set` is logged and ignored - the
+    /// thread keeps running at userInteractive.
+    private static func applyRealtimeScheduling() {
+        var timebase = mach_timebase_info_data_t()
+        guard mach_timebase_info(&timebase) == KERN_SUCCESS, timebase.numer != 0 else {
+            Diag.warn("pacer tick thread: mach_timebase_info failed; staying userInteractive", "Stream.Pacer")
+            return
+        }
+        // ns -> mach abs-time units. Conservative cadence: a ~4.0ms period covers
+        // up to 240Hz so the thread gets a reserved slot often enough for any
+        // panel (120/240Hz) without knowing the refresh yet; it simply skips
+        // slots it doesn't need. computation is handleTick's tiny timing-capture
+        // budget (it dispatches the real present off-thread). constraint = period:
+        // the callback must land within the vsync. Non-preemptible - the window is
+        // small enough to always complete once started.
+        func toAbs(_ ns: UInt64) -> UInt32 {
+            UInt32(ns * UInt64(timebase.denom) / UInt64(timebase.numer))
+        }
+        var policy = thread_time_constraint_policy_data_t(
+            period: toAbs(4_000_000),       // 4.0ms - covers up to 240Hz
+            computation: toAbs(500_000),    // 0.5ms - cheap timing capture
+            constraint: toAbs(4_000_000),   // 4.0ms - finish within the vsync
+            preemptible: 0)                 // non-preemptible (tiny window)
+        // THREAD_TIME_CONSTRAINT_POLICY_COUNT is a C sizeof macro the Swift
+        // overlay doesn't expose; derive the integer_t-word count from the struct.
+        let count = mach_msg_type_number_t(
+            MemoryLayout<thread_time_constraint_policy_data_t>.stride / MemoryLayout<integer_t>.stride)
+        let kr = withUnsafeMutablePointer(to: &policy) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                thread_policy_set(mach_thread_self(), thread_policy_flavor_t(THREAD_TIME_CONSTRAINT_POLICY),
+                                  $0, count)
+            }
+        }
+        if kr == KERN_SUCCESS {
+            Diag.notice("pacer tick thread: realtime scheduling applied", "Stream.Pacer")
+        } else {
+            Diag.warn("pacer tick thread: thread_policy_set failed (kr=\(kr)); staying userInteractive", "Stream.Pacer")
+        }
     }
 
     deinit { stop() }

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.46
-CURRENT_PROJECT_VERSION = 20260657
+MARKETING_VERSION = 2026.6.47
+CURRENT_PROJECT_VERSION = 20260658


### PR DESCRIPTION
THE fix for the residual judder. A live diagnostic (the .46 classifier) proved it 100%: tick_miss_descheduled=2774, coalesced=0 - the .32 present-tick thread (userInteractive QoS, no higher class exists) gets PREEMPTED under load, firing its CADisplayLink callback ~2.5 vsyncs late (refresh_min dips to 48 while max stays 120, zero panel mode-changes, queue empty at the dips). The user's bookmarked stutter moments coincide exactly with descheduled misses.

FIX: apply Mach THREAD_TIME_CONSTRAINT_POLICY (the class CoreAudio's IO thread uses) to PacerTickThread from inside the thread body (mach_thread_self(), after run-loop setup, before CFRunLoopRun). period 4ms (covers <=240Hz), computation 1ms (tick uses ~0.2ms - headroom so a heavier tick can't overrun->demote; it's a ceiling not a spin), constraint 4ms, non-preemptible. Best-effort: thread_policy_set failure logs + continues at userInteractive (never crashes). Behind pacerTickRealtime flag (default true) for instant fallback. No latency cost, negligible CPU (the reservation is unused-budget-free). Lock holds unchanged + minimal (no priority-inversion concern added). VERIFY: glimmer_tick_miss_descheduled_total should drop toward ~0. Build + 156 tests green.