### PR TITLE
fix: 2026.6.50 - audit batch (audio recovery, disk caps, input/security, lifecycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2026.6.50 - 2026-06-26
+
+Robustness pass from a wide audit - several real "works until it doesn't" gaps.
+
+Audio now recovers mid-stream. Switching output device while streaming (AirPods,
+a USB DAC, unplugging HDMI, an OS sample-rate change) used to stop the audio
+engine for good - sound gone until you reconnected. It now detects the change
+and restarts the engine in place, and a stream that comes up with audio
+genuinely failing now says so instead of going silently video-only.
+
+Held controller inputs survive a reconnect. After a silent reconnect or a
+wake-from-sleep, a held trigger/stick/button used to read as released on the
+host until you moved it (ADS dropped, your character stopped, a charge
+cancelled). The real held state is now re-sent on reconnect.
+
+A host that crashes or drops now shows a distinct "ended unexpectedly" message
+with Retry, instead of the same calm toast as a clean quit. A wedged launch now
+gives up after ~22s (was ~55-65s) and Cancel bounces back immediately.
+
+Under the hood: quitting mid-reconnect no longer leaks a background connection;
+the per-session diagnostics trace is now size-capped and old logs are swept (it
+could grow unbounded); release builds refuse to build from an uncommitted tree;
+plus telemetry-accuracy fixes. No change to streaming/latency behavior.
+
 ## 2026.6.49 - 2026-06-26
 
 Release-integrity gate: release builds are now refused from a dirty worktree,

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -166,31 +166,71 @@ extension MoonlightManager {
             uniqueId: host.id,
             serverName: host.displayName
         )
-        // PinnedCertStore.load handles file-store + UserDefaults migration
-        // transparently - file wins, UserDefaults fallback migrates
-        // forward + cleans up.
-        let persistedPin = PinnedCertStore.load(forHostID: host.id)
-        if persistedPin == nil {
-            // Diagnostic: a stream attempt against a host record that has
-            // no pin under the canonical key means we're about to go
-            // through TOFU even though the user thinks they're paired.
-            // This was the silent failure mode the pin-key normalization
-            // (#4) was introduced to fix; if it still trips after that
-            // fix lands, the host record's `id` and the pair-time
-            // `server.uniqueId` are out of sync for a reason the fix
-            // didn't cover.
-            log.error(
-                """
-                No pinned cert for host id=\(host.id, privacy: .public) - stream will fall to TOFU. \
-                Check that host.id matches server.uniqueId (the host's `<uniqueid>` from /serverinfo).
-                """
-            )
-        }
-        info.serverCertPEM = persistedPin ?? host.serverCertPEM
+        // H1: the mode-0600 file store is the ONLY authoritative pin source.
+        // `host.serverCertPEM` lives in same-UID-writable UserDefaults
+        // (hosts.N.srvcert) - an attacker can swap it for a MITM cert via
+        // cfprefsd, so we treat it as an untrusted HINT, never a direct pin.
+        info.serverCertPEM = authoritativePin(for: host)
         info.appVersion = host.appVersion
         info.gfeVersion = host.gfeVersion
         info.pairStatus = .paired      // host is in our local list → already paired
         return info
+    }
+
+    /// Resolve the host's TLS pin from the authoritative file store, honoring
+    /// the legacy UserDefaults hint (`host.serverCertPEM`) only as a one-way
+    /// migration source. File ALWAYS wins; a file-vs-hint mismatch is a hard
+    /// error (refuse + force re-pair), never a silent fallback. Returns nil
+    /// when no trustworthy pin exists - the pairStatus gate then forces a
+    /// re-pair rather than pinning a writable value.
+    private func authoritativePin(for host: MoonlightHost) -> String? {
+        let filePin = PinnedCertStore.load(forHostID: host.id)
+        let hint = host.serverCertPEM.flatMap { $0.isEmpty ? nil : $0 }
+
+        if let filePin {
+            // File wins. If the writable hint disagrees, someone moved one of
+            // them - refuse to stream and force a re-pair rather than guess.
+            if let hint, hint != filePin {
+                log.error(
+                    """
+                    Pinned cert for host id=\(host.id, privacy: .public) DISAGREES with the \
+                    UserDefaults hint - refusing to stream and forcing re-pair (possible MITM).
+                    """
+                )
+                return nil
+            }
+            return filePin
+        }
+
+        // No file pin. Migrate the untrusted hint into the file store ONCE,
+        // then read it back from the file store so every later read is
+        // file-only. If the migration write fails, refuse rather than pin a
+        // same-UID-writable value.
+        if let hint {
+            do {
+                try PinnedCertStore.store(pem: hint, forHostID: host.id)
+                return PinnedCertStore.load(forHostID: host.id)
+            } catch {
+                log.error(
+                    """
+                    Failed to migrate the UserDefaults cert hint into the file store for host \
+                    id=\(host.id, privacy: .public): \(error.localizedDescription, privacy: .public) - \
+                    forcing re-pair instead of pinning a writable value.
+                    """
+                )
+                return nil
+            }
+        }
+
+        // Neither store has a pin: stream falls to a forced re-pair (the
+        // pairStatus gate handles it), not TOFU on a writable cert.
+        log.error(
+            """
+            No pinned cert for host id=\(host.id, privacy: .public) - forcing re-pair. \
+            Check that host.id matches server.uniqueId (the host's `<uniqueid>` from /serverinfo).
+            """
+        )
+        return nil
     }
 
     /// UI entry point for a launch. If the host is already streaming an app
