### PR TITLE
fix(input): raise all held keys/buttons on focus loss

### DIFF
--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -96,11 +96,13 @@ extension InputForwarder {
             object: window, queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                // Release cursor when the user Cmd-Tabs away or the system
-                // grabs focus for a sheet. We do NOT raise keys here - the
-                // window-resign path can be a transient (e.g. notification
-                // banner) and we want held game keys to survive it. The
-                // gate against orphan modifiers is in detach().
+                // Release the cursor AND raise all held input when focus
+                // leaves. The physical key-up goes to whatever now owns focus
+                // (Cmd-Tab target, an app stealing foreground), so without the
+                // raise the host keeps a held W pressed and the game walks
+                // forever. A key still physically held on refocus stays lost
+                // until re-pressed - predictable, and what upstream clients do.
+                self?.raiseAllHeldInputs(reason: "focus loss")
                 self?.exitCapturedMode()
             }
         }

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -113,13 +113,15 @@ extension InputForwarder: StreamInputViewDelegate {
         // Ignore auto-repeated keys; the host generates its own repeats.
         guard !event.isARepeat, isReady else { return true }
         guard let vk = vkScanCode(forCarbonKeyCode: Int(event.keyCode)) else { return true }
+        let wireCode = Int16(bitPattern: 0x8000 | UInt16(bitPattern: vk))
         let rc = backend?.sendKeyboard(
-            keyCode: Int16(bitPattern: 0x8000 | UInt16(bitPattern: vk)),
+            keyCode: wireCode,
             action: Int8(StreamProtocol.KEY_ACTION_DOWN),
             modifiers: Int8(bitPattern: modifierByte(from: mods)),
             flags: 0
         ) ?? -2
         record("LiSendKeyboardEvent2(down)", rc)
+        heldKeys.insert(wireCode)
         return true
     }
 
@@ -137,13 +139,15 @@ extension InputForwarder: StreamInputViewDelegate {
         }
 
         guard let vk = vkScanCode(forCarbonKeyCode: Int(event.keyCode)) else { return }
+        let wireCode = Int16(bitPattern: 0x8000 | UInt16(bitPattern: vk))
         let rc = backend?.sendKeyboard(
-            keyCode: Int16(bitPattern: 0x8000 | UInt16(bitPattern: vk)),
+            keyCode: wireCode,
             action: Int8(StreamProtocol.KEY_ACTION_UP),
             modifiers: Int8(bitPattern: modifierByte(from: mods)),
             flags: 0
         ) ?? -2
         record("LiSendKeyboardEvent2(up)", rc)
