### PR TITLE
feat(input): Cruise - magic resolution-aware mouse traversal (2026.6.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.6.51 - 2026-06-26
+
+Magic resolution-aware mouse traversal - fast flicks cover the screen
+consistently at any stream resolution while aim sensitivity stays exactly raw.
+Automatic, no settings.
+
 ## 2026.6.50 - 2026-06-26
 
 Robustness pass from a wide audit - several real "works until it doesn't" gaps.

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		D1000066 /* NetworkClient+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000065 /* NetworkClient+Request.swift */; };
 		D1000068 /* Network+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000067 /* Network+Support.swift */; };
 		D100006A /* InputForwarder+Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000069 /* InputForwarder+Capture.swift */; };
+		D1000CR2 /* InputForwarder+Cruise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000CR1 /* InputForwarder+Cruise.swift */; };
 		D100006C /* InputForwarder+StreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100006B /* InputForwarder+StreamView.swift */; };
 		D100006E /* StreamWindow+Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100006D /* StreamWindow+Show.swift */; };
 		D1000070 /* StatsOverlayLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100006F /* StatsOverlayLayer.swift */; };
@@ -182,6 +183,7 @@
 		D2000021 /* EnetWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000020 /* EnetWireTests.swift */; };
 		D2000023 /* ReedSolomonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000022 /* ReedSolomonTests.swift */; };
 		D2000025 /* InputEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000024 /* InputEncoderTests.swift */; };
+		D2000CR2 /* CruiseTraversalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000CR1 /* CruiseTraversalTests.swift */; };
 		D2000027 /* SdpCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000026 /* SdpCodecTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
@@ -348,6 +350,7 @@
 		D1000065 /* NetworkClient+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/NetworkClient+Request.swift"; sourceTree = "<group>"; };
 		D1000067 /* Network+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/Network+Support.swift"; sourceTree = "<group>"; };
 		D1000069 /* InputForwarder+Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/InputForwarder+Capture.swift"; sourceTree = "<group>"; };
+		D1000CR1 /* InputForwarder+Cruise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/InputForwarder+Cruise.swift"; sourceTree = "<group>"; };
 		D100006B /* InputForwarder+StreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/InputForwarder+StreamView.swift"; sourceTree = "<group>"; };
 		D100006D /* StreamWindow+Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamWindow+Show.swift"; sourceTree = "<group>"; };
 		D100006F /* StatsOverlayLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/StatsOverlayLayer.swift; sourceTree = "<group>"; };
@@ -409,6 +412,7 @@
 		D2000020 /* EnetWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnetWireTests.swift; sourceTree = "<group>"; };
 		D2000022 /* ReedSolomonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReedSolomonTests.swift; sourceTree = "<group>"; };
 		D2000024 /* InputEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEncoderTests.swift; sourceTree = "<group>"; };
+		D2000CR1 /* CruiseTraversalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CruiseTraversalTests.swift; sourceTree = "<group>"; };
 		D2000026 /* SdpCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdpCodecTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
@@ -547,6 +551,7 @@
 				D1000C12 /* StreamWindow+Views.swift */,
 				D100006B /* InputForwarder+StreamView.swift */,
 				D1000069 /* InputForwarder+Capture.swift */,
+				D1000CR1 /* InputForwarder+Cruise.swift */,
 				D1000067 /* Network+Support.swift */,
 				D1000065 /* NetworkClient+Request.swift */,
 				D1000063 /* NetworkClient+Endpoints.swift */,
@@ -692,6 +697,7 @@
 				D2000020 /* EnetWireTests.swift */,
 				D2000022 /* ReedSolomonTests.swift */,
 				D2000024 /* InputEncoderTests.swift */,
+				D2000CR1 /* CruiseTraversalTests.swift */,
 				D2000026 /* SdpCodecTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
@@ -879,6 +885,7 @@
 				D1000C11 /* StreamWindow+Views.swift in Sources */,
 				D100006C /* InputForwarder+StreamView.swift in Sources */,
 				D100006A /* InputForwarder+Capture.swift in Sources */,
+				D1000CR2 /* InputForwarder+Cruise.swift in Sources */,
 				D1000068 /* Network+Support.swift in Sources */,
 				D1000066 /* NetworkClient+Request.swift in Sources */,
 				D1000064 /* NetworkClient+Endpoints.swift in Sources */,
