### PR TITLE
polish: felt-bad pass - floor-violation assist, honest perceived gaps, per-host skew seed

### DIFF
--- a/Glimmer/AppModel.swift
+++ b/Glimmer/AppModel.swift
@@ -122,22 +122,8 @@ final class AppModel {
 
     /// Connection lifecycle published from the native engine. Drives the
     /// connect-banner, the StreamButton role, and the ReadinessChip's
-    /// transitional state. See `StreamPhase` for the case set;
-    /// `nativeStreamPhase` is a string-typed read shim for UI code that
-    /// hasn't migrated to switching on the enum.
+    /// transitional state. See `StreamPhase` for the case set.
     var streamPhase: StreamPhase = .idle
-
-    /// String-typed read shim for code that hasn't migrated to switching
-    /// on `streamPhase`. Read-only; writers go through `streamPhase`.
-    var nativeStreamPhase: String? {
-        switch streamPhase {
-        case .idle:                       return nil
-        case .connecting(let stage):      return stage
-        case .streaming:                  return "Streaming"
-        case .disconnecting:              return nil
-        case .error:                      return nil
-        }
-    }
 
     /// True when a stream is running but its window has been orderOut'd
     /// because the user Cmd-Tabbed away. The launcher UI shows a "Back to
@@ -266,8 +252,7 @@ final class AppModel {
 
     var quitHotkey: HotkeyChord = .defaultQuit {
         didSet {
-            // UserDefaults key matches the legacy QuitHotkey typealias so
-            // previously-stored chords still decode.
+            // Historical UserDefaults key - previously-stored chords still decode.
             if let data = try? JSONEncoder().encode(quitHotkey) {
                 UserDefaults.standard.set(data, forKey: "quitHotkey")
             }

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -476,7 +476,7 @@ struct StreamButton: View {
     /// captured at stream() entry): ⌘1-⌘9 can re-point `selectedHost`
     /// mid-handshake, and the capsule must keep naming the PC it's dialling.
     private var connectingPrimary: String {
-        if let stage = model.nativeStreamPhase,
+        if case .connecting(let stage) = model.streamPhase,
            stage.hasPrefix("Connecting to ") || stage == "Cancelling..." {
             return stage
         }
@@ -491,7 +491,7 @@ struct StreamButton: View {
     /// stripping whatever the primary already carries ("Connecting to X..."
     /// duplicates, the "Cancelling..." repaint).
     private var connectingSubtext: String? {
-        guard let stage = model.nativeStreamPhase, !stage.isEmpty else { return nil }
+        guard case .connecting(let stage) = model.streamPhase, !stage.isEmpty else { return nil }
         if stage == connectingPrimary { return nil }
         if stage.hasPrefix("Connecting to ") || stage == "Connecting..." { return nil }
         return stage

--- a/Glimmer/Models/Host.swift
+++ b/Glimmer/Models/Host.swift
@@ -107,9 +107,8 @@ enum QualityPreset: String, CaseIterable, Identifiable {
 /// A single user-configurable in-stream hotkey: modifier flags + one character
 /// key. One type covers every chord-shaped intercept Glimmer fires at the
 /// SwiftUI layer (currently: quit-stream, toggle-stats-overlay). The JSON
-/// shape is identical to the legacy `QuitHotkey` blob persisted in
-/// UserDefaults under `"quitHotkey"`, so the typealias round-trips without
-/// a migration step.
+/// shape matches the blob historically persisted under the UserDefaults key
+/// `"quitHotkey"`, so stored chords decode without a migration step.
 public struct HotkeyChord: Codable, Equatable, Sendable {
     public var ctrl: Bool
     public var alt: Bool
@@ -156,10 +155,6 @@ public struct HotkeyChord: Codable, Equatable, Sendable {
     ///     opt-in diagnostic session.
     public static let defaultBookmark = HotkeyChord(ctrl: true, alt: false, shift: false, cmd: false, keyChar: "b")
 
-    /// Source-compat shim: existing call sites that read `.default` still
-    /// resolve to the quit chord. New code should prefer the explicit name.
-    public static let `default` = defaultQuit
-
     var displayString: String {
         var parts: [String] = []
         if ctrl { parts.append("⌃") }
@@ -180,11 +175,6 @@ public struct HotkeyChord: Codable, Equatable, Sendable {
         return parts.joined(separator: "+")
     }
 }
-
-/// Legacy spelling preserved as a typealias so the persisted JSON blob's
-/// type identity (and any pre-existing callers we miss) keeps working
-/// without a forced migration. New code should refer to `HotkeyChord`.
-public typealias QuitHotkey = HotkeyChord
 
 /// A single capturable controller button, used for the user-recorded custom
 /// quit chord. Covers everything ControllerForwarder can read (GameController

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -237,6 +237,49 @@ extension AudioDecoder {
             forKey: key)
     }
 
+    // MARK: - Resampler skew persistence (per host)
+
+    /// UserDefaults key prefix; full key = prefix + host. The host↔Mac clock
+    /// offset is a property of the two CLOCKS, not the link, so it is keyed by
+    /// host alone (unlike the cushion's host|link records).
+    static let resamplerSkewKeyPrefix = "audioResamplerSkew."
+    /// Read-side age half-life. Crystal skew is hardware-stable across days; a
+    /// week halves a stale record toward 0 so junk can't outlive its host.
+    static let resamplerSkewAgeHalfLifeSeconds: Double = 7 * 24 * 3600
+    /// Below this |ppm| neither persist nor seed - the PI re-converges from 0
+    /// in seconds at that scale and the write is churn.
+    static let resamplerSkewMinPersistPpm = 20.0
+    /// Min ns between opportunistic saves (driveResampler's engaged branch).
+    static let resamplerSkewSaveIntervalNanos: UInt64 = 60_000_000_000
+
+    static func resamplerSkewKey(host: String) -> String {
+        resamplerSkewKeyPrefix + host
+    }
+
+    /// Aged, clamped per-host skew seed, or 0 (no / stale / junk record). The
+    /// clamp to `cushionReleaseSkewPpm` keeps a seed inside the converged
+    /// envelope (stored values already are; this guards edited plists), so a
+    /// seeded session never starts in the "railing" shallow-release lockout.
+    static func loadResamplerSkewSeed(host: String) -> Double {
+        guard host != "unknown",
+              let dict = UserDefaults.standard.dictionary(forKey: resamplerSkewKey(host: host)),
+              let ppm = dict["ppm"] as? Double, ppm.isFinite,
+              let savedAt = dict["saved_at"] as? Double else { return 0 }
+        let age = max(0, Date().timeIntervalSinceReferenceDate - savedAt)
+        let aged = ppm * pow(0.5, age / resamplerSkewAgeHalfLifeSeconds)
+        let clamped = max(-cushionReleaseSkewPpm, min(cushionReleaseSkewPpm, aged))
+        return abs(clamped) >= resamplerSkewMinPersistPpm ? clamped : 0
+    }
+
+    /// Persist a converged skew for this host. Callers gate on the converged
+    /// envelope + the save throttle (driveResampler); this only checks identity.
+    static func persistResamplerSkew(host: String, ppm: Double) {
+        guard host != "unknown", ppm.isFinite else { return }
+        UserDefaults.standard.set(
+            ["ppm": ppm, "saved_at": Date().timeIntervalSinceReferenceDate],
+            forKey: resamplerSkewKey(host: host))
+    }
+
     /// Resolve this session's seed: the init key's own record first; when the
     /// link is still unknown, BORROW the deepest of the link-split records
     /// (deep-by-default fails toward a few ms of extra audio latency that the
@@ -545,11 +588,16 @@ extension AudioDecoder {
         lastResamplerUpdateNanos = now
 
         var rateToApply: Float?
+        var skewPpmToPersist: Double?
         if !engaged {
             // Pre-roll / re-prime / drain: slew the APPLIED rate to 1.0 (no pitch
             // step) but HOLD the integral - the host↔Mac clock offset survives a
             // drain, so re-engage with it already learned, not re-converged from 0.
-            resamplerIntegralPpm *= Self.resamplerIntegralHoldFactor
+            // The bleed waits for the FIRST engaged tick: a pre-roll must not
+            // erode a persisted per-host skew seed the loop hasn't used yet.
+            if resamplerEverEngaged {
+                resamplerIntegralPpm *= Self.resamplerIntegralHoldFactor
+            }
             if resamplerEpsPpm != 0 {
                 resamplerEpsPpm += max(-Self.resamplerSlewPpm,
                                        min(Self.resamplerSlewPpm, -resamplerEpsPpm))
@@ -559,6 +607,7 @@ extension AudioDecoder {
             // Fill above the cushion setpoint ⇒ too much buffered ⇒ consume faster
             // (rate > 1). INTEGRAL absorbs the steady ppm offset; PROPORTIONAL answers
             // transient excursions; the deadband stops accrual on sub-ms noise.
+            resamplerEverEngaged = true
             let error = fillMs - targetMs
             let e = abs(error) < Self.resamplerDeadbandMs ? 0 : error
             resamplerIntegralPpm = clampResamplerPpm(resamplerIntegralPpm + Self.resamplerKiPpmPerMs * e)
@@ -567,9 +616,26 @@ extension AudioDecoder {
             resamplerEpsPpm += max(-Self.resamplerSlewPpm,
                                    min(Self.resamplerSlewPpm, targetPpm - resamplerEpsPpm))
             rateToApply = Float(1.0 + resamplerEpsPpm * 1e-6)
+            // Opportunistic per-host skew persist (throttled ~1/min, ≥5ppm delta):
+            // a stable integral within the converged envelope IS the host↔Mac
+            // clock offset - save it so the NEXT session seeds pre-converged
+            // (initDecoderCore). Railing values (> the converged line) never
+            // persist, so junk can't poison a future seed.
+            let magnitude = abs(resamplerIntegralPpm)
+            if magnitude >= Self.resamplerSkewMinPersistPpm,
+               magnitude <= Self.cushionReleaseSkewPpm,
+               now &- lastResamplerSkewSaveNanos >= Self.resamplerSkewSaveIntervalNanos,
+               !(abs(resamplerIntegralPpm - lastSavedResamplerSkewPpm) < 5.0) {
+                lastResamplerSkewSaveNanos = now
+                lastSavedResamplerSkewPpm = resamplerIntegralPpm
+                skewPpmToPersist = resamplerIntegralPpm
+            }
         }
         audioMeterLock.unlock()
         if let rateToApply { applyVarispeedRate(rateToApply) }
+        if let skewPpmToPersist {
+            Self.persistResamplerSkew(host: cushionHostLabel, ppm: skewPpmToPersist)
+        }
     }
 
     private func clampResamplerPpm(_ v: Double) -> Double {

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -136,6 +136,14 @@ public final class AudioDecoder: @unchecked Sendable {
     /// drain, so keep most of it (slow ×0.97 bleed only while packets flow) and
     /// re-engage with it already learned rather than re-converging from 0.
     static let resamplerIntegralHoldFactor = 0.97
+    /// True once the loop has run at least one ENGAGED tick this session. The
+    /// disengage hold-bleed applies only after this: a pre-roll must not bleed
+    /// a persisted per-host skew seed before the loop ever engages with it.
+    var resamplerEverEngaged = false
+    /// Skew-save throttle state (audioMeterLock): the last opportunistic
+    /// per-host persist, so a stable integral writes at most ~1/min.
+    var lastResamplerSkewSaveNanos: UInt64 = 0
+    var lastSavedResamplerSkewPpm: Double = .nan
     /// SHALLOW-RELEASE gate: the |integral ppm| ceiling under which the resampler is
     /// deemed to be CARRYING the skew (not railing), so the wired cushion may converge.
     /// Real host skews seen ~450ppm; above ~500 the loop is at/near its rail and the
@@ -407,12 +415,22 @@ public final class AudioDecoder: @unchecked Sendable {
         // + route latch); seeding the target from per-host memory makes the cold
         // pre-roll build last session's learned depth, not re-pay 5-8 startup blips.
         let seed = Self.loadCushionSeed()
+        // Per-host skew seed: start the resampler's integral at the persisted
+        // converged clock offset so the session begins pre-corrected instead of
+        // re-drifting into the first minutes' underruns (the ratchet feed).
+        let skewSeedPpm = Self.loadResamplerSkewSeed(host: seed.host)
+        if skewSeedPpm != 0 {
+            Diag.notice("audio resampler skew seed: \(Int(skewSeedPpm.rounded()))ppm "
+                + "from per-host memory - starts pre-converged", "Stream.Audio")
+        }
         let seedNowNanos = DispatchTime.now().uptimeNanoseconds
         audioMeterLock.lock()
         meterSampleRate = Double(sampleRate)
         framesScheduled = 0; framesPlayed = 0
         driftAnchorNanos = 0; driftAnchorFramesPlayed = 0
-        resamplerIntegralPpm = 0; resamplerEpsPpm = 0; varispeed.rate = 1.0
+        resamplerIntegralPpm = skewSeedPpm; resamplerEpsPpm = 0; varispeed.rate = 1.0
+        resamplerEverEngaged = false
+        lastResamplerSkewSaveNanos = 0; lastSavedResamplerSkewPpm = .nan
         playoutStarted = false; playoutDrained = false; meterShutdown = false
         // FIX: clear the teardown latch on RE-init. A reconnect's stopConnection →
         // shutdown() set `isShutdown = true` and nothing reset it, so post-reconnect

--- a/Glimmer/Stream/EnvSignalController.swift
+++ b/Glimmer/Stream/EnvSignalController.swift
@@ -1,7 +1,7 @@
 //
 //  EnvSignalController.swift
 //
-//  The ENV-SIGNAL adaptive layer - SHADOW MODE. A CLEAR/CAUTION/DISTRESS
+//  The ENV-SIGNAL adaptive layer. A CLEAR/CAUTION/DISTRESS
 //  link-condition state machine fed once per telemetry capture tick (~1Hz)
 //  with the stream ROUTE (StreamRouteProbe - the honest stream_link, re-probed
 //  on every NWPathMonitor change), the associated-radio physics (RSSI / PHY
@@ -34,12 +34,14 @@
 //   * radio: RSSI ≤ session-p50 − 8dB, or tx-rate ≤ 0.5× session-p95 -
 //     armed only on a wifi stream route, only after a ~1min baseline warmup.
 //
-//  SHADOW MODE (the contract for this pass): the state machine RUNS and
-//  EXPORTS (env_state / env_state_changes_total / pings_sent counters, plus
-//  an `env_state` NDJSON event with the evidence vector + a Diag NOTICE on
-//  every transition) but ACTUATES nothing - except the single approved live
-//  actuation below. The state machine is judged against felt events for one
-//  full session BEFORE any further dial moves; see "Future actuations".
+//  LIVE ACTUATIONS (the shadow-mode contract of the original pass is
+//  superseded): the state machine RUNS, EXPORTS (env_state /
+//  env_state_changes_total / pings_sent counters, plus an `env_state` NDJSON
+//  event with the evidence vector + a Diag NOTICE on every transition), and
+//  moves TWO dials - the conditional keepalive cadence (#1 below) and, with
+//  `reconcilerEnabled`, the unified jitter→headroom decision consumed by the
+//  FramePacer adaptive depth and the FEC reorder-hold. Anything further stays
+//  dark; see "Future actuations".
 //
 //  LIVE ACTUATION #1 - CONDITIONAL KEEPALIVE (`steadyPingInterval()`):
 //  75ms steady ping cadence only when stream_link == wifi AND (input-idle OR
@@ -689,7 +691,7 @@ final class EnvSignalController: @unchecked Sendable {
     /// Publish a state change: bump the counter, log the recoverable-state
     /// NOTICE (quiet - never warn/error for a state the machine recovers
     /// from), and emit the `env_state` NDJSON event WITH the evidence vector
-    /// so the shadow session is judgeable post-hoc.
+    /// so the session is judgeable post-hoc.
     private func applyTransition(to next: EnvState, reason: String) {
         let previous: EnvState
         lock.lock()
@@ -699,8 +701,8 @@ final class EnvSignalController: @unchecked Sendable {
         guard previous != next else { return }
         windowsSinceChange = 0
         stateChangesTotal.increment()
-        Diag.notice("ENV \(previous.label) → \(next.label) (\(reason)) - shadow mode, "
-            + "no dial moved (keepalive cadence aside)", Self.cat)
+        Diag.notice("ENV \(previous.label) → \(next.label) (\(reason)) - gates keepalive "
+            + "cadence + reconciler headroom", Self.cat)
         var fields = [
             "\"event\":\"env_state\"",
             "\"from\":\"\(previous.label)\"",
@@ -790,7 +792,7 @@ final class EnvSignalController: @unchecked Sendable {
         windowsSinceChange = Int.max
     }
 
-    // MARK: - Future actuations (LISTED BUT DARK - the shadow-mode contract)
+    // MARK: - Future actuations (LISTED BUT DARK)
     //
     // Every candidate below is an EXISTING, bounded, reversible dial. None is
     // wired; each gets enabled ONE AT A TIME, only after a full shadow

--- a/Glimmer/Stream/FramePacer+TickDeficit.swift
+++ b/Glimmer/Stream/FramePacer+TickDeficit.swift
@@ -78,6 +78,10 @@ extension FramePacer {
     /// fires it - sustained for `floorViolationNoticeSeconds`.
     static let floorViolationRatio = 0.9
     static let floorViolationNoticeSeconds = 1.0
+    /// Continuous healthy seconds (ticks ≥ the floor ratio) before the
+    /// floor-violation ASSIST disengages. 3s spans the measured 1-3s
+    /// violate/clear flap so one throttle episode arms the timer once.
+    static let floorAssistExitHealthySeconds = 3.0
     /// Repaint the current frame during a deficit only after this many stream
     /// intervals without a REAL release (a real release is itself a commit, so
     /// repaints matter only when the host also faded / the queue ran dry).
@@ -131,6 +135,8 @@ extension FramePacer {
             repaints: UInt64, ticksPerS: Double)
         case floorViolation(ticksPerS: Double, floorHz: Double)
         case floorRecovered(durationSeconds: Double, ticksPerS: Double)
+        case floorAssistEngaged(ticksPerS: Double, floorHz: Double, depth: Int)
+        case floorAssistDisengaged(reason: String, durationSeconds: Double, releases: UInt64, ticksPerS: Double)
         case warmHandoverComplete(ticksPerS: Double)
     }
 
@@ -272,23 +278,67 @@ extension FramePacer {
     ) -> [TickDeficitEvent] {
         let floor = tickDeficit.pinnedFloorHz
         guard floor.isFinite, floor > 0 else { return [] }
+        var events: [TickDeficitEvent] = []
         if ticksPerS < floor * FramePacer.floorViolationRatio {
             if !tickDeficit.floorViolationSince.isFinite { tickDeficit.floorViolationSince = now - windowSeconds }
-            if !tickDeficit.floorViolationLogged,
-               now - tickDeficit.floorViolationSince >= FramePacer.floorViolationNoticeSeconds {
+            tickDeficit.floorAssistHealthySince = .nan
+            let sustained = now - tickDeficit.floorViolationSince >= FramePacer.floorViolationNoticeSeconds
+            if !tickDeficit.floorViolationLogged, sustained {
                 // Once per episode - a multi-second collapse logs one NOTICE,
                 // not one per window.
                 tickDeficit.floorViolationLogged = true
-                return [.floorViolation(ticksPerS: ticksPerS, floorHz: floor)]
+                events.append(.floorViolation(ticksPerS: ticksPerS, floorHz: floor))
             }
-            return []
+            // ASSIST: a sustained violation in the dead band between the floor
+            // ratio (0.9x) and the hard-deficit enter (0.5x) got a breadcrumb
+            // and NO response - at 120fps content that is ~12 releases/s
+            // slipping a vsync, the field's dominant felt-judder signature.
+            // Arm the SAME off-tick timer the hard deficit uses; the due gate
+            // dedupes, so it only fills the beats the throttled link misses.
+            // Queue guard mirrors the deficit engage: an empty queue is an
+            // upstream drought, nothing to release.
+            if sustained, !tickDeficit.floorAssistActive,
+               !tickDeficit.deficitModeActive, !queue.isEmpty {
+                tickDeficit.floorAssistActive = true
+                tickDeficit.floorAssistEngagedAt = now
+                tickDeficit.floorAssistEngageReleaseCount = liveness.releaseCount
+                events.append(.floorAssistEngaged(
+                    ticksPerS: ticksPerS, floorHz: floor, depth: queue.count))
+            }
+            return events
         }
         let wasLogged = tickDeficit.floorViolationLogged
         let since = tickDeficit.floorViolationSince
         tickDeficit.floorViolationSince = .nan
         tickDeficit.floorViolationLogged = false
-        guard wasLogged, since.isFinite else { return [] }
-        return [.floorRecovered(durationSeconds: now - since, ticksPerS: ticksPerS)]
+        if wasLogged, since.isFinite {
+            events.append(.floorRecovered(durationSeconds: now - since, ticksPerS: ticksPerS))
+        }
+        if tickDeficit.floorAssistActive {
+            if !tickDeficit.floorAssistHealthySince.isFinite {
+                tickDeficit.floorAssistHealthySince = now - windowSeconds
+            }
+            if now - tickDeficit.floorAssistHealthySince >= FramePacer.floorAssistExitHealthySeconds {
+                events.append(disengageFloorAssistLocked(
+                    reason: "ticks recovered", now: now, ticksPerS: ticksPerS))
+            }
+        }
+        return events
+    }
+
+    /// Stand the floor-violation assist down and mint its breadcrumb. Under `lock`.
+    private func disengageFloorAssistLocked(
+        reason: String, now: CFTimeInterval, ticksPerS: Double
+    ) -> TickDeficitEvent {
+        tickDeficit.floorAssistActive = false
+        let duration = tickDeficit.floorAssistEngagedAt.isFinite
+            ? now - tickDeficit.floorAssistEngagedAt : 0
+        let released = liveness.releaseCount &- tickDeficit.floorAssistEngageReleaseCount
+        tickDeficit.floorAssistEngagedAt = .nan
+        tickDeficit.floorAssistHealthySince = .nan
+        return .floorAssistDisengaged(
+            reason: reason, durationSeconds: duration,
+            releases: released, ticksPerS: ticksPerS)
     }
 
     /// Warm-handover verdict: cut over to paced release only after the rebuilt
@@ -326,16 +376,22 @@ extension FramePacer {
         tickDeficit.floorViolationSince = .nan
         tickDeficit.floorViolationLogged = false
         tickDeficit.warmHealthyWindowStreak = 0
-        guard tickDeficit.deficitModeActive else { return [] }
+        var events: [TickDeficitEvent] = []
+        if tickDeficit.floorAssistActive {
+            events.append(disengageFloorAssistLocked(
+                reason: "presentation suppressed", now: now, ticksPerS: 0))
+        }
+        guard tickDeficit.deficitModeActive else { return events }
         tickDeficit.deficitModeActive = false
         let duration = tickDeficit.deficitEngagedAt.isFinite ? now - tickDeficit.deficitEngagedAt : 0
         let released = liveness.releaseCount &- tickDeficit.deficitEngageReleaseCount
         let repaints = tickDeficit.deficitRepaints
         tickDeficit.deficitEngagedAt = .nan
         tickDeficit.lastRepaintHostTime = .nan
-        return [.deficitDisengaged(
+        events.append(.deficitDisengaged(
             reason: "presentation suppressed", durationSeconds: duration,
-            releases: released, repaints: repaints, ticksPerS: 0)]
+            releases: released, repaints: repaints, ticksPerS: 0))
+        return events
     }
 
     /// Re-seed the realized-rate window from `now` and void the published
@@ -373,6 +429,10 @@ extension FramePacer {
         tickDeficit.warmHealthyWindowStreak = 0
         tickDeficit.floorViolationSince = .nan
         tickDeficit.floorViolationLogged = false
+        tickDeficit.floorAssistActive = false
+        tickDeficit.floorAssistEngagedAt = .nan
+        tickDeficit.floorAssistEngageReleaseCount = 0
+        tickDeficit.floorAssistHealthySince = .nan
         tickDeficit.pinnedFloorHz = .nan
     }
 
@@ -469,6 +529,30 @@ extension FramePacer {
                     + "\(String(format: "%.0f", duration * 1000))ms - ticks back at "
                     + "\(String(format: "%.1f", ticksPerS))/s",
                     "Stream.Pacer")
+            case let .floorAssistEngaged(ticksPerS, floorHz, depth):
+                reconcile = true
+                log.notice(
+                    // swiftlint:disable:next line_length
+                    "FramePacer floor-violation ASSIST engaged - ticks \(ticksPerS, privacy: .public)/s vs \(floorHz, privacy: .public)Hz floor, depth=\(depth, privacy: .public); off-tick timer filling missed beats")
+                Diag.notice(
+                    "FramePacer floor-violation ASSIST engaged - ticks "
+                    + "\(String(format: "%.1f", ticksPerS))/s vs "
+                    + "\(String(format: "%.1f", floorHz))Hz floor, depth=\(depth); "
+                    + "off-tick timer filling missed beats",
+                    "Stream.Pacer")
+                OSSignposter.render.emitEvent(
+                    "PacerFloorAssistEngaged",
+                    "ticksPerS=\(ticksPerS, privacy: .public) depth=\(depth, privacy: .public)")
+            case let .floorAssistDisengaged(reason, duration, releases, ticksPerS):
+                reconcile = true
+                Diag.info(
+                    "FramePacer floor-violation ASSIST disengaged (\(reason)) after "
+                    + "\(String(format: "%.0f", duration * 1000))ms - \(releases) releases "
+                    + "during assist, ticks \(String(format: "%.1f", ticksPerS))/s",
+                    "Stream.Pacer")
+                OSSignposter.render.emitEvent(
+                    "PacerFloorAssistDisengaged",
+                    "durationMs=\(duration * 1000, privacy: .public) releases=\(releases, privacy: .public)")
             case let .warmHandoverComplete(ticksPerS):
                 log.notice(
                     // swiftlint:disable:next line_length
@@ -494,7 +578,7 @@ extension FramePacer {
     /// converge on the latest state instead of double-arming.
     func reconcileDeficitTimer() {
         os_unfair_lock_lock(&lock)
-        let want = tickDeficit.deficitModeActive && running
+        let want = (tickDeficit.deficitModeActive || tickDeficit.floorAssistActive) && running
         let interval = streamFrameIntervalSeconds
         os_unfair_lock_unlock(&lock)
         if want, tickDeficit.deficitTimer == nil {
@@ -520,7 +604,8 @@ extension FramePacer {
     /// at one per stream interval no matter how the two sources interleave).
     func deficitTimerFired() {
         os_unfair_lock_lock(&lock)
-        let active = tickDeficit.deficitModeActive && running && !presentSuppressed
+        let active = (tickDeficit.deficitModeActive || tickDeficit.floorAssistActive)
+            && running && !presentSuppressed
         let interval = streamFrameIntervalSeconds
         os_unfair_lock_unlock(&lock)
         guard active else { return }
@@ -552,7 +637,7 @@ extension FramePacer {
             ? now - liveness.lastReleaseHostTime : .infinity
         let sinceRepaint = tickDeficit.lastRepaintHostTime.isFinite
             ? now - tickDeficit.lastRepaintHostTime : .infinity
-        if tickDeficit.deficitModeActive, !presentSuppressed,
+        if tickDeficit.deficitModeActive || tickDeficit.floorAssistActive, !presentSuppressed,
            sinceRelease > interval * FramePacer.repaintAfterIdleIntervals,
            sinceRepaint >= interval,
            let sampleBuffer = tickDeficit.lastPresentedSampleBuffer {

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -373,6 +373,17 @@ final class FramePacer: @unchecked Sendable {
         /// pinned preferredFrameRateRange floor >1s - direct governor evidence).
         var floorViolationSince: CFTimeInterval = .nan
         var floorViolationLogged = false
+        /// FLOOR-VIOLATION ASSIST: true while the off-tick timer is armed to
+        /// fill the governor's 0.5-0.9x dead band (ticks throttled below the
+        /// pinned floor but above the hard-deficit ratio - the field's
+        /// most-frequent judder signature, logged for weeks with no response).
+        var floorAssistActive = false
+        var floorAssistEngagedAt: CFTimeInterval = .nan
+        var floorAssistEngageReleaseCount: UInt64 = 0
+        /// Continuous healthy time (ticks back at/above the floor ratio) before
+        /// the assist stands down - rides the observed 1-3s violate/clear flap
+        /// through as ONE episode instead of cycling the timer with it.
+        var floorAssistHealthySince: CFTimeInterval = .nan
         /// Lock-guarded mirror of the main-actor `appliedFloorHz`, written wherever
         /// the range is (re)applied, so the off-main rate-window roll can compare
         /// realized ticks against the pinned floor without an actor hop.

--- a/Glimmer/Stream/StatsCollector+Record.swift
+++ b/Glimmer/Stream/StatsCollector+Record.swift
@@ -185,7 +185,35 @@ extension StatsCollector {
         // for BOTH paced and direct presents - so the present-path watchdog and
         // fps_rendered both source from the actual screen-update moment and
         // never gap on a pacer disable/re-enable transition.
-        lastPresentTime = CFAbsoluteTimeGetCurrent()
+        let now = CFAbsoluteTimeGetCurrent()
+        lastPresentTime = now
+        // Perceived-gap judge: a drought since the last present with frames
+        // still ARRIVING in between means the screen held while content flowed
+        // (loss storm / decode starvation / pacing wedge) - a felt gap. Sparse
+        // content (nothing arrived) never counts; a designed-idle span
+        // (window backgrounded) clears the baseline instead of being judged.
+        if gapJudgingExcluded {
+            gapBaselineTime = 0
+        } else {
+            if gapBaselineTime > 0,
+               now - gapBaselineTime > Self.perceivedGapSeconds,
+               receivedFrames &- gapBaselineReceived >= Self.perceivedGapMinReceived {
+                presentationGaps &+= 1
+            }
+            gapBaselineTime = now
+            gapBaselineReceived = receivedFrames
+        }
+    }
+
+    /// Exclude presentation droughts from the perceived-gap judge while the
+    /// window is DESIGNED idle (backgrounded/occluded: receive continues,
+    /// presents stop). The first present after clearing re-seeds the baseline
+    /// un-judged, so the hidden span can never mint a false gap.
+    func setGapJudgingExcluded(_ excluded: Bool) {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+        gapJudgingExcluded = excluded
+        if excluded { gapBaselineTime = 0 }
     }
 
     /// Record a frame dropped because the AVSampleBufferVideoRenderer was
@@ -262,8 +290,10 @@ extension StatsCollector {
         return presentationLateDrops
     }
 
-    /// Record a PERCEIVED present gap: a drop where the present path showed nothing
-    /// fresh (drop-to-newest the renderer also refused) - the felt-stutter signal,
+    /// Record a PERCEIVED present gap from the pacer's backoff path: the
+    /// drop-to-newest's replacement was ALSO refused, so nothing fresh reached
+    /// the screen. The drought-with-content-arriving case is counted inline in
+    /// `recordRendererEnqueue` - together they are the felt-stutter signal,
     /// distinct from catch-up discards (which DID present a newer frame).
     func recordPresentationGap() {
         os_unfair_lock_lock(&lock)

--- a/Glimmer/Stream/StatsCollector.swift
+++ b/Glimmer/Stream/StatsCollector.swift
@@ -157,10 +157,29 @@ final class StatsCollector: @unchecked Sendable {
     /// drops (VT rejected the bitstream) and renderer-backpressure drops (the
     /// OS renderer queue was full). Session-cumulative.
     var presentationLateDrops: UInt64 = 0
-    /// Perceived present GAPS: a drop where the renderer showed nothing fresh
-    /// (drop-to-newest it also refused) - the felt-stutter signal. Catch-up
-    /// discards that DID present a newer frame are NOT counted. Session-cumulative.
+    /// Perceived present GAPS - the felt-stutter signal. Counted when (a) a
+    /// drop-to-newest's replacement was ALSO refused by the renderer, or (b) a
+    /// present landed after a drought > `perceivedGapSeconds` during which
+    /// frames were still ARRIVING (loss storm / decode starvation / pacing
+    /// wedge - the screen held while content flowed). Sparse content (desktop
+    /// idle: nothing arriving) and designed-idle spans (window backgrounded)
+    /// are excluded. Session-cumulative.
     var presentationGaps: UInt64 = 0
+    /// Present-drought baseline for the perceived-gap check: wall-clock + the
+    /// receivedFrames total at the last judged present. 0 = re-seed (session
+    /// start, or the first present after a designed-idle span).
+    var gapBaselineTime: CFAbsoluteTime = 0
+    var gapBaselineReceived: UInt64 = 0
+    /// True while presentation is DESIGNED idle (window backgrounded/occluded:
+    /// receive continues, presents stop). Droughts spanning it never count.
+    var gapJudgingExcluded = false
+    /// A present this long after the previous one, with frames still arriving
+    /// in between, is a felt gap. 100ms is ~unambiguous at any content rate;
+    /// sub-100ms microstutter stays the cadence metric's job.
+    static let perceivedGapSeconds: CFAbsoluteTime = 0.100
+    /// Minimum frames RECEIVED inside the drought for it to count - proves
+    /// content was flowing (a single frame at the boundary doesn't).
+    static let perceivedGapMinReceived: UInt64 = 2
 
     /// On-cadence presents this window: |cadence error| within tolerance of the
     /// stream's frame interval. Reset each snapshot alongside the FPS window.
@@ -245,6 +264,9 @@ final class StatsCollector: @unchecked Sendable {
         rendererBackpressureDrops = 0
         presentationLateDrops = 0
         presentationGaps = 0
+        gapBaselineTime = 0
+        gapBaselineReceived = 0
+        gapJudgingExcluded = false
         onTimePresents = 0
         latePresents = 0
         presentCadenceErrorMsSum = 0

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -199,7 +199,7 @@ extension TelemetryExporter {
             extras.latencyRolling60s = Self.captureBaselines.latencyRolling.advance(with: histograms)
         }
 
-        // ENV-SIGNAL (shadow mode): fold this tick's route/radio/gap evidence
+        // ENV-SIGNAL: fold this tick's route/radio/gap evidence
         // into the CLEAR/CAUTION/DISTRESS state machine (transitions Diag-log
         // and emit `env_state` events with their evidence vector; the ONLY
         // live actuation is the conditional keepalive cadence), then carry
@@ -224,7 +224,7 @@ extension TelemetryExporter {
         if let histograms = snap.latencyHistograms {
             sessionAggregate.foldLatency(histograms, active: segment == .active)
         }
-        // Seconds-in-state for the scorecard (the shadow-session judge wants
+        // Seconds-in-state for the scorecard (the env-signal judge wants
         // "how long was each state" next to the transition count).
         if let ordinal = extras.envStateOrdinal {
             sessionAggregate.noteEnvState(

--- a/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureExtras.swift
@@ -112,7 +112,7 @@ extension TelemetryExporter {
         return extras
     }
 
-    /// Sample the ENV-SIGNAL shadow state + the keepalive cadence + the
+    /// Sample the ENV-SIGNAL state + the keepalive cadence + the
     /// per-socket pings_sent counters for this tick. Called AFTER
     /// `observeCaptureTick` so the row carries the state the tick produced.
     /// The pings/s rates derive from deltas like every other per_s field, but
@@ -246,7 +246,7 @@ extension TelemetrySnapshot {
         /// bad" view next to the cumulative "was bad" one. nil when the
         /// latency rig has no data this tick.
         var latencyRolling60s: LatencyHistogramSnapshot?
-        /// ENV-SIGNAL shadow state (0 clear / 1 caution / 2 distress) + label
+        /// ENV-SIGNAL state (0 clear / 1 caution / 2 distress) + label
         /// + transition count, the LIVE keepalive cadence (ms), and the
         /// per-socket pings_sent counters + per-second rates - the cadence
         /// judge for evaluating keepalive-interval changes from data. nil only

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -196,9 +196,10 @@ extension TelemetryExporter {
             // steadyPingInterval), flagged so fast-while-active windows
             // self-explain.
             "\"keepalive_caution_forces_fast\":true",
-            // The env-signal layer ships SHADOW: state machine + exports live,
-            // every actuation dark except the keepalive gate above.
-            "\"env_shadow_mode\":true",
+            // True only when the env state moves no dial beyond the keepalive
+            // gate above. With the reconciler live it also drives the pacer
+            // depth + FEC reorder-hold headroom, so shadow reads false.
+            "\"env_shadow_mode\":\(!EnvSignalController.reconcilerEnabled)",
             "\"audio_cushion_base_ms\":\(Int(AudioDecoder.playoutCushionBaseMs))",
             "\"audio_cushion_step_ms\":\(Int(AudioDecoder.playoutCushionStepMs))",
             "\"audio_cushion_max_ms\":\(Int(AudioDecoder.playoutCushionMaxMs))",

--- a/Glimmer/Stream/TelemetryExporter+Render.swift
+++ b/Glimmer/Stream/TelemetryExporter+Render.swift
@@ -84,7 +84,7 @@ enum TelemetryRenderer {
         promDisplay(&builder, snap, extras)
         promAudio(&builder, snap, extras)
         promWiFi(&builder, snap)
-        // ENV-SIGNAL shadow state + the conditional-keepalive judge counters
+        // ENV-SIGNAL state + the conditional-keepalive judge counters
         // (pings_sent / live cadence) - rendered right after the radio family
         // they gate on (TelemetryExporter+RenderNetwork.swift).
         promEnvSignal(&builder, extras)

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -404,7 +404,7 @@ extension TelemetryRenderer {
             builder.addString("stream_link", routeSnapshot.linkLabel)
             builder.addString("stream_if", routeSnapshot.interfaceName)
         }
-        // ENV-SIGNAL shadow state + the conditional-keepalive judge fields -
+        // ENV-SIGNAL state + the conditional-keepalive judge fields -
         // they ride the link section because the link IS their evidence.
         // Transitions additionally get their own `event:"env_state"` row with
         // the full evidence vector (see EnvSignalController).

--- a/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
@@ -138,7 +138,7 @@ extension TelemetryRenderer {
                      "Inter-packet arrival gap max this window, microseconds.", snap.packetGapMaxUs)
     }
 
-    /// ENV-SIGNAL shadow state + the conditional-keepalive judge family: the
+    /// ENV-SIGNAL state + the conditional-keepalive judge family: the
     /// CLEAR/CAUTION/DISTRESS ordinal (with its label), the transition count,
     /// the LIVE keepalive cadence, and the per-socket pings_sent counters -
     /// the counters that make a keepalive-cadence change judgeable from data.
@@ -149,7 +149,7 @@ extension TelemetryRenderer {
         if let ordinal = extras.envStateOrdinal {
             builder.emitLabeled(
                 "glimmer_env_state",
-                "Env-signal link state ordinal (0 clear, 1 caution, 2 distress) - SHADOW mode.",
+                "Env-signal link state ordinal (0 clear, 1 caution, 2 distress) - gates keepalive cadence + reconciler headroom.",
                 Double(ordinal), labels: [("state", extras.envStateLabel ?? "unknown")])
         }
         if let changes = extras.envStateChangesTotal {

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -185,11 +185,11 @@ struct SessionAggregate {
         activeLatency = activeLatency.map { LatencyRollingWindow.sum($0, plus: delta) } ?? delta
     }
 
-    // ---- ENV-SIGNAL shadow-session judge inputs ----
+    // ---- ENV-SIGNAL judge inputs ----
     /// Ticks (~seconds) spent in each env state (index = the state ordinal:
     /// clear/caution/distress) + the final transition count - "how long was
     /// each state, and how often did it move" is the scorecard half of
-    /// judging the shadow state machine against felt events.
+    /// judging the state machine against felt events.
     var envStateSeconds = [Int](repeating: 0, count: 3)
     var envStateChangesTotal: UInt64 = 0
 
@@ -307,7 +307,7 @@ struct SessionReport {
         // Per-TYPE ignored-control totals - durable here (the teardown Diag
         // NOTICE is lossy: a crash or a still-running session loses it).
         top.append("\"ctrl_ignored_by_type\":\(ctrlIgnoredByTypeObject())")
-        // ENV-SIGNAL shadow scorecard: seconds-in-state + transition count -
+        // ENV-SIGNAL scorecard: seconds-in-state + transition count -
         // the per-session judge for the state machine (DISTRESS seconds are
         // EXCLUDED from present-path quality reads, never added).
         top.append("\"env\":\(envObject())")
@@ -480,7 +480,7 @@ struct SessionReport {
         return "{" + parts.joined(separator: ",") + "}"
     }
 
-    /// ENV-SIGNAL shadow scorecard: per-state tick counts (~seconds at the
+    /// ENV-SIGNAL scorecard: per-state tick counts (~seconds at the
     /// 1Hz cadence) + the transition total, plus the final per-socket
     /// pings_sent counts (the keepalive cadence judge).
     private func envObject() -> String {

--- a/Glimmer/Stream/VideoDecoder+Suppression.swift
+++ b/Glimmer/Stream/VideoDecoder+Suppression.swift
@@ -89,6 +89,7 @@ extension VideoDecoder {
                 "present suppressed (window backgrounded/occluded) - pacer holds newest frame only, IDR escalation off",
                 "Stream")
             TelemetryCounters.shared.setPresentSuppressed(true)
+            statsCollector.setGapJudgingExcluded(true)
             framePacer?.setPresentSuppressed(true)
             framePacer?.dropToNewest(reason: "present_suppressed")
             // Arm stage 2: if the window stays hidden past the gate delay,
@@ -109,6 +110,7 @@ extension VideoDecoder {
                 "present un-suppressed (window refocused) - retained newest frame presents, single IDR resync",
                 "Stream")
             TelemetryCounters.shared.setPresentSuppressed(false)
+            statsCollector.setGapJudgingExcluded(false)
             framePacer?.setPresentSuppressed(false)
             framePacer?.dropToNewest(reason: "present_resync")
             // Stand down stage 2 BEFORE the resync below: cancel a pending


### PR DESCRIPTION
Telemetry-driven polish pass from the cataloged Ctrl-B "felt bad" bookmarks (22 across 14 days) and their surrounding metrics/logs.

**The two felt-bad signatures found:**
1. Governor tick-throttle judder: `FramePacer FLOOR VIOLATION` at ~0.85x the pinned floor every few seconds (still on 2026.7.1, with RT scheduling confirmed applied) - sat in the dead band between the violation breadcrumb (0.9x) and the hard tick-deficit rescue (0.5x), so it was logged for weeks with no response.
2. Loss-storm freezes invisible to the stutter signal: `glimmer_present_perceived_gaps_total` = 0 across ALL 14 days - its only increment site was a doubly-rare backoff-then-renderer-reject path, so the badge's late-burst arm was structurally dead while users flagged jank.

**Changes:**
- **FramePacer floor-violation ASSIST**: arms the existing off-tick release timer while a sustained floor violation is latched; 3s-healthy exit rides the observed 1-3s violate/clear flap as one episode. The due gate dedupes, so the timer only fills the beats the throttled link misses.
- **Perceived-gap honesty**: a present landing after a >100ms drought with frames still arriving counts as a felt gap. Desktop idle (nothing arriving) and backgrounded spans (receive continues by design) stay excluded. Badge thresholds unchanged - this only revives the arm at its designed sensitivity.
- **Per-host resampler skew persistence** (the long-deferred item): persist the converged host-Mac clock-offset ppm (~1/min, only within the converged envelope); seed the next session's integral aged (7-day half-life) and clamped, so playout starts pre-corrected instead of drifting into the early-session underruns that feed the cushion ratchet.
- **env-signal honesty**: `env_shadow_mode` emitted a hardcoded `true` while the controller actuates two live dials (keepalive cadence + reconciler headroom) - now emits the honest value; stale "shadow mode" framing relabeled.
- **Stale-code sweep**: `QuitHotkey` typealias + `HotkeyChord.default` (zero users) deleted; `nativeStreamPhase` string shim migrated to the `streamPhase` enum and deleted.

**Validation plan (draft until then):** next live session's telemetry judges it - assist ENGAGED/disengaged breadcrumbs with release counts, `perceived_gaps > 0` during real degradation, the "resampler skew seed" NOTICE plus early-session underrun rate. 163 tests pass; installed locally via `make dev`.