### PR TITLE
tune(cruise): re-band the traversal boost + de-jitter its velocity gate

### DIFF
--- a/Glimmer/Stream/InputForwarder+Cruise.swift
+++ b/Glimmer/Stream/InputForwarder+Cruise.swift
@@ -36,8 +36,12 @@ enum CruiseTraversal {
     static let referenceWidth: Double = 1920
     /// Defaults for the velocity gate (counts/sec). Below `vKnee` the gain is
     /// exactly 1.0; at/above `vFull` it is the full `gMax`; between, a smoothstep.
-    static let defaultVKnee: Double = 1400
-    static let defaultVFull: Double = 4500
+    /// Re-tuned from 1400/4500 on 14d of field data: real flicks peak ~3200
+    /// counts/s, so half of all sessions never reached full gain (max 1.06-1.57)
+    /// and fast aim above 1400 was getting nibbled - the "mushy" mid-band. The
+    /// 2000/3200 band keeps aim raw to 2000 and puts real flicks AT gMax.
+    static let defaultVKnee: Double = 2000
+    static let defaultVFull: Double = 3200
 
     /// Whether the feature is on (default true).
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -233,6 +233,10 @@ extension InputForwarder: StreamInputViewDelegate {
         let initialDeltas = mouseDelta(from: event)
         var accumDx = initialDeltas.dx
         var accumDy = initialDeltas.dy
+        // Track the LAST coalesced event's timestamp: the deltas sum through the
+        // drained events, so dt must span to the last of them - measuring to the
+        // first event inflated the batch velocity whenever coalescing engaged.
+        var batchTimestamp = event.timestamp
         while let queued = window?.nextEvent(matching: .mouseMoved,
                                              until: Date.distantPast,
                                              inMode: .eventTracking,
@@ -240,19 +244,30 @@ extension InputForwarder: StreamInputViewDelegate {
             let delta = mouseDelta(from: queued)
             accumDx += delta.dx
             accumDy += delta.dy
+            batchTimestamp = queued.timestamp
         }
 
         // CRUISE traversal boost (InputForwarder+Cruise.swift). Velocity-gated,
         // resolution-derived gain on ONLY fast flicks - aim (sub-knee) is untouched.
         // Runs AFTER the Mac linearization, so it's the only client gain. dt is the
-        // inter-batch interval; v is counts/sec over this batch. Below the knee the
-        // gain is exactly 1.0 and accumDx/Dy are unchanged, so the residual path
-        // below runs byte-for-byte as it does today.
-        let now = event.timestamp
+        // inter-batch interval; the gate reads a SHORT velocity EMA (per-batch
+        // instantaneous v jitters ~±30%, flickering the gain through the ramp -
+        // the mushy feel). A post-gap batch seeds the EMA to the raw v, so flick
+        // onset carries zero added lag. Below the knee the gain is exactly 1.0
+        // and accumDx/Dy are unchanged, so the residual path below runs
+        // byte-for-byte as it does today.
+        let now = batchTimestamp
         if CruiseTraversal.isEnabled, cruiseGMax > 1.0 {
             let dt = now - lastMoveTimestamp
-            let v = hypot(accumDx, accumDy) / dt
-            let g = CruiseTraversal.gain(velocity: v, dt: dt, gMax: cruiseGMax,
+            if dt > 0 && dt <= 0.1 {
+                let v = hypot(accumDx, accumDy) / dt
+                // Seed fresh on the first batch after a gap (ema cleared below)
+                // so onset reads the true velocity; blend within continuous motion.
+                cruiseVelocityEma = cruiseVelocityEma > 0 ? 0.5 * v + 0.5 * cruiseVelocityEma : v
+            } else {
+                cruiseVelocityEma = 0
+            }
+            let g = CruiseTraversal.gain(velocity: cruiseVelocityEma, dt: dt, gMax: cruiseGMax,
                                          vKnee: CruiseTraversal.vKnee, vFull: CruiseTraversal.vFull)
             if g > 1.0 {
                 accumDx *= g

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -279,6 +279,12 @@ public final class InputForwarder {
     /// derived ceiling, set at start and re-set on a reconnect resolution change.
     var lastMoveTimestamp: TimeInterval = 0
     var cruiseGMax: Double = 1.0
+    /// Short EMA of batch velocity feeding the Cruise gate. Per-batch
+    /// instantaneous velocity jitters ~±30% at 120Hz event cadence, flickering
+    /// the gain through the ramp band (part of the "mushy" feel). Seeded to the
+    /// raw velocity on a post-gap batch so flick ONSET keeps zero added lag;
+    /// the smoothing only acts within continuous motion.
+    var cruiseVelocityEma: Double = 0
 
     /// Pull the relative delta out of a mouseMoved NSEvent. Reads the CGEvent
     /// integer fields `kCGMouseEventDeltaX/Y` (valid whether or not the cursor is


### PR DESCRIPTION
Fixes the "mushy" mouse feel in the resolution-aware traversal boost (Cruise).

**Field evidence (14d):** the boost engaged on only 0.8% of batches; in half of all sessions the max gain ever reached was 1.06–1.57 (never the designed 2.0). Real flicks peak ~3200 counts/s, so they lived entirely inside the old 1400→4500 ramp - partial, varying gain through every stroke (an acceleration curve by another name), while fast aim above 1400 got nibbled.

- **Band re-tuned 2000/3200** (was 1400/4500): aim fully raw below 2000; real flicks hit full gMax; ramp residency halves.
- **Velocity EMA on the gate** (0.5 blend, seeded fresh post-gap): kills the ±30% per-batch jitter that flickered the gain mid-band, with zero added onset lag.
- **Coalescing dt honesty**: batch dt now spans to the last drained event (deltas already summed through it).

The band values were validated live mid-session via the hidden `cruiseVKnee`/`cruiseVFull` defaults before promotion. 163 tests pass.