### PR TITLE
feat(telemetry): RT-applied gauge + preempted-vs-linkskip split (2026.6.48)

### DIFF
--- a/Glimmer/Stream/FramePacer+Tick.swift
+++ b/Glimmer/Stream/FramePacer+Tick.swift
@@ -168,6 +168,20 @@ extension FramePacer {
             } else {
                 TelemetryCounters.shared.tickMissCoalescedTotal.increment()
             }
+            // FINER split via a DIRECT promptness measure (the entryGap test above
+            // conflates a starved thread with a skipped vsync DELIVERY - both
+            // stretch the gap). `link.timestamp` is the just-passed vsync this
+            // callback fired for, in the same CACurrentMediaTime base; the lag of
+            // `handleTick` behind it separates the two: ran a full frame-or-more
+            // late = thread starved (PREEMPTED, RT not working); ran promptly but
+            // the interval still stretched = the link skipped a vsync (LINKSKIP, RT
+            // working, residual is the display server). One clock read, off-lock.
+            let lag = CACurrentMediaTime() - link.timestamp
+            if lag.isFinite, lag > vsyncInterval {
+                TelemetryCounters.shared.tickMissPreemptedTotal.increment()
+            } else {
+                TelemetryCounters.shared.tickMissLinkskipTotal.increment()
+            }
         }
 
         handleTickDeficitEvents(deficitEvents)

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -122,6 +122,9 @@ final class PacerTickThread: @unchecked Sendable {
             // userInteractive (the pre-realtime path). Gated on the flag.
             if UserDefaults.standard.bool(forKey: Self.realtimeDefaultsKey) {
                 Self.applyRealtimeScheduling()
+            } else {
+                // Flag off: the thread stays userInteractive, so the RT gauge is 0.
+                TelemetryCounters.shared.setPacerTickRealtime(false)
             }
             // CFRunLoopRun blocks until CFRunLoopStop breaks it; RunLoop.run()'s
             // no-source early-return is the freeze this avoids.
@@ -205,6 +208,7 @@ final class PacerTickThread: @unchecked Sendable {
         var timebase = mach_timebase_info_data_t()
         guard mach_timebase_info(&timebase) == KERN_SUCCESS, timebase.numer != 0 else {
             Diag.warn("pacer tick thread: mach_timebase_info failed; staying userInteractive", "Stream.Pacer")
+            TelemetryCounters.shared.setPacerTickRealtime(false)
             return
         }
         // ns -> mach abs-time units. Conservative cadence: a ~4.0ms period covers
@@ -234,6 +238,8 @@ final class PacerTickThread: @unchecked Sendable {
                                   $0, count)
             }
         }
