### PR TITLE
fix: 2026.6.49 - release-integrity gate, RT-flag breadcrumb, telemetry accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026.6.49 - 2026-06-26
+
+Release-integrity gate: release builds are now refused from a dirty worktree,
+and publishing asserts the committed version at the tag matches the built
+bundle - so the GPLv3 source at a tag always reproduces the binary (closing the
+2026.6.48 dirty-build gap). Adds a per-session diagnostic for why the 2026.6.47
+real-time present scheduling never engages in the field, plus telemetry-accuracy
+fixes: per-second metrics no longer emit a giant spike across a reconnect, the
+real-time gauge no longer lies on reconnect, and the present on-time/late counts
+are now honest per-window gauges instead of non-monotonic counters. No behavior
+change.
+
 ## 2026.6.48 - 2026-06-26
 
 Under the hood: confirms the 2026.6.47 real-time scheduling actually took (a

--- a/Glimmer/Stream/FramePacer+TickThread.swift
+++ b/Glimmer/Stream/FramePacer+TickThread.swift
@@ -120,6 +120,11 @@ final class PacerTickThread: @unchecked Sendable {
             // apply the Mach time-constraint policy from INSIDE the thread (once)
             // before it blocks. Best-effort - on failure it continues at
             // userInteractive (the pre-realtime path). Gated on the flag.
+            // Breadcrumb the flag's ACTUAL value at the tick thread every session,
+            // so the field tells us why RT never applies (gauge=0, no apply log).
+            Diag.notice("pacer tick realtime flag = "
+                + "\(UserDefaults.standard.bool(forKey: Self.realtimeDefaultsKey)) "
+                + "(key=\(Self.realtimeDefaultsKey))", "Stream.Pacer")
             if UserDefaults.standard.bool(forKey: Self.realtimeDefaultsKey) {
                 Self.applyRealtimeScheduling()
             } else {

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -692,9 +692,10 @@ final class TelemetryCounters: @unchecked Sendable {
         // the next suppression/gate edge.
         setPresentSuppressed(false)
         setDecodeGated(false)
-        // RT gauge: re-stamped when the next session's tick thread starts (the
-        // reset runs at the connect edge, before the pacer re-binds).
-        setPacerTickRealtime(false)
+        // RT gauge is NOT reset here: it's a THREAD-LIFETIME fact, set once when
+        // the tick thread starts. The thread is REUSED across reconnects (it never
+        // re-applies/re-stamps), so clearing it here would make the gauge lie
+        // inversely on every reconnect. Leave it at its thread-set value.
         // Per-type ignored-control tallies are per-session like the aggregate
         // total; the audio-TTF record resets but its last-stream-end stamp
         // survives (it anchors THIS session's host_idle_s).

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -66,7 +66,8 @@ extension TelemetryExporter {
         snap.decodeEmaMs = stats.avgDecodeTimeMs
 
         snap.presentCadenceErrorMs = stats.avgPresentCadenceErrorMs
-        // on-time/late split: derive counts from the on-time percent if present.
+        // on-time/late split: per-window frame counts derived from the on-time
+        // percent. Emitted as GAUGES (not counters - they're not monotonic).
         if let onTimePct = stats.onTimePresentPercent, let rendered = stats.renderedFps {
             snap.presentOnTimePercent = onTimePct
             let approxPresents = max(rendered, 0)
@@ -316,10 +317,19 @@ extension TelemetryExporter {
                         Double(now.uptimeNanoseconds &- foldedAt.uptimeNanoseconds) / 1_000_000_000.0
                     if foldDt > 0.05 { snap.packetsPerSecond = Double(packetsDelta) / foldDt }
                 }
-                snap.inputEventsPerSecond = Double(inputEventsTotal &- prevInputEventsTotal) / dt
-                snap.inputFlushPerSecond = Double(inputFlushTotal &- prevInputFlushTotal) / dt
+                // Guard each delta against a reset/wrap: resetForNewSession zeroes
+                // the totals mid-run, so emit only across a monotonic window (the
+                // prev rebaselines below regardless) - else &- renders a 2^64 spike.
+                if inputEventsTotal >= prevInputEventsTotal {
+                    snap.inputEventsPerSecond = Double(inputEventsTotal &- prevInputEventsTotal) / dt
+                }
+                if inputFlushTotal >= prevInputFlushTotal {
+                    snap.inputFlushPerSecond = Double(inputFlushTotal &- prevInputFlushTotal) / dt
+                }
                 // P1 PRESENT stale-frame repeats/sec (the invisible-stutter rate).
-                snap.staleRepeatsPerSecond = Double(staleRepeatTotal &- prevStaleFrameRepeatTotal) / dt
+                if staleRepeatTotal >= prevStaleFrameRepeatTotal {
+                    snap.staleRepeatsPerSecond = Double(staleRepeatTotal &- prevStaleFrameRepeatTotal) / dt
+                }
                 let framesDelta = framesTotal &- prevFramesTotal
                 if framesDelta > 0 {
                     snap.fecRecoveryRate =

--- a/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
@@ -68,11 +68,20 @@ extension TelemetryExporter {
         if let prev = prevCaptureTime {
             let dt = Double(now.uptimeNanoseconds &- prev.uptimeNanoseconds) / 1_000_000_000.0
             if dt > 0.05 {
-                extras.pacerOverTargetReleasesPerSecond =
-                    Double(overTargetTotal &- baselines.pacerOverTargetReleaseTotal) / dt
-                extras.audioTrimsPerSecond = Double(trimTotal &- baselines.audioTrimTotal) / dt
-                extras.rumbleEventsPerSecond =
-                    Double(rumbleTotal &- baselines.rumbleEventTotal) / dt
+                // Guard each delta against a reset/wrap: resetForNewSession zeroes
+                // the totals mid-run, so emit only across a monotonic window (skip
+                // + rebaseline below otherwise) - else &- renders a ~2^64 spike.
+                if overTargetTotal >= baselines.pacerOverTargetReleaseTotal {
+                    extras.pacerOverTargetReleasesPerSecond =
+                        Double(overTargetTotal &- baselines.pacerOverTargetReleaseTotal) / dt
+                }
+                if trimTotal >= baselines.audioTrimTotal {
+                    extras.audioTrimsPerSecond = Double(trimTotal &- baselines.audioTrimTotal) / dt
+                }
+                if rumbleTotal >= baselines.rumbleEventTotal {
+                    extras.rumbleEventsPerSecond =
+                        Double(rumbleTotal &- baselines.rumbleEventTotal) / dt
+                }
                 // The liveness totals are PER-PACER (a rebuilt pacer restarts at
                 // 0) and the snapshot is nil while the pacer is disabled - emit
                 // only across a monotonic window with a baseline, skipping (and

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -29,12 +29,16 @@ extension TelemetryRenderer {
         builder.emit("glimmer_present_on_time_percent",
                      "% of new-frame presents on-cadence (excl. stale fills) - the judder signal.",
                      snap.presentOnTimePercent)
-        if let onTime = snap.presentOnTimeCount {
-            builder.emitCounter("glimmer_present_on_time_total", "Presents that landed on-cadence.", onTime)
-        }
-        if let late = snap.presentLateCount {
-            builder.emitCounter("glimmer_present_late_total", "Presents that landed off-cadence.", late)
-        }
+        // GAUGES, not counters: these are derived per-tick from fps×pct (window-
+        // local frame counts), not monotonic accumulators, so a _total counter
+        // poisoned rate() with a reset on every fps dip. Emit the honest per-window
+        // count as a gauge - the on_time_percent gauge above is the rate signal.
+        builder.emit("glimmer_present_on_time_frames",
+                     "New-frame presents that landed on-cadence this window (count).",
+                     snap.presentOnTimeCount.map(Double.init))
+        builder.emit("glimmer_present_late_frames",
+                     "New-frame presents that landed off-cadence this window (count).",
+                     snap.presentLateCount.map(Double.init))
         builder.emit("glimmer_host_encode_latency_min_ms",
                      "Host capture+encode latency min this window, ms (host idle-ramp visible).",
                      snap.hostEncodeLatencyMinMs)

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.48
-CURRENT_PROJECT_VERSION = 20260659
+MARKETING_VERSION = 2026.6.49
+CURRENT_PROJECT_VERSION = 20260660

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,8 @@ HELPER_TARGET := arm64-apple-macos26.0
         helper-build embed-helper \
         profile profile-signposts setup-notary notarize dmg dist preflight \
         codesign-setup codesign-teardown ensure-signing dev test \
-        creds-init enable-telem disable-telem release-publish sparkle-keys
+        creds-init enable-telem disable-telem release-publish sparkle-keys \
+        guard-clean-tree
 
 # TIER 1 - "everything but publish": the full release pipeline at Release
 # (xcodebuild -> inside-out sign -> embed + re-sign dylibs -> notarize -> staple),
@@ -473,12 +474,21 @@ preflight:
 creds-init:
 	@$(CREDS) init
 
-# Full distribution pipeline: preflight (fail fast, see above) → clean Release
-# → Developer ID sign + embed → notarize + staple → DMG. The DMG's app is
-# stapled, so it passes Gatekeeper offline on any Mac. Non-interactive from any
-# session once the one-time setup is done (creds file + codesign-setup +
-# setup-notary - docs/RELEASE.md).
-dist:
+# Release-integrity gate: refuse to build a release from a dirty worktree. A
+# dirty tree means the bundle can contain uncommitted changes the tag won't
+# capture, so the GPLv3 source at the tag wouldn't reproduce the binary (the .48
+# regression). Catches both unstaged AND staged changes. Reused by dist (and
+# thus release-publish). Commit or stash first.
+guard-clean-tree:
+	@git diff --quiet HEAD || { echo "ERROR: refusing to build a release from a dirty worktree (commit or stash first)"; exit 1; }
+	@git diff --cached --quiet || { echo "ERROR: refusing to build a release with staged changes (commit or stash first)"; exit 1; }
+
+# Full distribution pipeline: clean-tree gate → preflight (fail fast, see above)
+# → clean Release → Developer ID sign + embed → notarize + staple → DMG. The
+# DMG's app is stapled, so it passes Gatekeeper offline on any Mac.
+# Non-interactive from any session once the one-time setup is done (creds file +
+# codesign-setup + setup-notary - docs/RELEASE.md).
+dist: guard-clean-tree
 	$(MAKE) CONFIG=Release preflight clean app notarize dmg
 
 # --- Auto-update publication (Sparkle) -------------------------------------

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -39,6 +39,26 @@ MAIN_SHA="$(git -C "$HERE" rev-parse origin/main)"
 	exit 1
 }
 
+# Version assertion: the committed version at the tag, the built bundle, and the
+# advertised version ($SHORT) must all agree. A dirty .48 shipped with a bundle
+# version that the committed source didn't carry; assert all three match so the
+# tag's GPLv3 source always reproduces the binary. Fail loud on any mismatch.
+COMMITTED_VERSION="$(git -C "$HERE" show "HEAD:Glimmer/Version.xcconfig" \
+	| sed -n 's/^MARKETING_VERSION = \(.*\)/\1/p' | tr -d ' ')"
+BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+	"$APP/Contents/Info.plist" 2>/dev/null || true)"
+[ "$COMMITTED_VERSION" = "$SHORT" ] || {
+	echo "ERR: committed MARKETING_VERSION ($COMMITTED_VERSION) at HEAD != advertised version ($SHORT)." >&2
+	echo "  Bump + commit Version.xcconfig so the tag's source matches what you're publishing." >&2
+	exit 1
+}
+[ "$BUNDLE_VERSION" = "$SHORT" ] || {
+	echo "ERR: built bundle CFBundleShortVersionString ($BUNDLE_VERSION) != advertised version ($SHORT)." >&2
+	echo "  Rebuild ('make dist') from the committed version - the bundle is stale." >&2
+	exit 1
+}
+echo "  ✓ version $SHORT matches committed source AND the built bundle"
+
 echo "▶ Zipping notarized bundle for Sparkle..."
 rm -f "$ZIP"
 ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"


### PR DESCRIPTION
First batch from the wide audit. C1: make dist/release-publish HARD-FAIL on a dirty worktree (guard-clean-tree) + assert tag version == bundle version (publish-release.sh) - prevents the .48 dirty-release recurrence. H2: root cause NOT found in code (key matches, registration runs at launch before the lazy tick-thread spawn, no shadowing set(false), real Bool default) - shipped a per-session breadcrumb logging the actual flag value the tick thread reads (likely a persisted UserDefaults value on the machine, not a code bug; field log will confirm). M4: stop clobbering the pacer_tick_realtime gauge in resetForNewSession (thread-lifetime fact). M1: guard 6 per-second telemetry deltas against ~2^64 wrap-spikes after reset (mirror the existing pings guard). M5: present on-time/late emitted as gauges not fake non-monotonic counters. Telemetry/tooling only, no pacing/present/audio/decode behavior change. Build + 156 tests green.