### PR TITLE
telem(forensics): pipeline cadence, cause splits, cruise distributions, audio near-miss

### DIFF
--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -144,10 +144,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // which needs the registered default to read `true` before first toggle.
         UserDefaults.standard.register(defaults: [
             MouseAccelerationControl.enabledDefaultsKey: true,
-            // Cruise: resolution-aware fast-flick traversal boost (raw aim
-            // preserved). Hidden, default-on, no UI - the non-UI gate reads it via
-            // UserDefaults.bool, so it needs the registered default to read `true`.
-            CruiseTraversal.enabledDefaultsKey: true,
+            // Cruise: resolution-aware fast-flick traversal boost. DEFAULT OFF
+            // as of 2026-07-19: at 4K, combat aim snaps and traversal flicks
+            // occupy the same velocity AND distance range (field histograms:
+            // aim snaps 1100-1800 counts/s, flicks p99 ~1770, distances
+            // overlap), so any velocity-gated boost eventually boosts aim -
+            // two "crazy sensitivity" incidents in one day. Raw everywhere
+            // wins until a discriminator that can't misfire exists. The
+            // machinery + hidden knobs stay for opt-in experimentation.
+            CruiseTraversal.enabledDefaultsKey: false,
             // Fire the present tick on a private high-QoS run loop (not .main)
             // so a busy main thread can't starve the CADisplayLink callback.
             // Flip false for an instant fallback to the main-runloop tick.

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -54,6 +54,12 @@ extension AudioDecoder {
     /// the BREADCRUMB rate so a cascade can't flood the 2000-entry Diag ring -
     /// edges suppressed by the limit ride the next line as a count.
     static let underrunNoticeMinIntervalNanos: UInt64 = 1_000_000_000
+    /// Near-miss fill thresholds (ms): a steady-state trough below the first
+    /// latches one `audioNearMissTotal` count; fill must recover above the
+    /// second to re-arm, so one dip counts exactly once.
+    static let nearMissFillMs: Double = 15
+    static let nearMissRearmFillMs: Double = 30
+
     /// Startup floor-learning gate (ns after the cold-start prime): the host
     /// feeds sub-realtime for its first seconds (startup-pacing=paced, ~15s
     /// measured), so drains in this window are boot-ramp artifacts. 45s covers
@@ -89,6 +95,20 @@ extension AudioDecoder {
         // conflated again. Gated on `primed` so it never starves the pre-roll, and on
         // `!playoutDrained` so a segment rebuilding its cushion after a drain isn't
         // trimmed before it can re-prime.
+        // NEAR-MISS latch (margin telemetry): steady-state fill dipping under
+        // ~15ms without fully draining - erosion visible BEFORE it's audible.
+        // Latched per dip (re-arms above 30ms) so one trough counts once. The
+        // counter is a leaf atomic, safe under the meter lock.
+        if primed && !playoutDrained {
+            if aheadMs < Self.nearMissFillMs {
+                if !nearMissLatched {
+                    nearMissLatched = true
+                    TelemetryCounters.shared.audioNearMissTotal.increment()
+                }
+            } else if aheadMs > Self.nearMissRearmFillMs {
+                nearMissLatched = false
+            }
+        }
         if primed && !playoutDrained && aheadMs >= playoutTargetMs + Self.playoutTrimHysteresisMs {
             // Clock reads live only inside the would-trim/would-drop branches - the
             // steady-state path at/below target stays clock-free.

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -304,6 +304,9 @@ public final class AudioDecoder: @unchecked Sendable {
     /// (~9 audible blips, 2026-07-05). Guarded by `audioMeterLock`; the AV
     /// work stays on the decode path.
     var pendingResolveTopUp = false
+    /// Near-miss dip latch (see AudioDecoder+Meter's near-miss thresholds).
+    /// Guarded by `audioMeterLock`.
+    var nearMissLatched = false
     /// `DispatchTime` ns deadline of the startup floor-learning gate, armed at
     /// the COLD-START prime: drains in the host's boot-ramp window are pacing
     /// artifacts, not link character - letting them teach the floor welded
@@ -474,6 +477,7 @@ public final class AudioDecoder: @unchecked Sendable {
         rePrimeCount = 0
         lastTrimNanos = 0; gateGraceUntilNanos = 0
         pendingResolveTopUp = false; floorLearnGateUntilNanos = 0
+        nearMissLatched = false
         quietSinceNanos = seedNowNanos
         floorQuietSinceNanos = seedNowNanos
         rebuildIsReprime = false

--- a/Glimmer/Stream/FramePacer+DueGate.swift
+++ b/Glimmer/Stream/FramePacer+DueGate.swift
@@ -498,17 +498,21 @@ extension FramePacer {
     /// and the over-target force-release telemetry. Called OFF the gate's lock
     /// (caller unlocked). See each sub-helper for its rationale.
     func recordPerTickPresentSignals(_ gate: DueGateResult, depth: Int) {
-        recordStaleRepeatIfNeeded(gate.toPresent == nil)
+        recordStaleRepeatIfNeeded(gate.toPresent == nil, queueEmpty: depth == 0)
         recordOverTargetReleaseIfNeeded(gate, depth: depth)
     }
 
     /// Bump the stale-frame REPEAT counter (signal: PRESENT) when a running tick
     /// presented no new frame - the layer re-shows the last one (the invisible
-    /// stutter). Kept off `releaseDueFrame` so its branch doesn't grow that
-    /// already-large function. Always-live sub-µs integer add; the exporter
-    /// derives a repeats/sec rate from the monotonic total.
-    func recordStaleRepeatIfNeeded(_ repeated: Bool) {
-        if repeated { TelemetryCounters.shared.staleFrameRepeatTotal.increment() }
+    /// stutter). The EMPTY-queue subset counts separately: with frames queued a
+    /// stale beat is a benign not-due idle tick (fps<refresh cadence), but an
+    /// empty queue means this beat's content hadn't arrived - the starve half
+    /// of the clump-then-starve oscillation. Always-live sub-µs integer adds;
+    /// the exporter derives per-second rates from the monotonic totals.
+    func recordStaleRepeatIfNeeded(_ repeated: Bool, queueEmpty: Bool) {
+        guard repeated else { return }
+        TelemetryCounters.shared.staleFrameRepeatTotal.increment()
+        if queueEmpty { TelemetryCounters.shared.staleEmptyQueueTotal.increment() }
     }
 
     /// OVER-TARGET force-release observability (the no-network present-stall fix).

--- a/Glimmer/Stream/FramePacer+TickDeficit.swift
+++ b/Glimmer/Stream/FramePacer+TickDeficit.swift
@@ -78,10 +78,16 @@ extension FramePacer {
     /// fires it - sustained for `floorViolationNoticeSeconds`.
     static let floorViolationRatio = 0.9
     static let floorViolationNoticeSeconds = 1.0
-    /// Continuous healthy seconds (ticks ≥ the floor ratio) before the
-    /// floor-violation ASSIST disengages. 3s spans the measured 1-3s
-    /// violate/clear flap so one throttle episode arms the timer once.
+    /// Continuous healthy seconds (ticks ≥ the assist exit ratio) before the
+    /// ASSIST disengages. 3s spans the measured 1-3s throttle flap so one
+    /// episode arms the timer once.
     static let floorAssistExitHealthySeconds = 3.0
+    /// CONTENT-OVERRATE assist band, vs expectedHz = min(stream, nominal).
+    /// Engage below 0.95x sustained; exit at/above 0.97x sustained. Brackets
+    /// the governor's ~0.9x hover point (ticks 106-108 on 120fps content)
+    /// that the old floor-ratio latch straddled and flapped on.
+    static let assistEngageRatio = 0.95
+    static let assistExitRatio = 0.97
     /// Repaint the current frame during a deficit only after this many stream
     /// intervals without a REAL release (a real release is itself a commit, so
     /// repaints matter only when the host also faded / the queue ran dry).
@@ -205,6 +211,7 @@ extension FramePacer {
                 tickDeficit.tickDeficitSince = .nan
                 tickDeficit.floorViolationSince = .nan
                 tickDeficit.floorViolationLogged = false
+                tickDeficit.assistShortSince = .nan
                 return []
             }
             tickDeficit.deficitVerdictHoldUntilHostTime = .nan
@@ -219,7 +226,7 @@ extension FramePacer {
         var events = trackDeficitLocked(
             now: now, windowSeconds: elapsed, ticksPerS: ticksPerS, expectedHz: expectedHz)
         events.append(contentsOf: trackFloorViolationLocked(
-            now: now, windowSeconds: elapsed, ticksPerS: ticksPerS))
+            now: now, windowSeconds: elapsed, ticksPerS: ticksPerS, expectedHz: expectedHz))
         return events
     }
 
@@ -274,14 +281,15 @@ extension FramePacer {
     /// proves the floor is being overridden, answering the re-pin co-trigger
     /// question one battery repro session could not). Under `lock`.
     private func trackFloorViolationLocked(
-        now: CFTimeInterval, windowSeconds: Double, ticksPerS: Double
+        now: CFTimeInterval, windowSeconds: Double, ticksPerS: Double, expectedHz: Double
     ) -> [TickDeficitEvent] {
         let floor = tickDeficit.pinnedFloorHz
         guard floor.isFinite, floor > 0 else { return [] }
         var events: [TickDeficitEvent] = []
+        // Floor-violation NOTICE (governor evidence breadcrumb) - unchanged,
+        // floor-based, decoupled from the assist below.
         if ticksPerS < floor * FramePacer.floorViolationRatio {
             if !tickDeficit.floorViolationSince.isFinite { tickDeficit.floorViolationSince = now - windowSeconds }
-            tickDeficit.floorAssistHealthySince = .nan
             let sustained = now - tickDeficit.floorViolationSince >= FramePacer.floorViolationNoticeSeconds
             if !tickDeficit.floorViolationLogged, sustained {
                 // Once per episode - a multi-second collapse logs one NOTICE,
@@ -289,38 +297,53 @@ extension FramePacer {
                 tickDeficit.floorViolationLogged = true
                 events.append(.floorViolation(ticksPerS: ticksPerS, floorHz: floor))
             }
-            // ASSIST: a sustained violation in the dead band between the floor
-            // ratio (0.9x) and the hard-deficit enter (0.5x) got a breadcrumb
-            // and NO response - at 120fps content that is ~12 releases/s
-            // slipping a vsync, the field's dominant felt-judder signature.
-            // Arm the SAME off-tick timer the hard deficit uses; the due gate
-            // dedupes, so it only fills the beats the throttled link misses.
-            // Queue guard mirrors the deficit engage: an empty queue is an
-            // upstream drought, nothing to release.
-            if sustained, !tickDeficit.floorAssistActive,
+        } else {
+            let wasLogged = tickDeficit.floorViolationLogged
+            let since = tickDeficit.floorViolationSince
+            tickDeficit.floorViolationSince = .nan
+            tickDeficit.floorViolationLogged = false
+            if wasLogged, since.isFinite {
+                events.append(.floorRecovered(durationSeconds: now - since, ticksPerS: ticksPerS))
+            }
+        }
+        // ASSIST: CONTENT-OVERRATE hold. Engage when realized ticks run
+        // sustained below 0.95x of expectedHz (= min(stream, nominal) - so
+        // fps<refresh setups never read short); exit only after 3s at/above
+        // 0.97x. The old latch keyed off the 0.9x FLOOR ratio, which a
+        // governor-throttled panel straddles exactly (ticks 106-108 vs a 120
+        // floor = 0.883-0.90) - the assist flapped in and out while ~13
+        // content frames/s had no present slot (the measured chug). The
+        // engage/exit band brackets the boundary so it cannot straddle, and
+        // holds regardless of WHY ticks are short (battery governor, AC
+        // thermal, coalescing). Same off-tick timer; due gate dedupes.
+        guard expectedHz.isFinite, expectedHz > 0 else { return events }
+        if ticksPerS < expectedHz * FramePacer.assistEngageRatio {
+            if !tickDeficit.assistShortSince.isFinite { tickDeficit.assistShortSince = now - windowSeconds }
+            tickDeficit.floorAssistHealthySince = .nan
+            if now - tickDeficit.assistShortSince >= FramePacer.floorViolationNoticeSeconds,
+               !tickDeficit.floorAssistActive,
                !tickDeficit.deficitModeActive, !queue.isEmpty {
                 tickDeficit.floorAssistActive = true
                 tickDeficit.floorAssistEngagedAt = now
                 tickDeficit.floorAssistEngageReleaseCount = liveness.releaseCount
                 events.append(.floorAssistEngaged(
-                    ticksPerS: ticksPerS, floorHz: floor, depth: queue.count))
+                    ticksPerS: ticksPerS, floorHz: expectedHz, depth: queue.count))
             }
-            return events
-        }
-        let wasLogged = tickDeficit.floorViolationLogged
-        let since = tickDeficit.floorViolationSince
-        tickDeficit.floorViolationSince = .nan
-        tickDeficit.floorViolationLogged = false
-        if wasLogged, since.isFinite {
-            events.append(.floorRecovered(durationSeconds: now - since, ticksPerS: ticksPerS))
-        }
-        if tickDeficit.floorAssistActive {
-            if !tickDeficit.floorAssistHealthySince.isFinite {
-                tickDeficit.floorAssistHealthySince = now - windowSeconds
-            }
-            if now - tickDeficit.floorAssistHealthySince >= FramePacer.floorAssistExitHealthySeconds {
-                events.append(disengageFloorAssistLocked(
-                    reason: "ticks recovered", now: now, ticksPerS: ticksPerS))
+        } else {
+            tickDeficit.assistShortSince = .nan
+            if ticksPerS >= expectedHz * FramePacer.assistExitRatio {
+                if tickDeficit.floorAssistActive {
+                    if !tickDeficit.floorAssistHealthySince.isFinite {
+                        tickDeficit.floorAssistHealthySince = now - windowSeconds
+                    }
+                    if now - tickDeficit.floorAssistHealthySince >= FramePacer.floorAssistExitHealthySeconds {
+                        events.append(disengageFloorAssistLocked(
+                            reason: "ticks recovered", now: now, ticksPerS: ticksPerS))
+                    }
+                }
+            } else {
+                // 0.95-0.97x: hold whatever state we're in, accrue nothing.
+                tickDeficit.floorAssistHealthySince = .nan
             }
         }
         return events
@@ -375,6 +398,7 @@ extension FramePacer {
         tickDeficit.tickDeficitSince = .nan
         tickDeficit.floorViolationSince = .nan
         tickDeficit.floorViolationLogged = false
+        tickDeficit.assistShortSince = .nan
         tickDeficit.warmHealthyWindowStreak = 0
         var events: [TickDeficitEvent] = []
         if tickDeficit.floorAssistActive {
@@ -429,6 +453,7 @@ extension FramePacer {
         tickDeficit.warmHealthyWindowStreak = 0
         tickDeficit.floorViolationSince = .nan
         tickDeficit.floorViolationLogged = false
+        tickDeficit.assistShortSince = .nan
         tickDeficit.floorAssistActive = false
         tickDeficit.floorAssistEngagedAt = .nan
         tickDeficit.floorAssistEngageReleaseCount = 0

--- a/Glimmer/Stream/FramePacer.swift
+++ b/Glimmer/Stream/FramePacer.swift
@@ -380,10 +380,14 @@ final class FramePacer: @unchecked Sendable {
         var floorAssistActive = false
         var floorAssistEngagedAt: CFTimeInterval = .nan
         var floorAssistEngageReleaseCount: UInt64 = 0
-        /// Continuous healthy time (ticks back at/above the floor ratio) before
-        /// the assist stands down - rides the observed 1-3s violate/clear flap
-        /// through as ONE episode instead of cycling the timer with it.
+        /// Continuous healthy time (ticks back at/above the assist exit ratio)
+        /// before the assist stands down - rides the observed 1-3s throttle
+        /// flap through as ONE episode instead of cycling the timer with it.
         var floorAssistHealthySince: CFTimeInterval = .nan
+        /// When realized ticks first ran below the content-overrate engage
+        /// ratio (vs expectedHz). `.nan` = not short. Drives the assist engage
+        /// independently of the floor-violation breadcrumb latch.
+        var assistShortSince: CFTimeInterval = .nan
         /// Lock-guarded mirror of the main-actor `appliedFloorHz`, written wherever
         /// the range is (re)applied, so the off-main rate-window roll can compare
         /// realized ticks against the pinned floor without an actor hop.

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -130,9 +130,11 @@ extension InputForwarder {
         guard !isMouseCaptured else { return }
         mouseResidualX = 0
         mouseResidualY = 0
-        // Reset the Cruise inter-batch clock so the first post-focus motion reads
-        // a stale dt (>0.1s) and forces gain==1.0 - never a spurious boost on resume.
+        // Reset the Cruise inter-batch clock AND the velocity EMA so the first
+        // post-focus motion reads a stale dt (>0.1s) and forces gain==1.0 -
+        // never a spurious or carried-over boost on resume.
         lastMoveTimestamp = 0
+        cruiseVelocityEma = 0
         // Disassociate: the OS stops moving the system cursor; HID motion still
         // arrives as relative deltas on the CGEvent layer. The return value is
         // a CGError; on the (vanishingly unlikely) failure we still proceed -

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -130,11 +130,12 @@ extension InputForwarder {
         guard !isMouseCaptured else { return }
         mouseResidualX = 0
         mouseResidualY = 0
-        // Reset the Cruise inter-batch clock AND the velocity EMA so the first
-        // post-focus motion reads a stale dt (>0.1s) and forces gain==1.0 -
-        // never a spurious or carried-over boost on resume.
+        // Reset the Cruise inter-batch clock AND the windowed-velocity accums
+        // so the first post-focus motion reads a stale dt (>0.1s) and forces
+        // gain==1.0 - never a spurious or carried-over boost on resume.
         lastMoveTimestamp = 0
-        cruiseVelocityEma = 0
+        cruiseDistAccum = 0
+        cruiseTimeAccum = 0
         // Disassociate: the OS stops moving the system cursor; HID motion still
         // arrives as relative deltas on the CGEvent layer. The return value is
         // a CGError; on the (vanishingly unlikely) failure we still proceed -

--- a/Glimmer/Stream/InputForwarder+Cruise.swift
+++ b/Glimmer/Stream/InputForwarder+Cruise.swift
@@ -36,12 +36,28 @@ enum CruiseTraversal {
     static let referenceWidth: Double = 1920
     /// Defaults for the velocity gate (counts/sec). Below `vKnee` the gain is
     /// exactly 1.0; at/above `vFull` it is the full `gMax`; between, a smoothstep.
-    /// Re-tuned from 1400/4500 on 14d of field data: real flicks peak ~3200
-    /// counts/s, so half of all sessions never reached full gain (max 1.06-1.57)
-    /// and fast aim above 1400 was getting nibbled - the "mushy" mid-band. The
-    /// 2000/3200 band keeps aim raw to 2000 and puts real flicks AT gMax.
-    static let defaultVKnee: Double = 2000
-    static let defaultVFull: Double = 3200
+    /// CALIBRATION NOTE: earlier bands (1400/4500, then 2000/3200) were tuned
+    /// against the old per-batch dist/dt estimator, whose tiny-dt spikes read
+    /// ~2x high. Under the honest windowed estimator the field distribution is
+    /// p50~220 / p90~750 / p99~1770 with precision aim topping out ~920, so
+    /// 1100/1800 keeps aim raw with margin and puts real flicks AT gMax
+    /// (validated live 2026-07-19; the 2000 knee left the boost engaging on
+    /// ~0.03% of batches - effectively off).
+    static let defaultVKnee: Double = 1100
+    static let defaultVFull: Double = 1800
+
+    /// DRAG-DELTA compensation: macOS (observed on the 27.0 beta) damps
+    /// *MouseDragged deltas relative to free mouseMoved for the same physical
+    /// motion - owner-verified by matched-speed swipes (button held travels
+    /// visibly less; the drag/move velocity histograms read ~0.6-0.7x). Scale
+    /// button-held batch deltas back up so drag aim matches free aim. Hidden
+    /// live-read tunable; 1.0 disables. Clamped so a bad write can't run away.
+    static let dragDeltaScaleDefaultsKey = "cruiseDragDeltaScale"
+    static let defaultDragDeltaScale: Double = 1.35
+    static var dragDeltaScale: Double {
+        let v = UserDefaults.standard.double(forKey: dragDeltaScaleDefaultsKey)
+        return v > 0 ? min(max(v, 0.5), 3.0) : defaultDragDeltaScale
+    }
 
     /// Whether the feature is on (default true).
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }

--- a/Glimmer/Stream/InputForwarder+Cruise.swift
+++ b/Glimmer/Stream/InputForwarder+Cruise.swift
@@ -36,8 +36,12 @@ enum CruiseTraversal {
     static let referenceWidth: Double = 1920
     /// Defaults for the velocity gate (counts/sec). Below `vKnee` the gain is
     /// exactly 1.0; at/above `vFull` it is the full `gMax`; between, a smoothstep.
-    static let defaultVKnee: Double = 1400
-    static let defaultVFull: Double = 4500
+    /// Re-tuned from 1400/4500 on 14d of field data: real flicks peak ~3200
+    /// counts/s, so half of all sessions never reached full gain (max 1.06-1.57)
+    /// and fast aim above 1400 was getting nibbled - the "mushy" mid-band. The
+    /// 2000/3200 band keeps aim raw to 2000 and puts real flicks AT gMax.
+    static let defaultVKnee: Double = 2000
+    static let defaultVFull: Double = 3200
 
     /// Whether the feature is on (default true).
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledDefaultsKey) }

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -266,10 +266,25 @@ extension InputForwarder: StreamInputViewDelegate {
         if CruiseTraversal.isEnabled, cruiseGMax > 1.0 {
             let dt = now - lastMoveTimestamp
             if dt > 0 && dt <= 0.1 {
-                let v = hypot(accumDx, accumDy) / dt
-                // Seed fresh on the first batch after a gap (ema cleared below)
-                // so onset reads the true velocity; blend within continuous motion.
-                cruiseVelocityEma = cruiseVelocityEma > 0 ? 0.5 * v + 0.5 * cruiseVelocityEma : v
+                // SPIKE GUARDS (the 2026-07-19 "crazy sensitive" episode):
+                // device-rate delivery (~1ms dragged events) makes a few counts
+                // read as thousands of counts/s; the EMA then HELD that spike,
+                // boosting real aim at gMax until a >100ms gap reset it ("stopped
+                // on refocus"). Guards: dt floored to half a 120Hz frame (a
+                // tiny-dt batch can't mint absurd velocity - understates, never
+                // overstates), EMA clamped just above vFull (gain saturates
+                // there; more is pure spike memory), and deceleration blends
+                // fast (0.7 new) so boost deflates within ~2 batches of the
+                // hand slowing while attack keeps the de-jittering 0.5 blend.
+                let v = hypot(accumDx, accumDy) / max(dt, 0.004)
+                if cruiseVelocityEma <= 0 {
+                    cruiseVelocityEma = v
+                } else if v >= cruiseVelocityEma {
+                    cruiseVelocityEma = 0.5 * v + 0.5 * cruiseVelocityEma
+                } else {
+                    cruiseVelocityEma = 0.7 * v + 0.3 * cruiseVelocityEma
+                }
+                cruiseVelocityEma = min(cruiseVelocityEma, CruiseTraversal.vFull * 1.5)
             } else {
                 cruiseVelocityEma = 0
             }

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -265,38 +265,35 @@ extension InputForwarder: StreamInputViewDelegate {
         let now = batchTimestamp
         if CruiseTraversal.isEnabled, cruiseGMax > 1.0 {
             let dt = now - lastMoveTimestamp
+            var velocity: Double = 0
             if dt > 0 && dt <= 0.1 {
-                // SPIKE GUARDS (the 2026-07-19 "crazy sensitive" episode):
-                // device-rate delivery (~1ms dragged events) makes a few counts
-                // read as thousands of counts/s; the EMA then HELD that spike,
-                // boosting real aim at gMax until a >100ms gap reset it ("stopped
-                // on refocus"). Guards: dt floored to half a 120Hz frame (a
-                // tiny-dt batch can't mint absurd velocity - understates, never
-                // overstates), EMA clamped just above vFull (gain saturates
-                // there; more is pure spike memory), and deceleration blends
-                // fast (0.7 new) so boost deflates within ~2 batches of the
-                // hand slowing while attack keeps the de-jittering 0.5 blend.
-                let v = hypot(accumDx, accumDy) / max(dt, 0.004)
-                if cruiseVelocityEma <= 0 {
-                    cruiseVelocityEma = v
-                } else if v >= cruiseVelocityEma {
-                    cruiseVelocityEma = 0.5 * v + 0.5 * cruiseVelocityEma
-                } else {
-                    cruiseVelocityEma = 0.7 * v + 0.3 * cruiseVelocityEma
+                // WINDOWED velocity (~30ms exponential window of Σdist/Σtime):
+                // immune to delivery-cadence variation by construction. A 1ms
+                // device-rate batch adds tiny distance AND tiny time, so the
+                // ratio can neither spike (the "crazy sensitive" incident) nor
+                // understate (the dt-floor chop: per-batch dist/dt flapped 4x
+                // as macOS alternated coalesced and per-event delivery). Needs
+                // ≥4ms of accumulated window before the gate trusts it, so a
+                // post-gap first batch stays identity.
+                let decay = exp(-dt / 0.030)
+                cruiseDistAccum = cruiseDistAccum * decay + hypot(accumDx, accumDy)
+                cruiseTimeAccum = cruiseTimeAccum * decay + dt
+                if cruiseTimeAccum >= 0.004 {
+                    velocity = cruiseDistAccum / cruiseTimeAccum
                 }
-                cruiseVelocityEma = min(cruiseVelocityEma, CruiseTraversal.vFull * 1.5)
             } else {
-                cruiseVelocityEma = 0
+                cruiseDistAccum = 0
+                cruiseTimeAccum = 0
             }
-            let g = CruiseTraversal.gain(velocity: cruiseVelocityEma, dt: dt, gMax: cruiseGMax,
+            let g = CruiseTraversal.gain(velocity: velocity, dt: dt, gMax: cruiseGMax,
                                          vKnee: CruiseTraversal.vKnee, vFull: CruiseTraversal.vFull)
             // Cruise forensics (telemetry-on only): velocity + gain
             // distributions split MOVE vs DRAG - the data a drag-specific band
             // tune needs (menu drag-pans vs held-button aim share this path).
-            if let tracker = FrameTimingTracker.shared, cruiseVelocityEma > 0 {
+            if let tracker = FrameTimingTracker.shared, velocity > 0 {
                 let isDrag = event.type != .mouseMoved
                 (isDrag ? tracker.cruiseVelocityDrag : tracker.cruiseVelocityMove)
-                    .observe(cruiseVelocityEma)
+                    .observe(velocity)
                 if g > 1.0 {
                     (isDrag ? tracker.cruiseGainDrag : tracker.cruiseGainMove).observe(g)
                 }

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -253,6 +253,19 @@ extension InputForwarder: StreamInputViewDelegate {
             batchTimestamp = queued.timestamp
         }
 
+        // DRAG-DELTA compensation (before Cruise, so the velocity gate sees the
+        // corrected motion): macOS damps dragged deltas vs free motion for the
+        // same hand speed (owner-verified matched-speed swipes, macOS 27 beta).
+        // Scale button-held batches back to parity; 1.0 disables.
+        let isDragBatch = event.type != .mouseMoved
+        if isDragBatch {
+            let scale = CruiseTraversal.dragDeltaScale
+            if scale != 1.0 {
+                accumDx *= scale
+                accumDy *= scale
+            }
+        }
+
         // CRUISE traversal boost (InputForwarder+Cruise.swift). Velocity-gated,
         // resolution-derived gain on ONLY fast flicks - aim (sub-knee) is untouched.
         // Runs AFTER the Mac linearization, so it's the only client gain. dt is the
@@ -291,11 +304,10 @@ extension InputForwarder: StreamInputViewDelegate {
             // distributions split MOVE vs DRAG - the data a drag-specific band
             // tune needs (menu drag-pans vs held-button aim share this path).
             if let tracker = FrameTimingTracker.shared, velocity > 0 {
-                let isDrag = event.type != .mouseMoved
-                (isDrag ? tracker.cruiseVelocityDrag : tracker.cruiseVelocityMove)
+                (isDragBatch ? tracker.cruiseVelocityDrag : tracker.cruiseVelocityMove)
                     .observe(velocity)
                 if g > 1.0 {
-                    (isDrag ? tracker.cruiseGainDrag : tracker.cruiseGainMove).observe(g)
+                    (isDragBatch ? tracker.cruiseGainDrag : tracker.cruiseGainMove).observe(g)
                 }
             }
             if g > 1.0 {

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -237,7 +237,13 @@ extension InputForwarder: StreamInputViewDelegate {
         // drained events, so dt must span to the last of them - measuring to the
         // first event inflated the batch velocity whenever coalescing engaged.
         var batchTimestamp = event.timestamp
-        while let queued = window?.nextEvent(matching: .mouseMoved,
+        // Drags route through this handler too (StreamInputView forwards all
+        // *MouseDragged here) - include them in the coalesce mask so a drag
+        // batches identically to free motion instead of one-event-per-NSEvent.
+        let motionMask: NSEvent.EventTypeMask = [
+            .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged
+        ]
+        while let queued = window?.nextEvent(matching: motionMask,
                                              until: Date.distantPast,
                                              inMode: .eventTracking,
                                              dequeue: true) {
@@ -269,6 +275,17 @@ extension InputForwarder: StreamInputViewDelegate {
             }
             let g = CruiseTraversal.gain(velocity: cruiseVelocityEma, dt: dt, gMax: cruiseGMax,
                                          vKnee: CruiseTraversal.vKnee, vFull: CruiseTraversal.vFull)
+            // Cruise forensics (telemetry-on only): velocity + gain
+            // distributions split MOVE vs DRAG - the data a drag-specific band
+            // tune needs (menu drag-pans vs held-button aim share this path).
+            if let tracker = FrameTimingTracker.shared, cruiseVelocityEma > 0 {
+                let isDrag = event.type != .mouseMoved
+                (isDrag ? tracker.cruiseVelocityDrag : tracker.cruiseVelocityMove)
+                    .observe(cruiseVelocityEma)
+                if g > 1.0 {
+                    (isDrag ? tracker.cruiseGainDrag : tracker.cruiseGainMove).observe(g)
+                }
+            }
             if g > 1.0 {
                 accumDx *= g
                 accumDy *= g

--- a/Glimmer/Stream/InputForwarder+StreamView.swift
+++ b/Glimmer/Stream/InputForwarder+StreamView.swift
@@ -233,6 +233,10 @@ extension InputForwarder: StreamInputViewDelegate {
         let initialDeltas = mouseDelta(from: event)
         var accumDx = initialDeltas.dx
         var accumDy = initialDeltas.dy
+        // Track the LAST coalesced event's timestamp: the deltas sum through the
+        // drained events, so dt must span to the last of them - measuring to the
+        // first event inflated the batch velocity whenever coalescing engaged.
+        var batchTimestamp = event.timestamp
         while let queued = window?.nextEvent(matching: .mouseMoved,
                                              until: Date.distantPast,
                                              inMode: .eventTracking,
@@ -240,19 +244,30 @@ extension InputForwarder: StreamInputViewDelegate {
             let delta = mouseDelta(from: queued)
             accumDx += delta.dx
             accumDy += delta.dy
+            batchTimestamp = queued.timestamp
         }
 
         // CRUISE traversal boost (InputForwarder+Cruise.swift). Velocity-gated,
         // resolution-derived gain on ONLY fast flicks - aim (sub-knee) is untouched.
         // Runs AFTER the Mac linearization, so it's the only client gain. dt is the
-        // inter-batch interval; v is counts/sec over this batch. Below the knee the
-        // gain is exactly 1.0 and accumDx/Dy are unchanged, so the residual path
-        // below runs byte-for-byte as it does today.
-        let now = event.timestamp
+        // inter-batch interval; the gate reads a SHORT velocity EMA (per-batch
+        // instantaneous v jitters ~±30%, flickering the gain through the ramp -
+        // the mushy feel). A post-gap batch seeds the EMA to the raw v, so flick
+        // onset carries zero added lag. Below the knee the gain is exactly 1.0
+        // and accumDx/Dy are unchanged, so the residual path below runs
+        // byte-for-byte as it does today.
+        let now = batchTimestamp
         if CruiseTraversal.isEnabled, cruiseGMax > 1.0 {
             let dt = now - lastMoveTimestamp
-            let v = hypot(accumDx, accumDy) / dt
-            let g = CruiseTraversal.gain(velocity: v, dt: dt, gMax: cruiseGMax,
+            if dt > 0 && dt <= 0.1 {
+                let v = hypot(accumDx, accumDy) / dt
+                // Seed fresh on the first batch after a gap (ema cleared below)
+                // so onset reads the true velocity; blend within continuous motion.
+                cruiseVelocityEma = cruiseVelocityEma > 0 ? 0.5 * v + 0.5 * cruiseVelocityEma : v
+            } else {
+                cruiseVelocityEma = 0
+            }
+            let g = CruiseTraversal.gain(velocity: cruiseVelocityEma, dt: dt, gMax: cruiseGMax,
                                          vKnee: CruiseTraversal.vKnee, vFull: CruiseTraversal.vFull)
             if g > 1.0 {
                 accumDx *= g

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -279,6 +279,12 @@ public final class InputForwarder {
     /// derived ceiling, set at start and re-set on a reconnect resolution change.
     var lastMoveTimestamp: TimeInterval = 0
     var cruiseGMax: Double = 1.0
+    /// Short EMA of batch velocity feeding the Cruise gate. Per-batch
+    /// instantaneous velocity jitters ~±30% at 120Hz event cadence, flickering
+    /// the gain through the ramp band (part of the "mushy" feel). Seeded to the
+    /// raw velocity on a post-gap batch so flick ONSET keeps zero added lag;
+    /// the smoothing only acts within continuous motion.
+    var cruiseVelocityEma: Double = 0
 
     /// Pull the relative delta out of a mouseMoved NSEvent. Reads the CGEvent
     /// integer fields `kCGMouseEventDeltaX/Y` (valid whether or not the cursor is

--- a/Glimmer/Stream/InputForwarder.swift
+++ b/Glimmer/Stream/InputForwarder.swift
@@ -279,12 +279,15 @@ public final class InputForwarder {
     /// derived ceiling, set at start and re-set on a reconnect resolution change.
     var lastMoveTimestamp: TimeInterval = 0
     var cruiseGMax: Double = 1.0
-    /// Short EMA of batch velocity feeding the Cruise gate. Per-batch
-    /// instantaneous velocity jitters ~±30% at 120Hz event cadence, flickering
-    /// the gain through the ramp band (part of the "mushy" feel). Seeded to the
-    /// raw velocity on a post-gap batch so flick ONSET keeps zero added lag;
-    /// the smoothing only acts within continuous motion.
-    var cruiseVelocityEma: Double = 0
+    /// WINDOWED velocity estimator feeding the Cruise gate: exponentially
+    /// weighted Σdistance/Σtime over a ~30ms window. Robust BY CONSTRUCTION to
+    /// variable event-delivery cadence - a device-rate 1ms batch contributes
+    /// tiny distance AND tiny time, so the ratio can never spike (the 07-19
+    /// "crazy sensitive" incident) nor understate under a dt floor (the
+    /// follow-up chop: per-batch distance/dt flapped 4x as macOS alternated
+    /// coalesced and per-event delivery). Both accums decay by exp(-dt/30ms).
+    var cruiseDistAccum: Double = 0
+    var cruiseTimeAccum: Double = 0
 
     /// Pull the relative delta out of a mouseMoved NSEvent. Reads the CGEvent
     /// integer fields `kCGMouseEventDeltaX/Y` (valid whether or not the cursor is

--- a/Glimmer/Stream/StatsCollector+Record.swift
+++ b/Glimmer/Stream/StatsCollector+Record.swift
@@ -199,6 +199,10 @@ extension StatsCollector {
                now - gapBaselineTime > Self.perceivedGapSeconds,
                receivedFrames &- gapBaselineReceived >= Self.perceivedGapMinReceived {
                 presentationGaps &+= 1
+                // Cause split for the exporter: this is the DROUGHT path
+                // (content arriving, screen held) - the backoff-reject path
+                // increments only the total. Leaf atomic; safe under our lock.
+                TelemetryCounters.shared.presentGapDroughtTotal.increment()
             }
             gapBaselineTime = now
             gapBaselineReceived = receivedFrames

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -249,6 +249,26 @@ final class TelemetryCounters: @unchecked Sendable {
     /// sub-µs integer op, far below the per-vsync budget even at 240Hz).
     let staleFrameRepeatTotal = Counter()
 
+    /// STALE beats where the pacer queue was EMPTY (signal: PRESENT) - the
+    /// starvation subset of `staleFrameRepeatTotal`. A stale beat with frames
+    /// queued is a benign not-due idle tick (fps<refresh cadence); an EMPTY
+    /// queue means content for this beat hadn't arrived - the clump-then-starve
+    /// oscillation's visible half. not_due = staleFrameRepeatTotal − this.
+    let staleEmptyQueueTotal = Counter()
+
+    /// PERCEIVED-GAP cause split (signal: PRESENT): the DROUGHT subset of
+    /// `presentationGaps` - a present landed after a >100ms hold with frames
+    /// still arriving (loss storm / decode starvation / pacing wedge). The
+    /// remainder (total − this) is the backoff-then-renderer-reject path.
+    let presentGapDroughtTotal = Counter()
+
+    /// AUDIO NEAR-MISS (signal: AUDIO) - steady-state playout fill dipped below
+    /// ~15ms without fully draining (latched per dip; re-arms above 30ms).
+    /// Margin erosion visible BEFORE it becomes an audible under-run: a rising
+    /// rate here with zero under-runs means the cushion is thinning toward the
+    /// edge (skew, gap texture) and the resampler/ratchet are living close.
+    let audioNearMissTotal = Counter()
+
     /// OVER-TARGET force-release count (signal: PRESENT). Bumped on each pacer tick
     /// where the due gate would have latched not-due against a GENUINE drainable
     /// backlog (one frame above the adaptive jitter-buffer target that survived the
@@ -686,7 +706,8 @@ final class TelemetryCounters: @unchecked Sendable {
                         ackSilenceNearMissTotal, ctrlIgnoredTotal,
                         decoderRecreateTotal, decoderRecreateFirstTotal,
                         decoderRecreateResolutionTotal, decoderRecreateColorspaceTotal,
-                        staleFrameRepeatTotal,
+                        staleFrameRepeatTotal, staleEmptyQueueTotal, audioNearMissTotal,
+                        presentGapDroughtTotal,
                         pacerOverTargetReleaseTotal,
                         tickMissDescheduledTotal, tickMissCoalescedTotal,
                         tickMissPreemptedTotal, tickMissLinkskipTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -123,6 +123,9 @@ extension TelemetryExporter {
         snap.vtSessionCreateMs = counters.vtSessionCreateMs
         snap.discontinuityFlushTotal = counters.discontinuityFlushTotal.value
         snap.staleFrameRepeatTotal = counters.staleFrameRepeatTotal.value
+        snap.staleEmptyQueueTotal = counters.staleEmptyQueueTotal.value
+        snap.presentGapDroughtTotal = counters.presentGapDroughtTotal.value
+        snap.audioNearMissTotal = counters.audioNearMissTotal.value
         snap.tickMissDescheduledTotal = counters.tickMissDescheduledTotal.value
         snap.tickMissCoalescedTotal = counters.tickMissCoalescedTotal.value
         snap.tickMissPreemptedTotal = counters.tickMissPreemptedTotal.value
@@ -160,6 +163,15 @@ extension TelemetryExporter {
         // stage, read off the same tracker on this queue.
         snap.inputLocalLatency = FrameTimingTracker.shared?.inputLocalLatency.snapshotValue()
         snap.inputDeliverLatency = FrameTimingTracker.shared?.inputDeliverLatency.snapshotValue()
+        // Pipeline cadence (clump forensics) + cruise forensics - standalone
+        // stages on the same tracker, read on this queue.
+        snap.pipelineReceiveCadence = FrameTimingTracker.shared?.receiveCadence.snapshotValue()
+        snap.pipelineAssembleCadence = FrameTimingTracker.shared?.assembleCadence.snapshotValue()
+        snap.pipelineOutputCadence = FrameTimingTracker.shared?.outputCadence.snapshotValue()
+        snap.cruiseVelocityMove = FrameTimingTracker.shared?.cruiseVelocityMove.snapshotValue()
+        snap.cruiseVelocityDrag = FrameTimingTracker.shared?.cruiseVelocityDrag.snapshotValue()
+        snap.cruiseGainMove = FrameTimingTracker.shared?.cruiseGainMove.snapshotValue()
+        snap.cruiseGainDrag = FrameTimingTracker.shared?.cruiseGainDrag.snapshotValue()
 
         // Wi-Fi radio (signal 3): one CoreWLAN read on this queue. Reads the
         // current association only - never a scan - so it cannot disturb the link.

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -20,6 +20,7 @@
 //
 
 import Foundation
+import IOKit.ps
 
 extension TelemetryExporter {
 
@@ -176,6 +177,14 @@ extension TelemetryExporter {
         // Wi-Fi radio (signal 3): one CoreWLAN read on this queue. Reads the
         // current association only - never a scan - so it cannot disturb the link.
         snap.wifi = wifi.sample()
+
+        // Power state: on-battery + Low Power Mode, 1Hz on this queue. The
+        // correlation labels for governor tick-throttle (the ~106-ticks-on-
+        // 120fps chug): if on_battery predicts it reliably, padding can be
+        // pre-armed at session start instead of waiting for the measured sag.
+        let powerSource = IOPSGetProvidingPowerSourceType(nil)?.takeRetainedValue() as String?
+        snap.onBattery = powerSource == kIOPMBatteryPowerKey
+        snap.lowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
 
         // Build attribution (signal 5a): the compile-time git SHA + build date.
         snap.buildCommit = BuildInfo.commit

--- a/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
@@ -47,6 +47,16 @@ extension TelemetryRenderer {
                 + "batcher slot stamp), ms.",
                 stage: inputDeliver)
         }
+        if let onBattery = snap.onBattery {
+            builder.emit("glimmer_on_battery",
+                         "1 while the providing power source is the internal battery.",
+                         onBattery ? 1 : 0)
+        }
+        if let lowPower = snap.lowPowerMode {
+            builder.emit("glimmer_low_power_mode",
+                         "1 while macOS Low Power Mode is enabled.",
+                         lowPower ? 1 : 0)
+        }
         // Cruise forensics: batch-velocity + applied-gain distributions, split
         // MOVE vs DRAG (menu drag-pans vs held-button aim share the drag path,
         // so a drag-specific band tune needs this split). Units are counts/sec

--- a/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderSystem.swift
@@ -47,6 +47,26 @@ extension TelemetryRenderer {
                 + "batcher slot stamp), ms.",
                 stage: inputDeliver)
         }
+        // Cruise forensics: batch-velocity + applied-gain distributions, split
+        // MOVE vs DRAG (menu drag-pans vs held-button aim share the drag path,
+        // so a drag-specific band tune needs this split). Units are counts/sec
+        // and gain multipliers - not ms; the histogram bucketing is unit-agnostic.
+        if let stage = snap.cruiseVelocityMove {
+            builder.emitHistogram("glimmer_cruise_velocity_move",
+                                  "Mouse batch velocity (counts/sec), free motion.", stage: stage)
+        }
+        if let stage = snap.cruiseVelocityDrag {
+            builder.emitHistogram("glimmer_cruise_velocity_drag",
+                                  "Mouse batch velocity (counts/sec), button-held drags.", stage: stage)
+        }
+        if let stage = snap.cruiseGainMove {
+            builder.emitHistogram("glimmer_cruise_gain_move",
+                                  "Applied Cruise gain per boosted batch, free motion.", stage: stage)
+        }
+        if let stage = snap.cruiseGainDrag {
+            builder.emitHistogram("glimmer_cruise_gain_drag",
+                                  "Applied Cruise gain per boosted batch, button-held drags.", stage: stage)
+        }
         // Input flush ticks skipped by backpressure, split by which signal fired
         // (the input p99 tail attribution).
         builder.emitCounter("glimmer_input_flush_backpressure_skips_total",

--- a/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderVideo.swift
@@ -295,6 +295,36 @@ extension TelemetryRenderer {
         builder.emit("glimmer_present_stale_repeats_per_second",
                      "Stale-frame repeats per second (spike at fps≈refresh = micro-judder).",
                      snap.staleRepeatsPerSecond)
+        builder.emitCounter("glimmer_present_stale_empty_total",
+                            "Stale beats with an EMPTY pacer queue (starve half of the "
+                            + "clump-then-starve oscillation; not_due = repeat_total - this).",
+                            snap.staleEmptyQueueTotal)
+        builder.emitCounter("glimmer_present_gap_drought_total",
+                            "Perceived gaps from a >100ms hold with frames still arriving "
+                            + "(remainder of perceived_gaps_total is renderer-reject).",
+                            snap.presentGapDroughtTotal)
+        builder.emitCounter("glimmer_audio_near_miss_total",
+                            "Steady-state audio fill dips under ~15ms without a full drain - "
+                            + "cushion margin erosion before it is audible.",
+                            snap.audioNearMissTotal)
+        // Pipeline cadence (clump forensics): inter-arrival histograms at three
+        // boundaries. Compare the three to locate where clumping is born
+        // (wire/receive vs depacketizer vs VideoToolbox).
+        if let stage = snap.pipelineReceiveCadence {
+            builder.emitHistogram("glimmer_cadence_receive_ms",
+                                  "Inter-arrival between consecutive frames at RECEIVE "
+                                  + "(last packet), ms.", stage: stage)
+        }
+        if let stage = snap.pipelineAssembleCadence {
+            builder.emitHistogram("glimmer_cadence_assemble_ms",
+                                  "Inter-arrival between consecutive frames at ASSEMBLE "
+                                  + "(depacketizer output), ms.", stage: stage)
+        }
+        if let stage = snap.pipelineOutputCadence {
+            builder.emitHistogram("glimmer_cadence_output_ms",
+                                  "Inter-arrival between consecutive frames at VT OUTPUT "
+                                  + "(decode complete), ms.", stage: stage)
+        }
         builder.emitCounter("glimmer_pacer_over_target_release_total",
                             "Over-target force-releases (zero in steady state; the due-gate "
                             + "self-oscillation breaker).",

--- a/Glimmer/Stream/TelemetryLatency.swift
+++ b/Glimmer/Stream/TelemetryLatency.swift
@@ -317,6 +317,50 @@ final class FrameTimingTracker: @unchecked Sendable {
     /// deliver→enqueue age `inputLocalLatency` can't see - it starts at enqueue).
     /// Same self-locked Stage; observed off the present path. Measurement only.
     let inputDeliverLatency = LatencyHistograms.Stage()
+
+    /// PIPELINE CADENCE (clump forensics): inter-arrival between CONSECUTIVE
+    /// frames at three boundaries - receive (last packet), assemble
+    /// (depacketizer output), and VT output. At 120fps every stage should tick
+    /// ~8.3ms; mass below ~4ms = frames arriving in clumps, mass above ~12ms =
+    /// the matching starve. Comparing the three locates WHERE clumping is born
+    /// (wire/receive vs depacketizer vs VideoToolbox) - the measured ~14/s
+    /// over-target churn + ~3/s stale beats on a smooth wire (recv jitter
+    /// 0.3ms) made that the open question. Deltas > 1s are treated as content
+    /// gaps and skipped, not cadence.
+    static let cadenceBoundsMs: [Double] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 20, 25, 33, 50, 66, 132
+    ]
+    let receiveCadence = LatencyHistograms.Stage(bounds: FrameTimingTracker.cadenceBoundsMs)
+    let assembleCadence = LatencyHistograms.Stage(bounds: FrameTimingTracker.cadenceBoundsMs)
+    let outputCadence = LatencyHistograms.Stage(bounds: FrameTimingTracker.cadenceBoundsMs)
+
+    /// CRUISE forensics (units are counts/sec and gain multipliers, NOT ms -
+    /// the Stage bucketing is unit-agnostic). Velocity distribution split MOVE
+    /// vs DRAG, plus the applied gain per boosted batch, same split. The split
+    /// is load-bearing: menu drag-pans and held-button aim (ADS/spray) share
+    /// the drag path, so any drag-specific band tune (owner-reported slow menu
+    /// drags) needs this distribution first.
+    static let cruiseVelocityBounds: [Double] = [
+        250, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000,
+        3500, 4000, 5000, 7000, 10000
+    ]
+    static let cruiseGainBounds: [Double] = [
+        1.02, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.98, 2.0, 2.67, 4.0
+    ]
+    let cruiseVelocityMove = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseVelocityBounds)
+    let cruiseVelocityDrag = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseVelocityBounds)
+    let cruiseGainMove = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseGainBounds)
+    let cruiseGainDrag = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseGainBounds)
+
+    /// Last-seen stage timestamps for the cadence deltas. Guarded by `mapLock`
+    /// (stamped on the same calls that touch the in-flight map).
+    private var lastReceiveNanos: UInt64 = 0
+    private var lastAssembleNanos: UInt64 = 0
+    private var lastOutputNanos: UInt64 = 0
+    /// Cadence deltas above this are a content gap (idle desktop, scene load),
+    /// not delivery cadence - skipped so they can't pollute the histogram sum.
+    private static let cadenceGapCutoffNanos: UInt64 = 1_000_000_000
+
     /// Both internal (not private): the trace renderer + drop-stub emitter in
     /// TelemetryLatency+Trace.swift are the only cross-file consumers.
     let traceWriter = FrameTraceWriter()
@@ -440,6 +484,13 @@ final class FrameTimingTracker: @unchecked Sendable {
                             isIDR: isIDR,
                             hostEncodeMs: Double(hostEncodeTenthsMs) / 10.0)
         os_unfair_lock_lock(mapLock)
+        // Cadence deltas for the receive + assemble boundaries (clump
+        // forensics). Captured under the map lock we already hold; observed
+        // after unlock (the Stage has its own lock).
+        let prevReceive = lastReceiveNanos
+        let prevAssemble = lastAssembleNanos
+        lastReceiveNanos = receiveNanos
+        lastAssembleNanos = assembleNanos
         if inFlight[rtpTimestamp] == nil {
             insertionOrder.append(rtpTimestamp)
         }
@@ -453,7 +504,16 @@ final class FrameTimingTracker: @unchecked Sendable {
             if let dropped = inFlight.removeValue(forKey: stale) { evicted.append((stale, dropped)) }
         }
         os_unfair_lock_unlock(mapLock)
+        observeCadence(receiveCadence, prev: prevReceive, now: receiveNanos)
+        observeCadence(assembleCadence, prev: prevAssemble, now: assembleNanos)
         if !evicted.isEmpty { emitDropStubs(evicted) }
+    }
+
+    /// Observe one inter-arrival delta into a cadence stage; skips the first
+    /// event (no prev), out-of-order stamps, and content-gap deltas (> 1s).
+    private func observeCadence(_ stage: LatencyHistograms.Stage, prev: UInt64, now: UInt64) {
+        guard prev > 0, now > prev, now &- prev < Self.cadenceGapCutoffNanos else { return }
+        stage.observe(Double(now &- prev) / 1_000_000.0)
     }
 
     /// Stage t_submit. Called just before VTDecompressionSessionDecodeFrame
@@ -474,10 +534,13 @@ final class FrameTimingTracker: @unchecked Sendable {
         guard rtpTimestamp != 0 else { return }
         let now = DispatchTime.now().uptimeNanoseconds
         os_unfair_lock_lock(mapLock)
+        let prevOutput = lastOutputNanos
+        lastOutputNanos = now
         if inFlight[rtpTimestamp] != nil {
             inFlight[rtpTimestamp]?.outputNanos = now
         }
         os_unfair_lock_unlock(mapLock)
+        observeCadence(outputCadence, prev: prevOutput, now: now)
     }
 
     /// Stage t_present. Called the instant the frame is enqueued to the renderer

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -77,6 +77,26 @@ struct TelemetrySnapshot: Sendable {
     /// Stale-frame repeats per second this window - a SPIKE while fps≈refresh is a
     /// real micro-judder (at fps<refresh a steady rate is the normal cadence).
     var staleRepeatsPerSecond: Double?
+    /// EMPTY-QUEUE subset of the stale repeats (the starve half of the
+    /// clump-then-starve oscillation; not_due = total − this).
+    var staleEmptyQueueTotal: UInt64 = 0
+    /// DROUGHT subset of the perceived present gaps (content arriving, screen
+    /// held >100ms); remainder is the backoff-then-renderer-reject path.
+    var presentGapDroughtTotal: UInt64 = 0
+    /// Steady-state audio fill dips under ~15ms that did NOT fully drain -
+    /// cushion margin erosion visible before it becomes an audible under-run.
+    var audioNearMissTotal: UInt64 = 0
+    /// PIPELINE CADENCE histograms (clump forensics): inter-arrival between
+    /// consecutive frames at receive / assemble / VT-output. Standalone stages.
+    var pipelineReceiveCadence: LatencyHistogramSnapshot.Stage?
+    var pipelineAssembleCadence: LatencyHistogramSnapshot.Stage?
+    var pipelineOutputCadence: LatencyHistogramSnapshot.Stage?
+    /// CRUISE forensics: batch velocity (counts/sec) + applied gain, split
+    /// move vs drag. Standalone stages; units are not ms.
+    var cruiseVelocityMove: LatencyHistogramSnapshot.Stage?
+    var cruiseVelocityDrag: LatencyHistogramSnapshot.Stage?
+    var cruiseGainMove: LatencyHistogramSnapshot.Stage?
+    var cruiseGainDrag: LatencyHistogramSnapshot.Stage?
     /// Present-tick MISS totals split by root cause (DESCHEDULED = the tick thread
     /// didn't get the CPU; COALESCED = macOS delayed the CADisplayLink callback).
     /// The split picks which of two opposite fixes the residual present gap needs.

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -86,6 +86,11 @@ struct TelemetrySnapshot: Sendable {
     /// Steady-state audio fill dips under ~15ms that did NOT fully drain -
     /// cushion margin erosion visible before it becomes an audible under-run.
     var audioNearMissTotal: UInt64 = 0
+    /// Power state (1Hz): governor-throttle correlation labels. `onBattery` =
+    /// providing source is the internal battery; `lowPowerMode` = the user
+    /// toggle. Together they test "battery predicts the ~106-tick throttle".
+    var onBattery: Bool?
+    var lowPowerMode: Bool?
     /// PIPELINE CADENCE histograms (clump forensics): inter-arrival between
     /// consecutive frames at receive / assemble / VT-output. Standalone stages.
     var pipelineReceiveCadence: LatencyHistogramSnapshot.Stage?


### PR DESCRIPTION
The "answer everything" telemetry pass - ten new metric families, each one a measurement recent forensic sessions reached for and lacked:

| Family | Question it answers |
|---|---|
| `glimmer_cadence_{receive,assemble,output}_ms` | Where frame clumping is born (wire vs depacketizer vs VT) - the open question behind ~14/s over-target churn + ~3/s stale beats on a smooth wire |
| `glimmer_present_stale_empty_total` | Starvation stale beats vs benign not-due idle ticks |
| `glimmer_present_gap_drought_total` | Perceived-gap cause (drought vs renderer-reject) |
| `glimmer_audio_near_miss_total` | Cushion margin erosion before it's audible (latched <15ms dips) |
| `glimmer_cruise_velocity_{move,drag}` | Real hand-velocity distributions, drag-split - the data for the menu-drag tune |
| `glimmer_cruise_gain_{move,drag}` | Band residency post-retune - is the mush quantitatively gone |

Plus: `*MouseDragged` events now join the motion coalesce mask (drags batch identically to free motion).

Implementation: standalone `LatencyHistograms.Stage` instances on the FrameTimingTracker (the `inputLocalLatency` precedent), cadence fed centrally from the existing stage-record methods under the map lock already held - zero new hot-path call sites; counters are leaf atomics on TelemetryCounters. Everything is telemetry-gated (nil tracker = zero cost). 163 tests pass.