+        heldKeys.remove(wireCode)
     }
 
     func streamView(_ view: StreamInputView, handleFlagsChanged event: NSEvent) {
@@ -307,16 +311,20 @@ extension InputForwarder: StreamInputViewDelegate {
 
     func streamView(_ view: StreamInputView, handleMouseDown event: NSEvent) {
         guard isReady else { return }
+        let hostButton = button(for: event)
         let rc = backend?.sendMouseButton(
-            action: Int8(StreamProtocol.BUTTON_ACTION_PRESS), button: button(for: event)) ?? -2
+            action: Int8(StreamProtocol.BUTTON_ACTION_PRESS), button: hostButton) ?? -2
         record("LiSendMouseButtonEvent(press)", rc)
+        heldMouseButtons.insert(hostButton)
     }
 
     func streamView(_ view: StreamInputView, handleMouseUp event: NSEvent) {
         guard isReady else { return }
+        let hostButton = button(for: event)
         let rc = backend?.sendMouseButton(
-            action: Int8(StreamProtocol.BUTTON_ACTION_RELEASE), button: button(for: event)) ?? -2
+            action: Int8(StreamProtocol.BUTTON_ACTION_RELEASE), button: hostButton) ?? -2
         record("LiSendMouseButtonEvent(release)", rc)
+        heldMouseButtons.remove(hostButton)
     }
 
     func streamView(_ view: StreamInputView, handleScroll event: NSEvent) {

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -36,8 +36,9 @@
 //     not collapse simultaneous presses), and the responder chain hands each
 //     to `keyDown(with:)`/`keyUp(with:)` independently. With four fingers on
 //     four keys we send four down events; lifting any one sends exactly one
-//     up event for that key. `releaseStuckModifiers()` is called ONLY in
-//     `detach()` (stream teardown) so it never resets state mid-game.
+//     up event for that key. `raiseAllHeldInputs()` (keys + buttons +
+//     modifiers) fires only on focus loss and `detach()` (stream teardown),
+//     so state never resets mid-game while the window stays key.
 //     `lastModFlags` is diffed against the new mask in `flagsChanged` so we
 //     only emit modifier transitions, not modifier state on every key. This
 //     matches moonlight-qt's `m_KeysDown` QSet semantics.
@@ -462,9 +463,9 @@ public final class InputForwarder {
     }
 
     public func detach() {
-        // Send key-up for any modifiers we believe are pressed so we don't
-        // leave the host with phantom-held modifiers if we tear down mid-press.
-        releaseStuckModifiers()
+        // Raise every held key/button/modifier so a mid-press teardown can't
+        // leave the host with phantom-held input.
+        raiseAllHeldInputs(reason: "stream teardown")
 
         // Disengage relative-aim mode + remove gesture defaults.
         // `exitCapturedMode()` RE-ASSOCIATES the cursor
@@ -571,6 +572,47 @@ public final class InputForwarder {
     /// Last-seen modifier mask, so we can diff against the previous flagsChanged
     /// event and emit per-modifier down/up.
     var lastModFlags: NSEvent.ModifierFlags = []
+
+    /// Wire keycodes (0x8000|VK, exactly as sent) of non-modifier keys the host
+    /// currently holds DOWN, and the mouse buttons it holds pressed. NKRO
+    /// forwarding stays stateless per-event; these sets exist solely so a focus
+    /// loss / teardown can raise everything - when another app steals focus
+    /// mid-hold, the physical key-up is delivered to the thief, so without a
+    /// raise the host keeps a held W pressed and the game walks forever.
+    /// Main-thread only (all key/mouse handling is).
+    var heldKeys: Set<Int16> = []
+    var heldMouseButtons: Set<Int32> = []
+
+    /// Send key-up / button-release for everything we believe the host holds,
+    /// then clear the bookkeeping (modifiers included, via
+    /// releaseStuckModifiers). Called on the window-resign edge and detach().
+    /// A key still physically held on refocus stays released until re-pressed
+    /// - the predictable trade (matching upstream clients' raise-on-focus-loss).
+    func raiseAllHeldInputs(reason: String) {
+        let keyCount = heldKeys.count
+        let buttonCount = heldMouseButtons.count
+        if isReady {
+            for code in heldKeys {
+                let rc = backend?.sendKeyboard(
+                    keyCode: code, action: Int8(StreamProtocol.KEY_ACTION_UP),
+                    modifiers: 0, flags: 0) ?? -2
+                record("LiSendKeyboardEvent2(raise-all)", rc)
+            }
+            for button in heldMouseButtons {
+                let rc = backend?.sendMouseButton(
+                    action: Int8(StreamProtocol.BUTTON_ACTION_RELEASE), button: button) ?? -2
+                record("LiSendMouseButtonEvent(raise-all)", rc)
+            }
+            if keyCount + buttonCount > 0 {
+                Diag.notice("input: released \(keyCount) held key(s) + \(buttonCount) "
+                    + "mouse button(s) on \(reason) - the physical release would have "
+                    + "gone to the newly focused app", "Stream")
+            }
+        }
+        heldKeys.removeAll()
+        heldMouseButtons.removeAll()
+        releaseStuckModifiers()
+    }
 
     func modifierByte(from flags: NSEvent.ModifierFlags) -> UInt8 {
         var b: Int32 = 0


### PR DESCRIPTION
Fixes the stuck-key bug: when another app steals focus while a key is held (holding W as something tabs itself to the foreground), the physical key-up goes to the newly focused app - the stream never sees it, and the host keeps the key pressed indefinitely. The old resign-key handler deliberately kept held keys alive to "survive a transient"; in practice a focus steal orphans the key and the game walks into a wall until refocus + re-press.

- Held non-modifier keys (exact wire keycodes) and mouse buttons are now tracked at the send sites; chord-consumed / Cmd-gated keys never enter the set, so the bookkeeping mirrors what the host actually believes is down.
- `raiseAllHeldInputs()` sends key-up / button-release for everything held plus the existing modifier release, with a Diag breadcrumb (`input: released N held key(s)...`).
- Fires on the window-resign edge and on `detach()` (mid-press teardown). A key still physically held on refocus stays released until re-pressed - the predictable trade, same as moonlight-qt.

Validate: start a stream, hold W, Cmd-Tab (or let anything steal focus) - character stops immediately; the Diag log shows the release breadcrumb.

163 tests pass. Installed locally via make dev.