@@ -397,9 +437,15 @@ extension MoonlightManager {
             // reach-failure copy is correct there.)
             self.nativeStreamError =
                 Self.connectFailureBanner(for: caughtError, hostName: hostName)
-        } else {
-            self.nativeStreamError = nil
         }
+        // M3: do NOT unconditionally clear nativeStreamError here. A host-side
+        // "ended unexpectedly" terminate (code != 0) already set the banner on
+        // the event loop, and this single teardown runs for BOTH a clean quit
+        // and that host error - unconditionally nilling wiped the banner before
+        // it ever rendered (host crash / power-loss / watchdog stall looked
+        // identical to a clean quit, and Retry went dead). Leaving an already-set
+        // banner in place lets it survive; a clean quit set it to nil up above
+        // (line 273 at stream start) so nothing stale leaks through.
         let wasStreaming = self.isStreaming
         self.streamPhase = .idle
         self.isStreaming = false

--- a/Glimmer/MoonlightManager+Streaming.swift
+++ b/Glimmer/MoonlightManager+Streaming.swift
@@ -585,6 +585,11 @@ extension MoonlightManager {
             streamPhase = .streaming
         case .hdrModeChanged: break  // intent signal only - see .hdrActive
         case .hdrActive(let active): nativeHDRActive = active
+        case .audioFailed:
+            // H7: audio receive failed to start - the session is video-only.
+            // Non-fatal to the visual stream, so stay in the streaming phase;
+            // the failure is already logged + counted at the source.
+            break
         case .log: break
         }
     }

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -40,6 +40,11 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `applyVarispeedRate` (the resampler extension) writes through it.
     let varispeedRateQueue = DispatchQueue(label: "io.ugfugl.Glimmer.audio.varispeed-rate")
     private var inputFormat: AVAudioFormat?
+    /// Last-known engine OUTPUT (hardware) format, captured when the engine
+    /// starts. The config-change handler (H3) compares against this to decide
+    /// whether the output route's format actually moved (so it reconnects
+    /// `varispeed -> mainMixer` only on a real change). Guarded by `stateLock`.
+    private var lastOutputFormat: AVAudioFormat?
     private var channelCount: Int = 2
     private var samplesPerFrame: Int = 240         // 5ms at 48kHz, common GFE/Sunshine config
     private var streams: Int = 1