@@ -1014,6 +1021,7 @@
 				D2000021 /* EnetWireTests.swift in Sources */,
 				D2000023 /* ReedSolomonTests.swift in Sources */,
 				D2000025 /* InputEncoderTests.swift in Sources */,
+				D2000CR2 /* CruiseTraversalTests.swift in Sources */,
 				D2000027 /* SdpCodecTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -144,6 +144,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // which needs the registered default to read `true` before first toggle.
         UserDefaults.standard.register(defaults: [
             MouseAccelerationControl.enabledDefaultsKey: true,
+            // Cruise: resolution-aware fast-flick traversal boost (raw aim
+            // preserved). Hidden, default-on, no UI - the non-UI gate reads it via
+            // UserDefaults.bool, so it needs the registered default to read `true`.
+            CruiseTraversal.enabledDefaultsKey: true,
             // Fire the present tick on a private high-QoS run loop (not .main)
             // so a busy main thread can't starve the CADisplayLink callback.
             // Flip false for an instant fallback to the main-runloop tick.

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -128,6 +128,9 @@ extension InputForwarder {
         guard !isMouseCaptured else { return }
         mouseResidualX = 0
         mouseResidualY = 0
+        // Reset the Cruise inter-batch clock so the first post-focus motion reads
+        // a stale dt (>0.1s) and forces gain==1.0 - never a spurious boost on resume.
+        lastMoveTimestamp = 0
         // Disassociate: the OS stops moving the system cursor; HID motion still
         // arrives as relative deltas on the CGEvent layer. The return value is
         // a CGError; on the (vanishingly unlikely) failure we still proceed -

--- a/Glimmer/Stream/InputForwarder+Cruise.swift
+++ b/Glimmer/Stream/InputForwarder+Cruise.swift
@@ -1,0 +1,77 @@
+//
+//  InputForwarder+Cruise.swift
+//
+//  "Cruise": a velocity-gated, resolution-derived traversal boost for relative
+//  mouse motion. Glimmer forwards raw HID deltas and linearizes the Mac's
+//  pointer accel (raw-aim, default-on), which removed the acceleration that used
+//  to let a fast flick cover the whole screen - so at 4K the cursor feels slow to
+//  traverse. Cruise restores fast-traversal coverage WITHOUT touching aim: it
+//  applies a gain >1 ONLY to fast movements, derived purely from the stream
+//  resolution. Below the knee the gain is exactly 1.0 (the sacred aim band, byte-
+//  identical to today). Same save→read discipline as MouseAccelerationControl.
+//
+//  Runs AFTER the Mac linearization - it is the only client-side gain, so there
+//  is no double-accel. No wire/host/protocol change: still relative LiSendMouseMove.
+//
+
+import Foundation
+
+// MARK: - Cruise traversal-boost gain
+
+/// Pure gain function + constants for the resolution-compensated traversal boost.
+/// `gMax` is DERIVED from the stream width (never user-dialed); the knee/full
+/// velocities are HIDDEN UserDefaults tunables with no UI surface - the owner
+/// wants zero user-facing controls, so this is "magic only".
+enum CruiseTraversal {
+    /// Master gate. HIDDEN, default-TRUE (registered in GlimmerApp beside the
+    /// other input defaults) - an escape hatch for purists, with no Settings row.
+    static let enabledDefaultsKey = "cruiseTraversalEnabled"
+    /// HIDDEN tune knobs (a standing tune-grant); NOT surfaced in UI. Velocities
+    /// are in raw HID counts/sec. Read once per gain call so a live `defaults
+    /// write` takes effect on the next stream without a rebuild.
+    static let vKneeDefaultsKey = "cruiseVKnee"
+    static let vFullDefaultsKey = "cruiseVFull"
+    /// The reference width the gain is normalized against: at this width gMax==1.0
+    /// (fully inert). 1920 → 4K(3840) gives gMax 2.0, 1440p(2560) ~1.33, 1080p 1.0.
+    static let referenceWidth: Double = 1920
+    /// Defaults for the velocity gate (counts/sec). Below `vKnee` the gain is
+    /// exactly 1.0; at/above `vFull` it is the full `gMax`; between, a smoothstep.
+    static let defaultVKnee: Double = 1400
+    static let defaultVFull: Double = 4500
+
+    /// Whether the feature is on (default true).
+    static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }
+
+    /// `vKnee` / `vFull` from defaults, falling back to the constants above when a
+    /// key is absent or non-positive. `vFull` is floored just above `vKnee` so the
+    /// smoothstep denominator can never be zero/negative.
+    static var vKnee: Double {
+        let v = UserDefaults.standard.double(forKey: vKneeDefaultsKey)
+        return v > 0 ? v : defaultVKnee
+    }
+    static var vFull: Double {
+        let v = UserDefaults.standard.double(forKey: vFullDefaultsKey)
+        return v > vKnee ? v : max(defaultVFull, vKnee + 1)
+    }
+
+    /// Resolution-derived ceiling for the boost. Clamped to >=1.0 so <=1080p is
+    /// provably inert (gMax==1.0 ⇒ gain is 1.0 at every velocity).
+    static func gMax(forStreamWidth width: Int) -> Double {
+        max(1.0, Double(width) / referenceWidth)
+    }
+
+    /// The pure gain. `v` is the batch speed (counts/sec); `dt` is the inter-batch
+    /// interval (NSEvent.timestamp deltas). Returns 1.0 on a stale/post-gap dt and
+    /// in the sacred low-speed aim band (EARLY RETURN, no float round-trip), gMax
+    /// at/above full speed, and a C1 smoothstep ramp between. With gMax==1.0 every
+    /// branch yields 1.0, so the whole feature is inert at <=referenceWidth.
+    static func gain(velocity v: Double, dt: Double, gMax: Double,
+                     vKnee: Double, vFull: Double) -> Double {
+        if dt <= 0 || dt > 0.1 { return 1.0 }   // stale/post-gap dt -> identity
+        if v <= vKnee { return 1.0 }             // sacred aim band, unscaled
+        if v >= vFull { return gMax }
+        let t = (v - vKnee) / (vFull - vKnee)
+        let s = t * t * (3 - 2 * t)              // smoothstep, C1 at both ends
+        return 1.0 + (gMax - 1.0) * s
+    }
+}

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -238,6 +238,29 @@ extension InputForwarder: StreamInputViewDelegate {
             accumDy += delta.dy
         }
 
+        // CRUISE traversal boost (InputForwarder+Cruise.swift). Velocity-gated,
+        // resolution-derived gain on ONLY fast flicks - aim (sub-knee) is untouched.
+        // Runs AFTER the Mac linearization, so it's the only client gain. dt is the
+        // inter-batch interval; v is counts/sec over this batch. Below the knee the
+        // gain is exactly 1.0 and accumDx/Dy are unchanged, so the residual path
+        // below runs byte-for-byte as it does today.
+        let now = event.timestamp
+        if CruiseTraversal.isEnabled, cruiseGMax > 1.0 {
+            let dt = now - lastMoveTimestamp
+            let v = hypot(accumDx, accumDy) / dt
+            let g = CruiseTraversal.gain(velocity: v, dt: dt, gMax: cruiseGMax,
+                                         vKnee: CruiseTraversal.vKnee, vFull: CruiseTraversal.vFull)
+            if g > 1.0 {
+                accumDx *= g
+                accumDy *= g
+                TelemetryCounters.shared.cruiseBoostedBatchesTotal.increment()
+                TelemetryCounters.shared.noteCruiseGain(g)
+            } else if accumDx != 0 || accumDy != 0 {
+                TelemetryCounters.shared.cruiseIdentityBatchesTotal.increment()
+            }
+        }
+        lastMoveTimestamp = now
+
         // The CGEvent path returns integer pixel deltas, so the residual
         // accumulator normally stays at zero and we forward the value as-is.
         // It still carries any sub-pixel fraction forward for the rare

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -271,6 +271,14 @@ public final class InputForwarder {
     var mouseResidualX: Double = 0
     var mouseResidualY: Double = 0
 
+    /// Cruise traversal-boost state (see InputForwarder+Cruise.swift). Stored on
+    /// the class because extensions can't add stored properties.
+    /// `lastMoveTimestamp` is the previous batch's NSEvent.timestamp, for the
+    /// inter-batch dt that gates the velocity; `cruiseGMax` is the resolution-
+    /// derived ceiling, set at start and re-set on a reconnect resolution change.
+    var lastMoveTimestamp: TimeInterval = 0
+    var cruiseGMax: Double = 1.0
+
     /// Pull the relative delta out of a mouseMoved NSEvent. Reads the CGEvent
     /// integer fields `kCGMouseEventDeltaX/Y` (valid whether or not the cursor is
     /// associated; NSEvent.deltaX/Y goes silent under associate-false), falling

--- a/Glimmer/Stream/StreamSession+Reconnect.swift
+++ b/Glimmer/Stream/StreamSession+Reconnect.swift
@@ -164,6 +164,10 @@ extension StreamSession {
         await MainActor.run {
             inp.setBackend(fresh)
             dec.setBackend(fresh)
+            // Re-derive the Cruise ceiling: reconnect reuses the forwarder and
+            // never re-runs StartSetup, so a mid-session resolution change would
+            // otherwise keep a stale gMax.
+            inp.cruiseGMax = CruiseTraversal.gMax(forStreamWidth: config.width)
         }
 
         // 3. Fresh NetworkClient + full handshake against the restarted host.

--- a/Glimmer/Stream/StreamSession+StartSetup.swift
+++ b/Glimmer/Stream/StreamSession+StartSetup.swift
@@ -166,6 +166,8 @@ extension StreamSession {
         // for system keys would surprise the user (Cmd-Tab suddenly
         // stops working mid-game, etc.).
         inp.captureSysKeys = config.captureSysKeys
+        // Cruise ceiling is derived from the stream width (4K→2.0, 1080p→1.0 inert).
+        inp.cruiseGMax = CruiseTraversal.gMax(forStreamWidth: config.width)
         inp.attach(to: win.window)
         // The window installs first responder only after it has
         // become key AND finished its enter-fullscreen transition.

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -153,6 +153,20 @@ extension TelemetryCounters {
         return vtSessionCreateMsValue
     }
 
+    /// Fold one applied Cruise gain into the per-session max (1.0 = unboosted).
+    /// Called from the mouse-batch path; cheap last-writer-max under the lock.
+    func noteCruiseGain(_ g: Double) {
+        os_unfair_lock_lock(cruiseMaxGainLock)
+        if g > cruiseMaxGainValue { cruiseMaxGainValue = g }
+        os_unfair_lock_unlock(cruiseMaxGainLock)
+    }
+    /// Largest Cruise gain applied this session (1.0 if never boosted). Read by
+    /// the exporter on its 1Hz queue (never the hot path).
+    var cruiseMaxGain: Double {
+        os_unfair_lock_lock(cruiseMaxGainLock); defer { os_unfair_lock_unlock(cruiseMaxGainLock) }
+        return cruiseMaxGainValue
+    }
+
     /// Set/clear the present-suppression gauge. Called at the suppression edges
     /// (backgrounded/occluded ↔ visible) by the present path - never per frame.
     /// The CLEAR edge also arms the latency rig's resume-present tag: the first

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -171,6 +171,14 @@ final class TelemetryCounters: @unchecked Sendable {
     /// Always-live like the other counters (the press is a rare, deliberate act).
     let bookmarkTotal = Counter()
 
+    /// CRUISE traversal-boost counters (signal: input, for tuning vKnee against
+    /// real traces). `boosted` = batches where the velocity gate applied gain>1;
+    /// `identity` = active-motion batches that stayed at gain==1 (below the knee
+    /// or stale dt). The ratio is the share of motion that the boost touched.
+    /// Always-live integer adds on the already-coalesced mouse-batch path.
+    let cruiseBoostedBatchesTotal = Counter()
+    let cruiseIdentityBatchesTotal = Counter()
+
     // ---- P2 SESSION-LIFECYCLE event counters (the lifecycle/recovery/quality
     //      signals). All always-live integer adds at already-rare sites (a
     //      reconnect, an IDR request/arrival, a corrupt-frame heuristic hit) - far
@@ -423,6 +431,16 @@ final class TelemetryCounters: @unchecked Sendable {
     let vtSessionCreateLock = os_unfair_lock_t.allocate(capacity: 1)
     var vtSessionCreateMsValue: Double = 0
 
+    // Module-internal (not private) so the gauge accessor in
+    // TelemetryCounters+Gauges.swift can reach these.
+    //
+    /// CRUISE max-gain gauge: the largest traversal-boost gain applied this
+    /// session (1.0 = never boosted). Read with the resolution-derived gMax it
+    /// tops out at, this proves whether real flicks ever cross vFull. A plain
+    /// Double behind an unfair lock; `noteCruiseGain` keeps the running max.
+    let cruiseMaxGainLock = os_unfair_lock_t.allocate(capacity: 1)
+    var cruiseMaxGainValue: Double = 1.0
+
     // Module-internal (not private) so the gauge accessors in
     // TelemetryCounters+Gauges.swift can reach these.
     //
@@ -619,6 +637,7 @@ final class TelemetryCounters: @unchecked Sendable {
         inputLock.initialize(to: os_unfair_lock_s())
         rttLock.initialize(to: os_unfair_lock_s())
         vtSessionCreateLock.initialize(to: os_unfair_lock_s())
+        cruiseMaxGainLock.initialize(to: os_unfair_lock_s())
         gapLock.initialize(to: os_unfair_lock_s())
         decodeStateLock.initialize(to: os_unfair_lock_s())
         fecHealthLock.initialize(to: os_unfair_lock_s())
@@ -631,6 +650,7 @@ final class TelemetryCounters: @unchecked Sendable {
     deinit {
         jitterLock.deallocate(); inputLock.deallocate()
         rttLock.deallocate(); vtSessionCreateLock.deallocate()
+        cruiseMaxGainLock.deallocate()
         gapLock.deallocate()
         decodeStateLock.deallocate(); fecHealthLock.deallocate()
         audioStateLock.deallocate(); audioFirstPacketLock.deallocate()
@@ -660,6 +680,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         fecRecoveredFramesTotal, inputEventsTotal, inputBatchFlushTotal,
                         inputFlushSendBackloggedSkipTotal, inputFlushReliableBackloggedSkipTotal,
                         inputIdleToActiveTotal, bookmarkTotal,
+                        cruiseBoostedBatchesTotal, cruiseIdentityBatchesTotal,
                         videoPacketsLostPreFecTotal, videoPacketsOutOfOrderTotal,
                         videoPacketsDuplicateTotal, enetRetransmitTotal,
                         ackSilenceNearMissTotal, ctrlIgnoredTotal,
@@ -694,6 +715,8 @@ final class TelemetryCounters: @unchecked Sendable {
         setRecvJitterMs(0)
         setRttMs(0)
         setVtSessionCreateMs(0)
+        // Cruise max-gain resets to the unboosted floor (1.0), not 0.
+        os_unfair_lock_lock(cruiseMaxGainLock); cruiseMaxGainValue = 1.0; os_unfair_lock_unlock(cruiseMaxGainLock)
         // Present-suppression + decode-gate gauges: a session starts with a
         // visible stream view, and the present/decode paths re-stamp these at
         // the next suppression/gate edge.

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -112,6 +112,9 @@ extension TelemetryExporter {
         snap.unrecoverableFrameTotal = counters.unrecoverableFrameTotal.value
         snap.pacerDisabledTotal = counters.pacerDisabledTotal.value
         snap.bookmarkTotal = counters.bookmarkTotal.value
+        snap.cruiseBoostedBatchesTotal = counters.cruiseBoostedBatchesTotal.value
+        snap.cruiseIdentityBatchesTotal = counters.cruiseIdentityBatchesTotal.value
+        snap.cruiseMaxGain = counters.cruiseMaxGain
         snap.decoderRecreateTotal = counters.decoderRecreateTotal.value
         snap.decoderRecreateFirstTotal = counters.decoderRecreateFirstTotal.value
         snap.decoderRecreateResolutionTotal = counters.decoderRecreateResolutionTotal.value

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -153,6 +153,12 @@ extension TelemetryRenderer {
                             "Times the pacer was disabled (present-path give-up).", snap.pacerDisabledTotal)
         builder.emitCounter("glimmer_bookmark_total",
                             "User \"that felt bad\" bookmark presses (jank markers).", snap.bookmarkTotal)
+        builder.emitCounter("glimmer_cruise_boosted_batches_total",
+                            "Mouse batches the Cruise traversal boost scaled (gain>1).",
+                            snap.cruiseBoostedBatchesTotal)
+        builder.emitCounter("glimmer_cruise_identity_batches_total",
+                            "Active-motion mouse batches Cruise left unscaled (gain==1).",
+                            snap.cruiseIdentityBatchesTotal)
     }
 
     /// Per-stage latency HISTOGRAMS (_bucket/_sum/_count). Real Prometheus
@@ -245,6 +251,10 @@ extension TelemetryRenderer {
         builder.emit("glimmer_vt_session_create_ms",
                      "VTDecompressionSessionCreate wall-clock cost, ms (first-frame-leg startup).",
                      snap.vtSessionCreateMs > 0 ? snap.vtSessionCreateMs : nil)
+        // Cruise max gain this session (1.0 = never boosted; drop the inert 1.0).
+        builder.emit("glimmer_cruise_max_gain",
+                     "Largest Cruise traversal-boost gain applied this session.",
+                     snap.cruiseMaxGain > 1.0 ? snap.cruiseMaxGain : nil)
         builder.emitCounter("glimmer_discontinuity_flush_total",
                             "Stream-discontinuity flushes (param-set rebuilds that flushed the "
                             + "renderer + cleared the pacer queue - a real multi-frame skip). 0 on "

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -518,6 +518,8 @@ struct SessionReport {
             ("present_stall", counters.presentStallTotal.value),
             ("pacer_disabled", counters.pacerDisabledTotal.value),
             ("bookmark", counters.bookmarkTotal.value),
+            ("cruise_boosted_batches", counters.cruiseBoostedBatchesTotal.value),
+            ("cruise_identity_batches", counters.cruiseIdentityBatchesTotal.value),
             // P1 NETWORK session tallies: the run's on-the-wire receive-quality
             // totals (all from the RTP seq of packets WE received) + the reliable
             // retransmit count - the "how was the link this run" line.

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -60,6 +60,8 @@ struct TelemetrySnapshot: Sendable {
     /// Latest VTDecompressionSessionCreate wall-clock cost (ms): the HW-decoder
     /// bring-up that lands on the first-frame leg. 0 before the first create.
     var vtSessionCreateMs: Double = 0
+    /// Largest Cruise traversal-boost gain applied this session (1.0 = unboosted).
+    var cruiseMaxGain: Double = 1.0
     /// Decoder (re)creates split by cause (monotonic; sum = decoderRecreateTotal):
     /// the one-time first create, real resolution changes, and colorspace/HDR/
     /// profile param-rebuilds that kept dims - so a recreate storm names its cause.
@@ -249,6 +251,10 @@ struct TelemetrySnapshot: Sendable {
     /// User "that felt bad" bookmark presses (signal 4). A short-window
     /// `increase()` marks the exact beat the user flagged jank.
     var bookmarkTotal: UInt64 = 0
+    /// Cruise traversal-boost batch counts: boosted (gain>1) vs identity (active
+    /// motion that stayed at gain==1). The split tunes vKnee against real traces.
+    var cruiseBoostedBatchesTotal: UInt64 = 0
+    var cruiseIdentityBatchesTotal: UInt64 = 0
 
     // Per-stage latency histograms. Captured from the FrameTimingTracker's
     // cumulative atomic buckets (one snapshot/tick on the exporter queue - never

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.6.50
-CURRENT_PROJECT_VERSION = 20260661
+MARKETING_VERSION = 2026.6.51
+CURRENT_PROJECT_VERSION = 20260662

--- a/GlimmerTests/CruiseTraversalTests.swift
+++ b/GlimmerTests/CruiseTraversalTests.swift
@@ -1,0 +1,83 @@
+//
+//  CruiseTraversalTests.swift
+//
+//  Pins the pure Cruise gain function (InputForwarder+Cruise.swift): the sacred
+//  sub-knee aim band is exactly 1.0, the boost saturates at the resolution-derived
+//  gMax above vFull, the ramp between is monotonic and C1-continuous at both ends,
+//  a stale/post-gap dt collapses to identity, and gMax==1.0 (<=referenceWidth) is
+//  fully inert at every velocity.
+//
+
+import Testing
+@testable import Glimmer
+
+struct CruiseTraversalTests {
+    // 4K stream: gMax derives to 2.0 against the 1920 reference width.
+    let gMax4K = CruiseTraversal.gMax(forStreamWidth: 3840)
+    let vKnee = CruiseTraversal.defaultVKnee   // 1400
+    let vFull = CruiseTraversal.defaultVFull   // 4500
+    let dt = 0.008                              // ~120Hz batch interval (valid)
+
+    private func gain(_ v: Double, dt: Double? = nil, gMax: Double? = nil) -> Double {
+        CruiseTraversal.gain(velocity: v, dt: dt ?? self.dt, gMax: gMax ?? gMax4K,
+                             vKnee: vKnee, vFull: vFull)
+    }
+
+    @Test func gMaxDerivesFromWidth() {
+        #expect(gMax4K == 2.0)                                    // 3840/1920
+        #expect(CruiseTraversal.gMax(forStreamWidth: 2560) == 2560.0 / 1920.0)  // ~1.33
+        #expect(CruiseTraversal.gMax(forStreamWidth: 1920) == 1.0)
+    }
+
+    @Test func identityAtAndBelowKnee() {
+        // The sacred aim band: exactly 1.0, no float drift, up to and including vKnee.
+        #expect(gain(0) == 1.0)
+        #expect(gain(500) == 1.0)
+        #expect(gain(vKnee) == 1.0)
+        #expect(gain(vKnee - 0.001) == 1.0)
+    }
+
+    @Test func fullGainAtAndAboveVFull() {
+        #expect(gain(vFull) == gMax4K)
+        #expect(gain(vFull + 1000) == gMax4K)
+        #expect(gain(50_000) == gMax4K)
+    }
+
+    @Test func rampIsMonotonicAndBoundedBetween() {
+        // Strictly increasing from 1.0 toward gMax across the knee→full band.
+        var prev = gain(vKnee)
+        var v = vKnee + 50
+        while v < vFull {
+            let g = gain(v)
+            #expect(g > prev)                 // monotonic ramp
+            #expect(g > 1.0 && g < gMax4K)    // bounded strictly inside
+            prev = g
+            v += 50
+        }
+    }
+
+    @Test func continuousAtBothEnds() {
+        // C1 smoothstep: value continuity at both knees (slope is 0 there too).
+        let eps = 0.5
+        #expect(abs(gain(vKnee + eps) - 1.0) < 1e-3)
+        #expect(abs(gain(vFull - eps) - gMax4K) < 1e-3)
+    }
+
+    @Test func staleDtIsIdentity() {
+        // A post-gap / stale dt (>0.1s) forces identity even at flick speed.
+        #expect(gain(vFull, dt: 0.2) == 1.0)
+        #expect(gain(vFull, dt: 0) == 1.0)
+        #expect(gain(vFull, dt: -1) == 1.0)
+    }
+
+    @Test func inertWhenGMaxIsOne() {
+        // <=1080p (gMax clamps to 1.0) is provably inert at every velocity.
+        let inert = CruiseTraversal.gMax(forStreamWidth: 1920)
+        #expect(inert == 1.0)
+        for v in stride(from: 0.0, through: 20_000, by: 250) {
+            #expect(gain(v, gMax: inert) == 1.0)
+        }
+        // 1080p width derives the same inert ceiling.
+        #expect(CruiseTraversal.gMax(forStreamWidth: 1080) == 1.0)
+    }
+}


### PR DESCRIPTION
Fixes 'mouse feels slow across the screen at 4K' (surfaced by the .18 raw-mouse linearization removing the acceleration that masked it). From a creative design panel (5 philosophies x 3 judge lenses): the absolute-mode auto-switch was killed (no host cursor-visibility signal exists in our inbound path), so the magic answer is velocity-gated, resolution-derived traversal boost. Below a velocity knee (1400 c/s) deltas pass BYTE-IDENTICAL (captured FPS aim untouched - only multiplies when g>1.0, no float round-trip); above it a smoothstep ramps to gMax = streamWidth/1920 (4K->2x, 1440p->1.33x, 1080p->fully inert), making screen-coverage-per-flick resolution-invariant by construction. gMax is DERIVED, never dialed: NO slider, NO visible toggle - default-on, invisible (hidden cruiseTraversalEnabled escape hatch only). Reuses the existing Double residual accumulator + Int16 split; no wire/host/protocol change. Reconnect re-derives gMax (reconnect reuses the forwarder + skips StartSetup). Telemetry: cruise_boosted/identity batch counts + max_gain to tune the knee from real traces. Honest tradeoff: slow deliberate 4K drags stay 1:1 (fixing that needs the absent absolute-mode signal). +7 unit tests (163 total), build green.