### PR TITLE
fix(audio): kill the startup drain cascade + the floor weld it teaches

### DIFF
--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -213,11 +213,14 @@ extension AudioDecoder {
         let link = key.split(separator: "|").last.map(String.init) ?? "unknown"
         let cap = recordSeedCapMs(forLink: link)
         let clampedTarget = min(max(agedTarget, playoutCushionBaseMs), cap)
-        // WELD REPAIR: a floor at/above the cap (or at/above the target) is a
-        // poisoned record - skew under-runs welded the floor to the cap and froze
-        // the target one step above it. Drop the floor to base so the session
-        // re-learns from a healthy floor instead of re-seeding into the lock.
-        if floor >= cap || floor >= clampedTarget {
+        // WELD REPAIR: a floor at/near the cap (or at/above the target) is a
+        // poisoned record - cascade under-runs weld the floor toward the cap and
+        // freeze the target against it (a 180-on-cap-200 floor blocked decay for
+        // a whole session while escaping the old >=cap test). Drop the floor to
+        // base so the session re-learns from a healthy floor instead of
+        // re-seeding into the lock. 0.85x: legit steady-state floors sit far
+        // below the cap; only a weld lives in the top band.
+        if floor >= cap * 0.85 || floor >= clampedTarget {
             floor = min(playoutCushionBaseMs, clampedTarget)
         }
         return (clampedTarget, min(max(floor, 0), clampedTarget))
@@ -289,7 +292,12 @@ extension AudioDecoder {
         let host = StreamRouteProbe.currentLatchedHost ?? "unknown"
         let link = EnvSignalController.shared.streamLink
         let key = cushionMemoryKey(host: host, link: link)
-        if let record = readCushionMemory(key: key) {
+        // The |unknown bucket is BORROW-ONLY: a legacy `host|unknown` record
+        // (written by pre-resolve sessions) direct-hitting here seeded 40ms
+        // while the real wifi record held 97ms - the shallow prime that set
+        // off the 2026-07-05 startup drain cascade. Real links direct-hit;
+        // unknown goes straight to the deepest-of-wifi/wired borrow.
+        if link != "unknown", let record = readCushionMemory(key: key) {
             return CushionSeed(key: key, host: host, link: link,
                                targetMs: record.targetMs, floorMs: record.floorMs,
                                fromMemory: true)
@@ -343,10 +351,15 @@ extension AudioDecoder {
     /// for the caller to commit off the lock.
     func cushionNoteUnderrunLocked(now: UInt64, failedTargetMs: Double) -> CushionMemoryWrite {
         cushionHadUnderrun = true
-        learnedFloorMs = learnedFloorMs <= 0
-            ? failedTargetMs
-            : learnedFloorMs + Self.cushionFloorEwmaWeight * (failedTargetMs - learnedFloorMs)
-        learnedFloorMs = min(learnedFloorMs, effectiveCushionMaxMs)
+        // STARTUP GATE: boot-ramp drains (host pacing sub-realtime) must not
+        // teach the floor - a 15s cascade welded a 180ms floor that blocked
+        // decay for a whole session. The target ratchet already grew above.
+        if now >= floorLearnGateUntilNanos {
+            learnedFloorMs = learnedFloorMs <= 0
+                ? failedTargetMs
+                : learnedFloorMs + Self.cushionFloorEwmaWeight * (failedTargetMs - learnedFloorMs)
+            learnedFloorMs = min(learnedFloorMs, effectiveCushionMaxMs)
+        }
         floorQuietSinceNanos = now
         quietWindowMinFillMs = .infinity
         return CushionMemoryWrite(key: cushionSeedKey, targetMs: playoutTargetMs,
@@ -412,7 +425,14 @@ extension AudioDecoder {
     /// Commit a captured write OUTSIDE the meter lock: UserDefaults (its own
     /// lock; never nested under the meter's) + the 1Hz floor gauge.
     func commitCushionMemory(_ write: CushionMemoryWrite) {
-        Self.persistCushionMemory(key: write.key, targetMs: write.targetMs, floorMs: write.floorMs)
+        // Never persist under an |unknown key: that learning is unlabeled (link
+        // class unresolved - telemetry off / probe dark), and a stale |unknown
+        // record later short-circuits the seed (the 40ms-vs-97ms 2026-07-05
+        // cascade). Learning continues in-memory; once the resolve re-keys,
+        // writes land in the real link's bucket.
+        if !write.key.hasSuffix("|unknown") {
+            Self.persistCushionMemory(key: write.key, targetMs: write.targetMs, floorMs: write.floorMs)
+        }
         AudioCushionTelemetry.shared.setFloorMs(write.floorMs)
     }
 
@@ -522,6 +542,19 @@ extension AudioDecoder {
         // railing, the deep cushion is LOAD-BEARING and the existing behavior stands.
         if link == "wired", resamplerSkewConverged, !cushionHadUnderrun {
             learnedFloorMs = min(learnedFloorMs, Self.playoutCushionBaseMs)
+        }
+        // RESOLVE TOP-UP: adopting a deeper target than the standing fill used
+        // to "materialize at the next re-prime (<=1 blip)" - but the host feeds
+        // sub-realtime at startup (startup-pacing=paced), so the deficit taught
+        // itself through a drain CASCADE instead. Arm the one-shot flag; the
+        // next decode-path maybePrime closes the gap with the silence backfill
+        // (zero further blips). AV work never happens here - this can run on
+        // the completion thread.
+        let aheadFrames = framesScheduled &- framesPlayed
+        let aheadMs = meterSampleRate > 0
+            ? Double(aheadFrames) / meterSampleRate * 1000.0 : 0
+        if primed, playoutTargetMs - aheadMs >= Self.playoutCushionStepMs {
+            pendingResolveTopUp = true
         }
         let target = playoutTargetMs
         let floor = learnedFloorMs

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -54,6 +54,12 @@ extension AudioDecoder {
     /// the BREADCRUMB rate so a cascade can't flood the 2000-entry Diag ring -
     /// edges suppressed by the limit ride the next line as a count.
     static let underrunNoticeMinIntervalNanos: UInt64 = 1_000_000_000
+    /// Startup floor-learning gate (ns after the cold-start prime): the host
+    /// feeds sub-realtime for its first seconds (startup-pacing=paced, ~15s
+    /// measured), so drains in this window are boot-ramp artifacts. 45s covers
+    /// the measured ramp with margin. Target ratchet + underrun counting stay
+    /// live; only the floor EWMA waits.
+    static let startupFloorGateNanos: UInt64 = 45_000_000_000
 
     // MARK: - P1 AUDIO meter (buffer fill / under-run / over-run / A/V drift)
 
@@ -128,6 +134,12 @@ extension AudioDecoder {
             playoutStarted = true
             driftAnchorNanos = DispatchTime.now().uptimeNanoseconds
             driftAnchorFramesPlayed = framesPlayed
+            // COLD START: arm the floor-learning gate. Drains inside the host's
+            // boot-ramp window (paced sub-realtime inflow) must not teach the
+            // per-link floor - see cushionNoteUnderrunLocked.
+            if !rebuildIsReprime {
+                floorLearnGateUntilNanos = driftAnchorNanos &+ Self.startupFloorGateNanos
+            }
             // Arm the gate grace on this same edge (cold start or post-drain
             // restart): the next ~250ms of arrivals are the cushion (re)build - the
             // catch-up clump the link just proved it needs - so neither the trim nor
@@ -183,7 +195,25 @@ extension AudioDecoder {
     /// across an AV call).
     func maybePrime(format: AVAudioFormat) {
         audioMeterLock.lock()
-        if primed { audioMeterLock.unlock(); return }
+        if primed {
+            // RESOLVE TOP-UP (one-shot, armed by resolveCushionLink): the link
+            // resolve adopted a target deeper than the standing fill. Close the
+            // deficit NOW with the silence backfill - this is the decode path
+            // (stateLock held), the one place AV calls are serialized against
+            // shutdown - instead of letting the host's paced startup inflow
+            // drain-cascade the difference audibly.
+            guard pendingResolveTopUp else { audioMeterLock.unlock(); return }
+            pendingResolveTopUp = false
+            let aheadFrames = framesScheduled &- framesPlayed
+            let aheadMs = meterSampleRate > 0
+                ? Double(aheadFrames) / meterSampleRate * 1000.0 : 0
+            let deficitMs = playoutTargetMs - aheadMs
+            audioMeterLock.unlock()
+            if deficitMs >= Self.playoutCushionStepMs {
+                backfillCushion(deficitMs: deficitMs, format: format)
+            }
+            return
+        }
         let aheadFrames = framesScheduled &- framesPlayed
         let aheadMs = meterSampleRate > 0 ? Double(aheadFrames) / meterSampleRate * 1000.0 : 0
         if aheadMs >= playoutTargetMs {

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -297,6 +297,19 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `DispatchTime` ns deadline of the post-(re)prime gate grace: both backlog
     /// gates stand down until this instant. Guarded by `audioMeterLock`.
     var gateGraceUntilNanos: UInt64 = 0
+    /// One-shot flag armed by the link resolve when adopting a deeper target
+    /// leaves standing fill a step+ short: the next DECODE-path `maybePrime`
+    /// tops the cushion up via the silence backfill instead of letting the
+    /// host's paced startup inflow teach the deficit through a drain cascade
+    /// (~9 audible blips, 2026-07-05). Guarded by `audioMeterLock`; the AV
+    /// work stays on the decode path.
+    var pendingResolveTopUp = false
+    /// `DispatchTime` ns deadline of the startup floor-learning gate, armed at
+    /// the COLD-START prime: drains in the host's boot-ramp window are pacing
+    /// artifacts, not link character - letting them teach the floor welded
+    /// 180ms in and blocked decay for a whole session. The target ratchet
+    /// still applies; only the floor EWMA waits. Guarded by `audioMeterLock`.
+    var floorLearnGateUntilNanos: UInt64 = 0
     /// `DispatchTime` ns anchor of the current under-run-free stretch (drives the
     /// cushion decay). Reset on every under-run edge AND on each decay step, so each
     /// 10ms step back down requires its own full quiet window. Guarded by
@@ -460,6 +473,7 @@ public final class AudioDecoder: @unchecked Sendable {
         quietWindowMinFillMs = .infinity
         rePrimeCount = 0
         lastTrimNanos = 0; gateGraceUntilNanos = 0
+        pendingResolveTopUp = false; floorLearnGateUntilNanos = 0
         quietSinceNanos = seedNowNanos
         floorQuietSinceNanos = seedNowNanos
         rebuildIsReprime = false


### PR DESCRIPTION
Telemetry forensics on the 2026-07-05 4K120 AV1 wifi session ("startup ramp could be a little shorter") found a four-link causal chain behind the rough first ~15s - and a worse hidden artifact it leaves behind:

1. A stale `host|unknown` cushion record direct-hit the seed at **40ms** (aged) while the real wifi record held **97ms** - the borrow that would have picked 97 never ran.
2. The ~1s link resolve raised the target +57ms above standing fill, against a host feeding **sub-realtime at startup** (`startup-pacing=paced rate=0.3x`).
3. That deficit taught itself through **~9 audible drains over 15s** (mostly notice-suppressed) until a +177ms silence backfill ended it.
4. The cascade **welded a 180ms floor** (escaping the >=cap weld repair at cap 200), which blocked cushion decay for the entire 75-minute session (~200ms standing audio latency) and then persisted for the next session to inherit.

## Fixes (all in the cushion module, each keyed to a link in the chain)
- **`|unknown` bucket is borrow-only**: a real link direct-hits its own record; unknown link goes straight to the deepest-of-wifi/wired borrow. And `commitCushionMemory` never persists under an `|unknown` key (pre-resolve / probe-dark learning is unlabeled).
- **Resolve top-up**: when the link resolve adopts a target deeper than standing fill, the deficit closes immediately via the existing silence backfill on the decode path - one splice at ~t+1s instead of a drain cascade. (The old contract accepted "<=1 blip at the next re-prime"; paced startup inflow turned that into ~9.)
- **Startup floor gate (45s)**: drains inside the host's boot-ramp window no longer teach the per-link floor; the target ratchet and counters are unchanged.
- **Weld repair tightened**: read-side repair now also drops a floor at >=0.85x cap, so the already-poisoned 200/180 wifi record on this Mac can't re-block decay tonight.

## Expected next-session signature
Prime near the learned depth, at most one splice at ~t+1s, 0-1 startup underruns (was ~9), and the cushion actually decays during quiet play instead of pinning at 200ms.

163 tests pass. Installed locally via make dev for validation.