@@ -345,6 +350,15 @@ public final class AudioDecoder: @unchecked Sendable {
     var routeListenerBlock: AudioObjectPropertyListenerBlock?
     let routeListenerQueue = DispatchQueue(label: "io.ugfugl.Glimmer.audio.route", qos: .utility)
 
+    /// `AVAudioEngineConfigurationChange` observer token (held so `shutdown()`
+    /// can remove it). On a mid-stream output-device/format change AVAudioEngine
+    /// STOPS its outputNode; without this, playout goes silent for the rest of
+    /// the session. The handler re-resolves + reconnects + restarts the engine on
+    /// the `stateLock`-serialized path. Fires on a NOTIFICATION (not a player-node
+    /// completion handler), so a node-prop change there is safe - see `handle
+    /// EngineConfigurationChange`. Lifecycle-guarded by `stateLock`.
+    private var configChangeObserver: NSObjectProtocol?
+
     // MARK: - P1 AUDIO playout MIN-fill telemetry
     //
     // The windowed MIN buffer-fill itself lives in `TelemetryCounters` (a
@@ -508,10 +522,19 @@ public final class AudioDecoder: @unchecked Sendable {
         // Engine-running mirror for the telemetry gauge, set under the meter lock
         // (read there by publishAudioState) - a plain Bool, no AVAudio call.
         audioMeterLock.lock(); engineRunning = engine.isRunning; audioMeterLock.unlock()
+        // Baseline the output (hardware) format so the config-change handler can
+        // tell a real route-format move from a benign notification.
+        lastOutputFormat = engine.outputNode.outputFormat(forBus: 0)
         // Seed + track the audio OUTPUT route for the under-run breadcrumbs.
         // Installed only after the engine is up, so a failed init never leaves a
         // listener behind; `shutdown()` removes it.
         installAudioRouteListener()
+        // H3: recover playout across a mid-stream output-device/format change
+        // (BT/AirPods connect-disconnect, HDMI/DP unplug, USB-DAC removal, OS
+        // sample-rate change), which STOPS the engine's outputNode. Installed
+        // after the engine is up so a failed init never leaves an observer behind;
+        // `shutdown()` removes it.
+        installConfigChangeObserver()
         return 0
     }
 
@@ -534,6 +557,7 @@ public final class AudioDecoder: @unchecked Sendable {
         playerNode.stop()
         engine.stop()
         removeAudioRouteListener()
+        removeConfigChangeObserver()
         if let decoderPtr = decoder {
             opus_multistream_decoder_destroy(decoderPtr)
             decoder = nil
@@ -542,6 +566,92 @@ public final class AudioDecoder: @unchecked Sendable {
         // ref to us; when StreamSession drops its strong reference the bridge
         // sees nil at the next callback (or the bridge itself is released
         // first, which short-circuits earlier).
+    }
+
+    // MARK: - H3/H4 mid-stream audio-config recovery
+    //
+    // On a mid-stream output-device/format change (BT/AirPods connect-disconnect,
+    // HDMI/DP unplug, USB-DAC removal, OS sample-rate change) AVAudioEngine STOPS
+    // its outputNode and posts `AVAudioEngineConfigurationChange` - so without
+    // recovery audio goes silent for the rest of the session. The route listener
+    // only swaps a cached string; this is the actual recovery hop.
+    //
+    // DEADLOCK SAFETY: this fires on a NOTIFICATION, not a player-node completion
+    // handler, so re-arming node properties here is safe - the historical freeze
+    // came from touching AVAudio node props INSIDE a completion handler (which
+    // holds the messenger lock and deadlocked teardown's `playerNode.stop()`).
+    // We serialize on the SAME `stateLock` the decode + shutdown paths use, and
+    // make ZERO node-prop changes from any completion path. `playerNode.stop()`
+    // here flushes the queued buffers' completions, but those run
+    // `meterCompleteOnePlayout`, which makes no AV calls (only `audioMeterLock`).
+
+    /// Register the `AVAudioEngineConfigurationChange` observer. Called once from
+    /// `initDecoderCore` with `stateLock` held (after the engine is up);
+    /// idempotent via the token. The handler runs off a utility queue so the
+    /// notification thread never blocks on `stateLock`.
+    private func installConfigChangeObserver() {
+        guard configChangeObserver == nil else { return }
+        configChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange, object: engine, queue: nil
+        ) { [weak self] _ in
+            self?.routeListenerQueue.async { self?.handleEngineConfigurationChange() }
+        }
+    }
+
+    /// Remove the config-change observer. Called from `shutdown()` with
+    /// `stateLock` held; safe when never installed.
+    private func removeConfigChangeObserver() {
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
+    }
+
+    /// Re-resolve the output format, reconnect `varispeed -> mainMixer` if it
+    /// moved, restart the engine if it stopped, and re-arm the pre-roll so the
+    /// cushion rebuilds. On the `stateLock`-serialized path (never a completion
+    /// handler). H4: re-samples `engine.isRunning` into the gauge mirror here too.
+    private func handleEngineConfigurationChange() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !isShutdown, let fmt = inputFormat else { return }
+        let newOutputFormat = engine.outputNode.outputFormat(forBus: 0)
+        let formatMoved = lastOutputFormat.map { $0.sampleRate != newOutputFormat.sampleRate
+            || $0.channelCount != newOutputFormat.channelCount } ?? true
+        lastOutputFormat = newOutputFormat
+        let wasRunning = engine.isRunning
+        if formatMoved {
+            // The output route's format changed: stop the player + reconnect the
+            // graph at our (unchanged) decode format - the mixer/output handle SRC
+            // to the new hardware rate. stop() here fires queued completions on the
+            // meter path (no AV calls), and we hold stateLock so no decode races.
+            playerNode.stop()
+            engine.connect(varispeed, to: engine.mainMixerNode, format: fmt)
+        }
+        if !engine.isRunning {
+            do {
+                try engine.start()
+            } catch {
+                Diag.error("audio engine restart after config change FAILED: "
+                    + "\(error.localizedDescription)", "Stream.Audio")
+            }
+        }
+        // H4: re-sample the engine-running gauge here (the same hop), and RE-ARM
+        // the pre-roll so the cushion rebuilds from the restart rather than the
+        // player resuming on the under-run floor. A plain Bool + state-machine
+        // resets under the meter lock - no AV call.
+        let nowRunning = engine.isRunning
+        audioMeterLock.lock()
+        engineRunning = nowRunning
+        if formatMoved || (!wasRunning && nowRunning) {
+            primed = false
+            playoutStarted = false
+            playoutDrained = false
+            buffersSinceArm = 0
+        }
+        audioMeterLock.unlock()
+        Diag.notice("audio engine config change handled "
+            + "(format \(formatMoved ? "moved" : "same"), running \(nowRunning))", "Stream.Audio")
     }
 
     // MARK: Per-sample decoding

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -502,6 +502,13 @@ public final class InputForwarder {
                 for state in attachedControllers.values {
                     sendArrival(state)
                 }
+                // H6: arrival's bundled fallback re-zeroes each pad, so on a
+                // SILENT reconnect/wake the host reads held triggers/sticks as
+                // neutral until the user twitches (valueChangedHandler only fires
+                // on CHANGE). Re-read + re-forward live held state right after the
+                // arrivals (idempotent; covers reconnects that keep the window key
+                // and so never hit the didBecomeKey resync).
+                resyncControllers()
                 installDiagnosticMonitors()
             } else {
                 removeDiagnosticMonitors()

--- a/Glimmer/Stream/NativeBackend+Pipeline.swift
+++ b/Glimmer/Stream/NativeBackend+Pipeline.swift
@@ -325,6 +325,11 @@ extension NativeBackend {
         } catch {
             Diag.error("native backend: audio receive start failed: \(error)", Self.logCategory)
             // Keep the ping alive (it keeps the A/V session up); only receive failed.
+            // H7: surface the video-only state instead of swallowing it - a
+            // queryable counter + a non-fatal event (the visual stream is fine).
+            TelemetryCounters.shared.audioReceiveFailedTotal.increment()
+            StreamBridgeContext.current?.eventContinuation?.yield(
+                .audioFailed("\(error)"))
         }
     }
 

--- a/Glimmer/Stream/StreamSession+Lifecycle.swift
+++ b/Glimmer/Stream/StreamSession+Lifecycle.swift
@@ -300,12 +300,102 @@ extension StreamSession {
             }
         } catch let first as StreamError {
             log.error("primary launch path failed: \(String(describing: first), privacy: .public)")
+            // M6: a stop()/cancelConnect() can land during the primary leg or the
+            // host-idle poll. The actor sweeps it in at our awaits; re-check here
+            // so the recovery leg (another ~5s poll + 20s /launch) doesn't stack on
+            // a session the user already cancelled - rethrow the first error and
+            // let start()'s teardown win instead.
+            guard isStreaming, !stopInProgress else { throw first }
             // Recovery: race between hint and actual host state. One more
             // cancel + launch covers the "we thought idle but host had an
             // orphan" and the "cancel raced" cases. We deliberately do NOT
             // fall back to /resume here - that's the bug we're closing.
             if let r = try? await tryCancelThenLaunch() { return r }
             throw first
+        }
+    }
+
+    /// True once a teardown has begun - either `stop()` flipped the latch or the
+    /// session is no longer streaming. The launch-deadline watcher polls this so a
+    /// stop()/cancelConnect() landing mid-launch bounces back without waiting out
+    /// the non-cancellable HTTP leg. Actor-isolated so the read is race-free.
+    var isTearingDown: Bool { !isStreaming || stopInProgress }
+
+    /// M6: run `launchWithBusyRecovery` under an overall wall-clock deadline.
+    ///
+    /// ControlTransport's HTTP leg is a blocking socket that isn't cancellation-
+    /// aware (it only unwinds on its own ~20s SO_RCVTIMEO), so we CANNOT rely on
+    /// structurally awaiting the launch - a task-group child or `Task.result`
+    /// await would pin us until that socket timed out, defeating the deadline.
+    /// Instead a first-writer-wins box collects whichever of {launch finished,
+    /// deadline/stop tripped} lands first; the read completes the instant either
+    /// writer fires, so on a timeout/cancel we return PROMPTLY and leave the
+    /// detached launch (now cancelled) to die on its own socket - rather than
+    /// stranding the user at "Connecting..." for ~55-65s. The timeout surfaces as
+    /// `.launchFailed` with honest copy.
+    func launchWithDeadline(
+        network: NetworkClient,
+        appID: Int,
+        config: StreamConfig,
+        hintCurrentGame: Int
+    ) async throws -> LaunchResponse {
+        let deadline = Self.launchOverallDeadlineSeconds
+        let box = FirstResultBox<LaunchResponse>()
+        let launchTask = Task { [self] in
+            do {
+                let r = try await launchWithBusyRecovery(
+                    network: network, appID: appID, config: config,
+                    hintCurrentGame: hintCurrentGame)
+                await box.offer(.success(r))
+            } catch {
+                await box.offer(.failure(error))
+            }
+        }
+        // Watcher: trips on the wall-clock deadline OR a stop()/cancelConnect()
+        // landing mid-launch (the blocking HTTP leg can't be force-aborted, so
+        // without this the user would wait out the full deadline). Polls in 250ms.
+        let watcher = Task { [self] in
+            let end = Date().addingTimeInterval(deadline)
+            while Date() < end {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                if Task.isCancelled { return }
+                if await self.isTearingDown {
+                    await box.offer(.failure(StreamError.launchFailed("Launch cancelled.")))
+                    return
+                }
+            }
+            await box.offer(.failure(StreamError.launchFailed(
+                "Host didn't respond within \(Int(deadline))s - giving up.")))
+        }
+        // Completes as soon as EITHER writer offers; the loser's later offer is
+        // dropped by the box. Don't await the detached tasks structurally.
+        let outcome = await box.value
+        watcher.cancel()
+        // On loss (timeout/cancel won), cancel the launch - best-effort; it dies
+        // on its socket timeout and its late box.offer is a no-op.
+        if case .failure = outcome { launchTask.cancel() }
+        return try outcome.get()
+    }
+}
+
+/// First-writer-wins async box: the first `offer` latches the value and resumes
+/// the (single) pending `value` read; later offers are dropped. Used by M6 to
+/// race a non-cancellable launch against a deadline/stop watcher and return the
+/// instant either lands. Actor-isolated for race-free latching.
+private actor FirstResultBox<T: Sendable> {
+    private var result: Result<T, Error>?
+    private var waiter: CheckedContinuation<Result<T, Error>, Never>?
+
+    func offer(_ value: Result<T, Error>) {
+        guard result == nil else { return }
+        result = value
+        if let waiter { self.waiter = nil; waiter.resume(returning: value) }
+    }
+
+    var value: Result<T, Error> {
+        get async {
+            if let result { return result }
+            return await withCheckedContinuation { cont in waiter = cont }
         }
     }
 }