+        // Record the outcome as the queryable RT gauge (1 = RT priority, 0 = not).
+        TelemetryCounters.shared.setPacerTickRealtime(kr == KERN_SUCCESS)
         if kr == KERN_SUCCESS {
             Diag.notice("pacer tick thread: realtime scheduling applied", "Stream.Pacer")
         } else {

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -193,6 +193,21 @@ extension TelemetryCounters {
         return decodeGatedValue
     }
 
+    /// Stamp the pacer-tick REALTIME gauge. Called once at tick-thread start by
+    /// PacerTickThread (RT-applied success/failure, or the flag-off path) - never
+    /// per frame.
+    func setPacerTickRealtime(_ applied: Bool) {
+        os_unfair_lock_lock(pacerTickRealtimeLock)
+        pacerTickRealtimeValue = applied
+        os_unfair_lock_unlock(pacerTickRealtimeLock)
+    }
+    /// Current pacer-tick realtime state. Read by the exporter on its 1Hz queue
+    /// (never the hot path).
+    var pacerTickRealtime: Bool {
+        os_unfair_lock_lock(pacerTickRealtimeLock); defer { os_unfair_lock_unlock(pacerTickRealtimeLock) }
+        return pacerTickRealtimeValue
+    }
+
     // MARK: - Ignored-control per-type tallies
 
     /// One-call contract for the inbound-control default arm: bump the

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -267,6 +267,20 @@ final class TelemetryCounters: @unchecked Sendable {
     let tickMissDescheduledTotal = Counter()
     let tickMissCoalescedTotal = Counter()
 
+    /// Present-tick MISS split by a DIRECT promptness measure (signal: PRESENT,
+    /// diagnostic). The descheduled/coalesced pair above tests the wall-clock
+    /// entry GAP, which stretches in BOTH thread preemption AND a CADisplayLink
+    /// vsync-delivery skip - so it can't tell "RT failed" from "the display server
+    /// dropped a vsync". This pair tests the LAG of `handleTick` behind its vsync
+    /// instead: PREEMPTED = the callback ran a full frame-or-more late (the thread
+    /// was starved - RT not doing its job); LINKSKIP = it ran promptly but the
+    /// inter-tick interval still stretched (the link didn't deliver a vsync - RT
+    /// working, the residual is the display server). Kept ALONGSIDE the older pair
+    /// for an old-vs-new comparison. Bumped on the tick path (one extra clock read +
+    /// a subtract + a compare); per-session like the sibling present counters.
+    let tickMissPreemptedTotal = Counter()
+    let tickMissLinkskipTotal = Counter()
+
     /// Frames dropped-to-NEWEST while presentation is SUPPRESSED (signal:
     /// PRESENT): the window is backgrounded/occluded, the display link is
     /// deliberately suspended, and the pacer keeps only the newest frame ready
@@ -426,6 +440,15 @@ final class TelemetryCounters: @unchecked Sendable {
     /// as the suppression gauge it extends.
     let decodeGatedLock = os_unfair_lock_t.allocate(capacity: 1)
     var decodeGatedValue = false
+
+    /// PACER-TICK REALTIME gauge (0/1): 1 once `thread_policy_set` confirmed the
+    /// Mach time-constraint (real-time) policy on the present-tick thread, 0 when
+    /// it failed OR the flag left the thread at userInteractive. Stamped ONCE at
+    /// tick-thread start by PacerTickThread (never per frame) and read at 1Hz by
+    /// the exporter - the one-query "are we getting RT priority" yes/no the
+    /// `tick_miss_*` split is read against. Last-writer-wins behind its own lock.
+    let pacerTickRealtimeLock = os_unfair_lock_t.allocate(capacity: 1)
+    var pacerTickRealtimeValue = false
 
     /// Live inter-packet-gap distribution (microseconds) for the microburst
     /// detector. Written once per ~2s receive-metrics window by the RTP path
@@ -597,6 +620,7 @@ final class TelemetryCounters: @unchecked Sendable {
         audioFirstPacketLock.initialize(to: os_unfair_lock_s())
         presentSuppressedLock.initialize(to: os_unfair_lock_s())
         decodeGatedLock.initialize(to: os_unfair_lock_s())
+        pacerTickRealtimeLock.initialize(to: os_unfair_lock_s())
     }
     deinit {
         jitterLock.deallocate(); inputLock.deallocate()
@@ -605,6 +629,7 @@ final class TelemetryCounters: @unchecked Sendable {
         decodeStateLock.deallocate(); fecHealthLock.deallocate()
         audioStateLock.deallocate(); audioFirstPacketLock.deallocate()
         presentSuppressedLock.deallocate(); decodeGatedLock.deallocate()
+        pacerTickRealtimeLock.deallocate()
     }
 
     // The gauge accessors live in same-module extension files (pure moves to
@@ -637,6 +662,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         staleFrameRepeatTotal,
                         pacerOverTargetReleaseTotal,
                         tickMissDescheduledTotal, tickMissCoalescedTotal,
+                        tickMissPreemptedTotal, tickMissLinkskipTotal,
                         suppressedDropTotal, decodeGatedDropTotal,
                         discontinuityFlushTotal,
                         audioPacketsTotal, audioPacketsLostTotal, audioFecRecoveredTotal,
@@ -666,6 +692,9 @@ final class TelemetryCounters: @unchecked Sendable {
         // the next suppression/gate edge.
         setPresentSuppressed(false)
         setDecodeGated(false)
+        // RT gauge: re-stamped when the next session's tick thread starts (the
+        // reset runs at the connect edge, before the pacer re-binds).
+        setPacerTickRealtime(false)
         // Per-type ignored-control tallies are per-session like the aggregate
         // total; the audio-TTF record resets but its last-stream-end stamp
         // survives (it anchors THIS session's host_idle_s).

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -120,6 +120,8 @@ extension TelemetryExporter {
         snap.staleFrameRepeatTotal = counters.staleFrameRepeatTotal.value
         snap.tickMissDescheduledTotal = counters.tickMissDescheduledTotal.value
         snap.tickMissCoalescedTotal = counters.tickMissCoalescedTotal.value
+        snap.tickMissPreemptedTotal = counters.tickMissPreemptedTotal.value
+        snap.tickMissLinkskipTotal = counters.tickMissLinkskipTotal.value
 
         // P1 DECODE state (HW-decode + pixel format + bit depth + colorspace) +
         // PRESENT/DISPLAY (EDR trend + HDR/screen/ProMotion). Both read off the

--- a/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
@@ -41,6 +41,9 @@ extension TelemetryExporter {
         // suppressed (decoded, dropped-to-newest) - plus its designed drops.
         extras.decodeGated = counters.decodeGated
         extras.decodeGatedDropTotal = counters.decodeGatedDropTotal.value
+        // RT-applied gauge: did the present-tick thread get Mach time-constraint
+        // scheduling? The yes/no the tick_miss_preempted/linkskip split reads against.
+        extras.pacerTickRealtime = counters.pacerTickRealtime
         extras.rumbleEventTotal = rumbleTotal
         // Defect sibling of the receipt counter (truncated / slot-out-of-range
         // drops). Total only - ~0 in practice, so a per-second rate would be
@@ -177,6 +180,10 @@ extension TelemetrySnapshot {
         /// (previously only reconstructable as rendered+stale).
         var pacerTicksPerSecond: Double?
         var pacerReleasesPerSecond: Double?
+        /// PACER-TICK REALTIME gauge (0/1): 1 once the Mach time-constraint policy
+        /// confirmed on the tick thread, 0 when it failed / the flag left it at
+        /// userInteractive - the yes/no the `tick_miss_*` split is read against.
+        var pacerTickRealtime: Bool = false
         /// DECODE-GATE state (0/1) + the frames quietly dropped while gated -
         /// the third hidden-window state, split from the suppression pair above
         /// so a gated zero-decode span never reads as a decode wedge.

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -194,6 +194,10 @@ extension TelemetryRenderer {
         // Present-tick miss split by cause (descheduled thread vs coalesced callback).
         builder.addCount("tick_miss_descheduled_total", snap.tickMissDescheduledTotal)
         builder.addCount("tick_miss_coalesced_total", snap.tickMissCoalescedTotal)
+        // The finer direct-promptness split (preempted thread vs skipped vsync
+        // delivery) - names the residual the pair above conflates.
+        builder.addCount("tick_miss_preempted_total", snap.tickMissPreemptedTotal)
+        builder.addCount("tick_miss_linkskip_total", snap.tickMissLinkskipTotal)
         builder.add("edr_headroom_min", snap.edrHeadroomMin)
         builder.add("edr_headroom_avg", snap.edrHeadroomAvg)
         builder.add("edr_headroom_max", snap.edrHeadroomMax)
@@ -285,6 +289,9 @@ extension TelemetryRenderer {
         // measure (a ticks/s deficit below the refresh Hz is missed callbacks).
         builder.add("pacer_ticks_per_s", extras.pacerTicksPerSecond)
         builder.add("pacer_releases_per_s", extras.pacerReleasesPerSecond)
+        // 1 = the tick thread got Mach time-constraint (RT) scheduling; the yes/no
+        // the tick_miss_preempted/linkskip split is read against.
+        builder.addBool("pacer_tick_realtime", extras.pacerTickRealtime)
         builder.addCount("drops_decoder", snap.dropsDecoder)
         builder.addCount("drops_backpressure", snap.dropsBackpressure)
         builder.addCount("drops_presentation_late", snap.dropsPresentationLate)

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -62,6 +62,12 @@ extension TelemetryRenderer {
         builder.emit("glimmer_pacer_releases_per_second",
                      "Pacer frame releases to the renderer per second.",
                      extras.pacerReleasesPerSecond)
+        // The queryable RT-priority yes/no: 1 once the Mach time-constraint policy
+        // applied on the present-tick thread, 0 if it failed / the flag disabled it.
+        builder.emit("glimmer_pacer_tick_realtime",
+                     "1 if the present-tick thread got Mach time-constraint (real-time) "
+                     + "scheduling, else 0 (failed or flag-disabled).",
+                     extras.pacerTickRealtime ? 1 : 0)
     }
 
     static func promDrops(
@@ -291,6 +297,17 @@ extension TelemetryRenderer {
                             "Stretched present ticks where handleTick ran on time but the "
                             + "vsync delta jumped (macOS coalesced the callback delivery).",
                             snap.tickMissCoalescedTotal)
+        // The FINER split via a direct promptness (lag-behind-vsync) measure - it
+        // names the residual the descheduled/coalesced pair conflates.
+        builder.emitCounter("glimmer_tick_miss_preempted_total",
+                            "Stretched present ticks where handleTick ran a full frame-or-more "
+                            + "behind its vsync (the tick thread was starved - RT not working).",
+                            snap.tickMissPreemptedTotal)
+        builder.emitCounter("glimmer_tick_miss_linkskip_total",
+                            "Stretched present ticks where handleTick ran promptly but the "
+                            + "interval still stretched (the link skipped a vsync delivery - "
+                            + "RT working, residual is the display server).",
+                            snap.tickMissLinkskipTotal)
         builder.emit("glimmer_display_edr_headroom_min",
                      "EDR headroom min this window (1.0 = SDR, >1.0 = HDR engaged).",
                      snap.edrHeadroomMin)

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -536,6 +536,9 @@ struct SessionReport {
             ("pacer_over_target_release", counters.pacerOverTargetReleaseTotal.value),
             ("tick_miss_descheduled", counters.tickMissDescheduledTotal.value),
             ("tick_miss_coalesced", counters.tickMissCoalescedTotal.value),
+            // The finer direct-promptness split (starved thread vs skipped vsync).
+            ("tick_miss_preempted", counters.tickMissPreemptedTotal.value),
+            ("tick_miss_linkskip", counters.tickMissLinkskipTotal.value),
             ("suppressed_drop", counters.suppressedDropTotal.value),
             ("drops_decode_gated", counters.decodeGatedDropTotal.value),
             // Per-socket GAP-EVENT tallies (the honest link-health counts the

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -80,6 +80,13 @@ struct TelemetrySnapshot: Sendable {
     /// The split picks which of two opposite fixes the residual present gap needs.
     var tickMissDescheduledTotal: UInt64 = 0
     var tickMissCoalescedTotal: UInt64 = 0
+    /// Present-tick MISS split by a DIRECT promptness measure (PREEMPTED = the
+    /// callback ran a full frame-or-more behind its vsync, so the thread was
+    /// starved - RT not working; LINKSKIP = it ran promptly but the interval still
+    /// stretched, so the display server skipped a vsync - RT working). The finer
+    /// split kept alongside the descheduled/coalesced pair for an old-vs-new read.
+    var tickMissPreemptedTotal: UInt64 = 0
+    var tickMissLinkskipTotal: UInt64 = 0
 
     // P1 PRESENT/DISPLAY: EDR-headroom trend + HDR-engaged + screen + ProMotion.
     /// EDR headroom (NSScreen.maximumEDR) min/avg/max over this window. 1.0 = SDR;


### PR DESCRIPTION
After .47, present cadence collapsed (0.52ms - the RT fix clearly worked + the user feels it) BUT tick_miss_descheduled did NOT drop (~120/min). The .46 classifier's entryGap test conflates (a) thread preemption [RT fixes] with (b) the CADisplayLink skipping a vsync DELIVERY [RT can't - display server]. This makes the answer queryable instead of inferred:

1. glimmer_pacer_tick_realtime (0/1 gauge) - did thread_policy_set actually succeed. Stamped at all 3 outcomes in applyRealtimeScheduling (timebase-fail/policy-result/flag-off). One-query 'are we getting real-time priority'.
2. Direct promptness split: on a stretched tick, lag = CACurrentMediaTime() - link.timestamp (time since this callback's vsync). lag > 1 vsync => tick_miss_preempted (thread starved, RT failing); else => tick_miss_linkskip (thread prompt, the display server skipped a vsync - RT working, residual not ours). Independent of entryGap which stretches in both. Old descheduled/coalesced kept for compare.

Measurement-only; .47 RT params untouched. Expected read: realtime=1, preempted~0, linkskip carries the residual => RT confirmed working, the 'not 100% perfect' is the macOS display pipeline. Build + 156 tests green.