--- a/Glimmer/Stream/StreamSession+Reconnect.swift
+++ b/Glimmer/Stream/StreamSession+Reconnect.swift
@@ -149,6 +149,12 @@ extension StreamSession {
         //    frame, the bridge + event stream, and StreamBridgeContext.current.
         await teardownConnectionForReconnect()
 
+        // H5: re-check after the teardown await. stop() flips isStreaming/
+        // stopInProgress synchronously before its own first await, so a guard
+        // evaluated ON the actor between awaits reliably observes a teardown that
+        // slipped in. Bail BEFORE building a fresh backend - nothing to clean up.
+        guard isStreaming, !stopInProgress else { return false }
+
         // 2. Swap in a fresh backend (NativeBackend is one-shot: its connection
         //    state can't be reused and interrupt() latches permanently). Re-point
         //    input + decoder on the MainActor so uplink + IDR requests go to the
@@ -182,10 +188,39 @@ extension StreamSession {
             return false
         }
 
+        // H5: a stop() can land at ANY of the awaits above (~0.8-2.4s of handshake
+        // per attempt, plus the frozen "Reconnecting..." banner invites a quit).
+        // If one did, `fresh` + `net` are now a LIVE ENet/RTP backend on a session
+        // with isStreaming=false and no teardown path - a zombie for the process
+        // lifetime, with the host holding a "busy" session. interruptConnection()
+        // (the permanent latch, drains the receive threads) + drop the client so
+        // no live backend/NetworkClient survives the slipped-in stop. The episode
+        // loop's own re-checks then exit; the existing stop() torn-down everything
+        // else (window/decoder/bridge) already.
+        guard isStreaming, !stopInProgress else {
+            Diag.notice("reconnect: stop slipped in mid-handshake - "
+                + "interrupting the freshly-built backend to kill the zombie connection", "Stream")
+            await tearDownSlippedInReconnect(fresh: fresh, net: net)
+            return false
+        }
+
         // 4. Nudge a keyframe so the fresh VT session repaints over the frozen
         //    frame promptly (Sunshine sends one at start; cheap insurance).
         backend.requestIdrFrame()
         return true
+    }
+
+    /// H5 cleanup: a `stop()` slipped in while this attempt was mid-handshake, so
+    /// the just-built `fresh` backend + `net` client are live on an already-ended
+    /// session. Interrupt the backend (permanent latch; drains the receive threads
+    /// so no callback can fire after) and shut the client so the host drops its
+    /// session record. Only nil `self.network` if it's still the one we built - a
+    /// concurrent stop() may have already nil'd it.
+    private func tearDownSlippedInReconnect(fresh: NativeBackend, net: NetworkClient) async {
+        fresh.interruptConnection()
+        try? await net.cancel()
+        await net.shutdown()
+        if self.network === net { self.network = nil }
     }
 
     /// Connection-only teardown for a reconnect: bring the backend connection

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -119,7 +119,11 @@ extension StreamSession {
         // already going), then fall back through busy-recovery if the host
         // disagrees. `<currentgame>` parsing is inconsistent across hosts so
         // we treat it as a hint, not gospel.
-        let launch: LaunchResponse = try await launchWithBusyRecovery(
+        // M6: bound the initial-connect launch with an overall deadline so the
+        // busy-recovery retries can't stack to ~55-65s of "Connecting...". The
+        // reconnect path keeps the un-deadlined call - its episode already bounds
+        // the total (attempt cap + window).
+        let launch: LaunchResponse = try await launchWithDeadline(
             network: network, appID: appID, config: config,
             hintCurrentGame: serverInfo.currentGameID
         )

--- a/Glimmer/Stream/StreamSession.swift
+++ b/Glimmer/Stream/StreamSession.swift
@@ -229,6 +229,15 @@ public actor StreamSession {
     /// ...and at most this long wall-clock before we give up and tear down.
     static let reconnectWindowSeconds: TimeInterval = 30.0
 
+    // MARK: - Launch deadline (M6)
+
+    /// Overall wall-clock cap on the initial-connect launch path
+    /// (`launchWithBusyRecovery`). Without it the busy-recovery retries stack to
+    /// ~55-65s of "Connecting...". 22s leaves room for one full /launch leg
+    /// (NetworkClient.launchTimeout = 20s) plus the host-idle poll, but bounds the
+    /// stack so the launcher bounces back honestly instead of hanging.
+    static let launchOverallDeadlineSeconds: TimeInterval = 22.0
+
     /// True once this session reached a LIVE state (`.connectionEstablished`).
     /// Gates reconnect: a terminate BEFORE we ever went live is a failed connect,
     /// not a recoverable interruption. Set on the established edge; never reset on

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -356,6 +356,12 @@ final class TelemetryCounters: @unchecked Sendable {
     /// be conflated in a cross-session comparison again. Bumped on the decode
     /// path like its sibling. Always-live integer add.
     let audioTrimTotal = Counter()
+    /// Audio RECEIVE-start failures (H7): `RtpAudioReceiver.startReceive()` threw,
+    /// so this session came up VIDEO-ONLY (the ping keeps the A/V session alive,
+    /// but no audio flows). Previously the throw was caught and dropped with no
+    /// counter and no user signal - a silent audio-dead session. Bumped from the
+    /// pipeline catch alongside the `.audioFailed` event. Always-live integer add.
+    let audioReceiveFailedTotal = Counter()
 
     // ---- Input-activity gauge (last-input instant + idle-edge detection) ----
     //
@@ -667,7 +673,8 @@ final class TelemetryCounters: @unchecked Sendable {
                         discontinuityFlushTotal,
                         audioPacketsTotal, audioPacketsLostTotal, audioFecRecoveredTotal,
                         audioFecMismatchTotal, audioUnderrunTotal, audioOverrunTotal,
-                        audioTrimTotal, rumbleEventTotal, rumbleDroppedInvalidTotal,
+                        audioTrimTotal, audioReceiveFailedTotal,
+                        rumbleEventTotal, rumbleDroppedInvalidTotal,
                         // Per-socket gap-event counters.
                         videoGapOver20msTotal, videoGapOver50msTotal, videoGapOver100msTotal,
                         audioGapOver20msTotal, audioGapOver50msTotal, audioGapOver100msTotal,

--- a/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
@@ -37,6 +37,7 @@ extension TelemetryExporter {
         extras.presentSuppressed = counters.presentSuppressed
         extras.ctrlIgnoredTotal = counters.ctrlIgnoredTotal.value
         extras.audioFecMismatchTotal = counters.audioFecMismatchTotal.value
+        extras.audioReceiveFailedTotal = counters.audioReceiveFailedTotal.value
         // The third hidden-window state: gated (decode stopped) vs merely
         // suppressed (decoded, dropped-to-newest) - plus its designed drops.
         extras.decodeGated = counters.decodeGated
@@ -184,6 +185,10 @@ extension TelemetrySnapshot {
         var audioTrimsPerSecond: Double?
         /// Audio FEC blocks dropped on a parity/data block-size mismatch.
         var audioFecMismatchTotal: UInt64 = 0
+        /// Audio RECEIVE-start failures (H7): the session came up video-only
+        /// because `startReceive()` threw. >0 with audio dark is the direct
+        /// "no audio this session" signal the silent catch used to hide.
+        var audioReceiveFailedTotal: UInt64 = 0
         /// Pacer display-link ticks + frame releases per second, from the
         /// liveness totals - the DIRECT measure of display-link callback misses
         /// (previously only reconstructable as rendered+stale).

--- a/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderAudio.swift
@@ -33,6 +33,10 @@ extension TelemetryRenderer {
         builder.emitCounter("glimmer_audio_fec_mismatch_total",
                             "Audio FEC blocks dropped on a parity/data block-size mismatch.",
                             extras.audioFecMismatchTotal)
+        builder.emitCounter("glimmer_audio_receive_failed_total",
+                            "Audio receive-start failures (session came up video-only - "
+                            + "startReceive() threw).",
+                            extras.audioReceiveFailedTotal)
         builder.emit("glimmer_audio_packets_per_second",
                      "Audio data packets accepted per second.", audio.packetsPerSecond)
         builder.emit("glimmer_audio_loss_rate",

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -120,6 +120,8 @@ extension TelemetryRenderer {
         // FEC blocks dropped on a parity/data size mismatch (counted, never a
         // silent permanent give-up).
         builder.addCount("audio_fec_mismatch_total", extras.audioFecMismatchTotal)
+        // Receive-start failures (H7): >0 with audio dark = video-only session.
+        builder.addCount("audio_receive_failed_total", extras.audioReceiveFailedTotal)
         builder.add("audio_pkts_per_s", audio.packetsPerSecond)
         builder.add("audio_loss_rate", audio.lossRate)
         builder.add("audio_fec_recovery_rate", audio.fecRecoveryRate)

--- a/Glimmer/Stream/TelemetryExporter.swift
+++ b/Glimmer/Stream/TelemetryExporter.swift
@@ -473,6 +473,13 @@ final class TelemetryExporter: @unchecked Sendable {
             log.error("Telemetry: could not create log dir: \(error.localizedDescription, privacy: .public)")
             return
         }
+        // C2: prune the Logs dir BEFORE creating this session's file (so the
+        // newest files - this session's siblings - always survive). A fresh trio
+        // of files was minted every session and never pruned; over months that
+        // dir grows without bound (the per-frame trace alone is ~1.5GB/6h before
+        // the rollover above caps it). Bounded by a total-byte budget + an age
+        // limit, newest-kept.
+        Self.sweepLogsDirectory(dir, log: log)
         // ISO8601 with ':' is filename-legal on APFS; keep the full timestamp so
         // each session's file is unique and sorts chronologically.
         let stamp = isoFormatter.string(from: Date())
@@ -496,6 +503,69 @@ final class TelemetryExporter: @unchecked Sendable {
             // A write failure (disk full, file removed) shouldn't take down the
             // stream - drop the line and keep going.
             log.error("Telemetry NDJSON write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - C2 Logs-directory sweep
+
+    /// Total-byte budget for `~/Library/Logs/Glimmer` after a sweep. Once the
+    /// dir exceeds this, the OLDEST Glimmer log files are pruned (newest kept)
+    /// until it fits. 300MB holds many sessions of NDJSON + the size-capped
+    /// per-frame trace tails while bounding unbounded growth.
+    private static let logsByteBudget: UInt64 = 300 * 1024 * 1024
+    /// Age limit (seconds): a Glimmer log file older than this is pruned
+    /// regardless of the byte budget. 14 days.
+    private static let logsMaxAgeSeconds: TimeInterval = 14 * 24 * 3600
+
+    /// Prune the Glimmer Logs dir to the age limit + the byte budget, newest
+    /// kept. Touches ONLY our own log files (`telemetry-*` / `glimmer-*` - the
+    /// NDJSON, per-frame trace, session report, and Diag log families) so it can
+    /// never remove anything else in the dir. Best-effort: any error per file is
+    /// swallowed (a failed prune must never break telemetry bring-up). On the
+    /// exporter's `workQueue` (called once at session start) - never a hot path.
+    static func sweepLogsDirectory(_ dir: URL, log: Logger) {
+        let fm = FileManager.default
+        let keys: [URLResourceKey] = [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey]
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]) else { return }
+        // Our own log families only - never delete a foreign file.
+        let ours = entries.filter { url in
+            let name = url.lastPathComponent
+            return name.hasPrefix("telemetry-") || name.hasPrefix("glimmer-")
+        }
+        struct Entry { let url: URL; let modified: Date; let size: UInt64 }
+        var files: [Entry] = []
+        for url in ours {
+            guard let values = try? url.resourceValues(forKeys: Set(keys)),
+                  values.isRegularFile == true else { continue }
+            files.append(Entry(url: url,
+                               modified: values.contentModificationDate ?? .distantPast,
+                               size: UInt64(values.fileSize ?? 0)))
+        }
+        let now = Date()
+        var pruned = 0
+        // (1) AGE prune.
+        var survivors: [Entry] = []
+        for entry in files {
+            if now.timeIntervalSince(entry.modified) > logsMaxAgeSeconds {
+                if (try? fm.removeItem(at: entry.url)) != nil { pruned += 1 }
+            } else {
+                survivors.append(entry)
+            }
+        }
+        // (2) BYTE-BUDGET prune: oldest-first until under budget.
+        var total = survivors.reduce(UInt64(0)) { $0 &+ $1.size }
+        if total > logsByteBudget {
+            for entry in survivors.sorted(by: { $0.modified < $1.modified }) {
+                guard total > logsByteBudget else { break }
+                if (try? fm.removeItem(at: entry.url)) != nil {
+                    total &-= entry.size
+                    pruned += 1
+                }
+            }
+        }
+        if pruned > 0 {
+            log.notice("Telemetry: swept \(pruned, privacy: .public) old log file(s) from Logs/Glimmer")
         }
     }
 

--- a/Glimmer/Stream/TelemetryFrameTrace.swift
+++ b/Glimmer/Stream/TelemetryFrameTrace.swift
@@ -41,9 +41,27 @@ final class FrameTraceWriter: @unchecked Sendable {
     /// losing the stalest is the right tradeoff) and is logged once.
     private static let maxPendingLines = 10_000
 
+    /// SIZE-CAPPED ROLLOVER (C2): the per-frame trace writes ~275B/presented
+    /// frame unconditionally - ~1.5GB/6h unbounded. Past this many bytes the
+    /// current file is closed and a fresh `-<n>` segment opens; only the last
+    /// `maxTraceFiles` segments of THIS session are kept (older ones pruned). The
+    /// steady-state signal still lives in the 1Hz NDJSON sink, so a bounded tail
+    /// of the per-frame detail is the right tradeoff. 96MB × 4 ≈ 384MB ceiling.
+    private static let maxFileBytes: UInt64 = 96 * 1024 * 1024
+    private static let maxTraceFiles = 4
+
     private let flushQueue = DispatchQueue(label: "io.ugfugl.Glimmer.telemetry.frames", qos: .utility)
     private var fileHandle: FileHandle?
     private var flushTimer: DispatchSourceTimer?
+    /// Rollover state (flushQueue-confined): the Logs dir + this session's ISO
+    /// stamp (so segments share a prefix), the running byte count of the current
+    /// segment, the next segment index, and the segment files written this session
+    /// (oldest-first, for the keep-last-K prune).
+    private var logDir: URL?
+    private var isoStamp = ""
+    private var bytesWritten: UInt64 = 0
+    private var rolloverIndex = 0
+    private var segmentURLs: [URL] = []
 
     /// Pending lines + their lock. The lock is taken ONLY on the telemetry path
     /// (which is off by default) - never on the proven decode/pace path when the
@@ -68,15 +86,9 @@ final class FrameTraceWriter: @unchecked Sendable {
                 self.log.error("Telemetry frames: could not create log dir: \(error.localizedDescription, privacy: .public)")
                 return
             }
-            let url = dir.appendingPathComponent("telemetry-frames-\(isoStamp).ndjson")
-            FileManager.default.createFile(atPath: url.path, contents: nil)
-            do {
-                self.fileHandle = try FileHandle(forWritingTo: url)
-                self.log.notice("Telemetry per-frame trace → \(url.path, privacy: .public)")
-            } catch {
-                self.log.error("Telemetry frames: could not open file: \(error.localizedDescription, privacy: .public)")
-                return
-            }
+            self.logDir = dir
+            self.isoStamp = isoStamp
+            guard self.openSegment() else { return }
             let timer = DispatchSource.makeTimerSource(queue: self.flushQueue)
             timer.schedule(deadline: .now() + Self.flushInterval, repeating: Self.flushInterval,
                            leeway: .milliseconds(50))
@@ -84,6 +96,41 @@ final class FrameTraceWriter: @unchecked Sendable {
             self.flushTimer = timer
             timer.resume()
         }
+    }
+
+    /// Open the next trace SEGMENT (`telemetry-frames-<iso>.ndjson` for the first,
+    /// `-<n>.ndjson` after a rollover), reset the byte count, and prune so only
+    /// the last `maxTraceFiles` segments of this session survive. flushQueue-only.
+    /// Returns false (and logs) if the file can't be opened.
+    private func openSegment() -> Bool {
+        guard let dir = logDir else { return false }
+        let suffix = rolloverIndex == 0 ? "" : "-\(rolloverIndex)"
+        let url = dir.appendingPathComponent("telemetry-frames-\(isoStamp)\(suffix).ndjson")
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        do {
+            fileHandle = try FileHandle(forWritingTo: url)
+        } catch {
+            log.error("Telemetry frames: could not open file: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+        log.notice("Telemetry per-frame trace → \(url.path, privacy: .public)")
+        bytesWritten = 0
+        rolloverIndex += 1
+        segmentURLs.append(url)
+        // Keep only the last K segments of THIS session - drop the oldest.
+        while segmentURLs.count > Self.maxTraceFiles {
+            let stale = segmentURLs.removeFirst()
+            try? FileManager.default.removeItem(at: stale)
+        }
+        return true
+    }
+
+    /// Close the current segment and open the next - the size-cap rollover.
+    /// flushQueue-only (called from `drainLocked` after a write crosses the cap).
+    private func rollover() {
+        try? fileHandle?.close()
+        fileHandle = nil
+        _ = openSegment()
     }
 
     /// Stop the timer, flush whatever is pending, close the file. Synchronous so
@@ -131,6 +178,12 @@ final class FrameTraceWriter: @unchecked Sendable {
         guard let data = blob.data(using: .utf8) else { return }
         do {
             try fileHandle.write(contentsOf: data)
+            bytesWritten &+= UInt64(data.count)
+            // Past the size cap: close + reopen a fresh segment, pruning so only
+            // the last K survive. One rollover per drain (the batch is at most one
+            // flush interval's frames, far below the cap), so the file can never
+            // overshoot by more than a single batch.
+            if bytesWritten >= Self.maxFileBytes { rollover() }
         } catch {
             log.error("Telemetry per-frame trace write failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -565,6 +565,7 @@ struct SessionReport {
             ("audio_underrun", counters.audioUnderrunTotal.value),
             ("audio_overrun", counters.audioOverrunTotal.value),
             ("audio_trim", counters.audioTrimTotal.value),
+            ("audio_receive_failed", counters.audioReceiveFailedTotal.value),
             // P2 session tallies: the run's reconnect count + the corruption/
             // artifact heuristic total (the white/purple-flash-class tally).
             ("reconnect", counters.reconnectTotal.value),

--- a/Glimmer/Stream/Types.swift
+++ b/Glimmer/Stream/Types.swift
@@ -462,6 +462,11 @@ public enum StreamEvent: Sendable {
     /// layer is configured for PQ/HLG with EDR. This is the "show the HDR
     /// chip" signal.
     case hdrActive(Bool)
+    /// Audio receive-start failed (H7): the session came up VIDEO-ONLY (the ping
+    /// keeps the A/V session alive, but no audio flows). Non-fatal - the visual
+    /// stream is unaffected - so it rides the event channel rather than aborting
+    /// the connect. Carries a short reason for the log; the UI keeps streaming.
+    case audioFailed(String)
     case log(String)
 }
 

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.49
-CURRENT_PROJECT_VERSION = 20260660
+MARKETING_VERSION = 2026.6.50
+CURRENT_PROJECT_VERSION = 20260661


### PR DESCRIPTION
Bundled audit fixes (3 batches implemented in parallel worktrees, merged clean, 156 tests green on the merged tree). Cluster B: AVAudioEngineConfigurationChange observer restarts the engine on mid-stream device/format change (H3, deadlock-safe - notification path not a completion handler) + engine_running re-sampled (H4) + audioFailed event/counter (H7). C2: per-frame trace size-capped (96MB x4) + Logs sweep (300MB/14d). H6: resyncControllers() on reconnect re-sends real held controller state (was reading neutral until twitch). H1: pin-store authoritative, UserDefaults srvcert treated as untrusted hint migrated once, mismatch=hard error (closes same-UID MITM); pinning intact, no URLSession. M3: host-error banner survives the single teardown cleanup. H5: stop() re-guards after each reconnect await + interruptConnection() on a slipped-in backend (kills the zombie-connection leak; approach b to avoid actor-reentrancy deadlock). M6: launch bounded to ~22s + cancellable. No streaming/latency behavior change. Build + 156 tests green on the merged tree.