### PR TITLE
Startup-ramp tune + reorder-displacement invariant

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		D10000CD /* TelemetryFrameTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000CC /* TelemetryFrameTrace.swift */; };
 		D10000CF /* TelemetryExporter+Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000CE /* TelemetryExporter+Capture.swift */; };
 		D10000D1 /* RtpVideoQueue+ReceiveQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000D0 /* RtpVideoQueue+ReceiveQuality.swift */; };
+		D10000EA /* RtpVideoQueue+ReorderStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000E9 /* RtpVideoQueue+ReorderStats.swift */; };
 		D10000E1 /* DisplayTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000E0 /* DisplayTelemetry.swift */; };
 		D10000E3 /* VideoDecoder+DecodeTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000E2 /* VideoDecoder+DecodeTelemetry.swift */; };
 		D10000F1 /* TelemetrySessionEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000F0 /* TelemetrySessionEvents.swift */; };
@@ -376,6 +377,7 @@
 		D10000CC /* TelemetryFrameTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/TelemetryFrameTrace.swift; sourceTree = "<group>"; };
 		D10000CE /* TelemetryExporter+Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/TelemetryExporter+Capture.swift"; sourceTree = "<group>"; };
 		D10000D0 /* RtpVideoQueue+ReceiveQuality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/Native/RtpVideoQueue+ReceiveQuality.swift"; sourceTree = "<group>"; };
+		D10000E9 /* RtpVideoQueue+ReorderStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/Native/RtpVideoQueue+ReorderStats.swift"; sourceTree = "<group>"; };
 		D10000E0 /* DisplayTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/DisplayTelemetry.swift; sourceTree = "<group>"; };
 		D10000E2 /* VideoDecoder+DecodeTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/VideoDecoder+DecodeTelemetry.swift"; sourceTree = "<group>"; };
 		D10000F0 /* TelemetrySessionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/TelemetrySessionEvents.swift; sourceTree = "<group>"; };
@@ -626,6 +628,7 @@
 				D1000021 /* VideoDepacketizer.swift */,
 				D1000023 /* RtpVideoQueue.swift */,
 				D10000D0 /* RtpVideoQueue+ReceiveQuality.swift */,
+				D10000E9 /* RtpVideoQueue+ReorderStats.swift */,
 				D1000D10 /* RtpVideoQueue+AddPacket.swift */,
 				D1000D20 /* RtpVideoQueue+Reconstruct.swift */,
 				D1000F00 /* FecHeadroomController.swift */,
@@ -960,6 +963,7 @@
 				D1000022 /* VideoDepacketizer.swift in Sources */,
 				D1000024 /* RtpVideoQueue.swift in Sources */,
 				D10000D1 /* RtpVideoQueue+ReceiveQuality.swift in Sources */,
+				D10000EA /* RtpVideoQueue+ReorderStats.swift in Sources */,
 				D1000D11 /* RtpVideoQueue+AddPacket.swift in Sources */,
 				D1000D21 /* RtpVideoQueue+Reconstruct.swift in Sources */,
 				D1000F01 /* FecHeadroomController.swift in Sources */,

--- a/Glimmer/Stream/AudioDecoder+CushionMemory.swift
+++ b/Glimmer/Stream/AudioDecoder+CushionMemory.swift
@@ -179,10 +179,14 @@ extension AudioDecoder {
     }
 
     /// Half-life (s) of a persisted record's AGE LERP toward base: an unrefreshed
-    /// target/floor lerps halfway back every ~6h. A link's loss character drifts
-    /// (moved rooms, a one-off bad night), so a stale deep record shouldn't seed
-    /// full-depth forever - it re-learns its own depth each session anyway.
-    static let cushionMemoryAgeHalfLifeSeconds: Double = 6 * 3600
+    /// target/floor lerps halfway back every ~3 DAYS. Was 6h - which fully aged a
+    /// learned wifi depth to base across any >1-day gap, so every next session
+    /// re-learned the cushion through 5 audible under-runs over ~70s (measured
+    /// 2026-07-21 wifi: seed 30ms → ratchet-walk to 80ms). A link's gap character
+    /// is stable across days on a tuned network; the quiet decay (1 step/min)
+    /// already walks off any overshoot within minutes, so aging is the slow
+    /// backstop for a MOVED/changed link, not the primary corrector.
+    static let cushionMemoryAgeHalfLifeSeconds: Double = 72 * 3600
 
     /// The cap (ms) a link-keyed record may seed at: its OWN learned class's cap,
     /// so a tunnel-depth never seeds a clean wired link. Unknown-keyed records
@@ -500,7 +504,11 @@ extension AudioDecoder {
                 playoutTargetMs = max(playoutTargetMs, stored.targetMs)
                 learnedFloorMs = max(learnedFloorMs, stored.floorMs)
             } else {
-                playoutTargetMs = stored.targetMs
+                // An aged-out record must not UNDERCUT what the live link
+                // demands: adopt the deeper of the stored depth and the
+                // jitter-aware cold seed (clean link ⇒ coldSeedMs == base ⇒
+                // byte-identical to the plain adoption).
+                playoutTargetMs = max(stored.targetMs, coldSeedMs)
                 learnedFloorMs = stored.floorMs
             }
             quietSinceNanos = now

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -61,11 +61,12 @@ extension AudioDecoder {
     static let nearMissRearmFillMs: Double = 30
 
     /// Startup floor-learning gate (ns after the cold-start prime): the host
-    /// feeds sub-realtime for its first seconds (startup-pacing=paced, ~15s
-    /// measured), so drains in this window are boot-ramp artifacts. 45s covers
-    /// the measured ramp with margin. Target ratchet + underrun counting stay
-    /// live; only the floor EWMA waits.
-    static let startupFloorGateNanos: UInt64 = 45_000_000_000
+    /// feeds sub-realtime for its first seconds and the wifi link runs its own
+    /// warm-up (EnvSignal co-gap cautions to ~t+80s measured 2026-07-21, with
+    /// ramp under-runs at t+67-77s teaching the floor past the old 45s gate).
+    /// 90s covers the measured ramp with margin. Target ratchet + underrun
+    /// counting stay live; only the floor EWMA waits.
+    static let startupFloorGateNanos: UInt64 = 90_000_000_000
 
     // MARK: - P1 AUDIO meter (buffer fill / under-run / over-run / A/V drift)
 

--- a/Glimmer/Stream/Native/RtpVideoQueue+ReceiveQuality.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue+ReceiveQuality.swift
@@ -60,7 +60,16 @@ extension RtpVideoQueue {
             } else {
                 // Forward jump: the gap beyond +1 is pre-FEC loss.
                 let jump = Int(Self.u16(Int(seq) - Int(seqHighestSeen)))
-                if jump > 1 { windowLostPreFec += (jump - 1) }
+                if jump > 1 {
+                    windowLostPreFec += (jump - 1)
+                    // Anchor the open gap for reorder-displacement: this packet
+                    // is the overtaker; a late filler measures against its
+                    // arrival. Newest gap wins the single slot.
+                    gapOpenLowSeq = Self.u16(Int(seqHighestSeen) + 1)
+                    gapOpenHighSeq = Self.u16(Int(seq) - 1)
+                    gapOpenAtUs = receiveTimeUs
+                    haveOpenGap = true
+                }
                 seqHighestSeen = seq
                 rememberSeq(seq)
             }
@@ -92,6 +101,7 @@ extension RtpVideoQueue {
                     // spike arbitrarily far in the future.
                     pendingReorderCredit += 1
                 }
+                recordReorderDisplacement(seq: seq, receiveTimeUs: receiveTimeUs)
                 rememberSeq(seq)
             }
         }

--- a/Glimmer/Stream/Native/RtpVideoQueue+ReorderStats.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue+ReorderStats.swift
@@ -1,0 +1,76 @@
+//
+//  RtpVideoQueue+ReorderStats.swift
+//
+//  REORDER-DISPLACEMENT measurement (measurement ONLY - the reorder hold value
+//  is untouched). Turns the raw out-of-order count into a checked invariant:
+//  track how LATE each reordered packet arrives (ms + packets), assert
+//  displacement < reorder hold, and count violations. On a tuned single-AP
+//  wifi path, reorders are 802.11 Block-Ack reorder-buffer releases with
+//  displacement bounded by MAC retry latency (single-digit ms) - driving the
+//  COUNT to zero is physics-impossible on shared spectrum; proving every
+//  reorder lands inside the hold is the correct target.
+//
+//  HOT-PATH SAFETY: runs ONLY on the rare out-of-order branch (0.0009% of
+//  packets on the reference session), on the single receive thread. No
+//  allocation; the histogram observes + counter increment are self-locked leaf
+//  adds gated on the telemetry tracker. Displacement-ms source, in order:
+//    * EXACT: the single-slot open-gap anchor (arrival time of the packet that
+//      overtook this one), when the late seq falls inside the anchored range.
+//    * FALLBACK: seq-distance x the window's mean inter-packet interval, when
+//      the anchor was overwritten by a newer gap.
+//
+
+import Foundation
+
+extension RtpVideoQueue {
+
+    /// Record one reordered packet's displacement. Called from
+    /// `accumulateReceiveQuality` on the genuine-reorder branch only.
+    func recordReorderDisplacement(seq: UInt16, receiveTimeUs: UInt64) {
+        // Displacement in packets: wrap-aware distance behind the highest seq
+        // accepted (how many sequence slots overtook it, dups notwithstanding).
+        let dispPackets = Int(Self.u16(Int(seqHighestSeen) - Int(seq)))
+        let dispMs: Double
+        if haveOpenGap,
+           !Self.isBefore16(seq, gapOpenLowSeq),
+           !Self.isBefore16(gapOpenHighSeq, seq),
+           receiveTimeUs >= gapOpenAtUs {
+            // Exact: lateness vs the arrival of the first packet that overtook it.
+            dispMs = Double(receiveTimeUs &- gapOpenAtUs) / 1000.0
+        } else {
+            // Fallback: seq distance x the window's mean inter-arrival. Window
+            // elapsed / packet count are both already maintained; ~200µs/pkt at
+            // 5k pps. Never negative; documented optimistic-vs-exact tradeoff
+            // in the header.
+            let elapsedUs = receiveTimeUs > metricsWindowStartUs
+                ? Double(receiveTimeUs &- metricsWindowStartUs) : 0
+            let meanGapUs = packetsInWindow > 1 ? elapsedUs / Double(packetsInWindow) : 200
+            dispMs = Double(dispPackets) * meanGapUs / 1000.0
+        }
+        if dispMs > reorderDispSessionMaxMs { reorderDispSessionMaxMs = dispMs }
+        if dispPackets > reorderDispSessionMaxPackets { reorderDispSessionMaxPackets = dispPackets }
+        // THE INVARIANT: a reorder displaced past the live hold outlived its
+        // release window (it was promoted to pre-FEC loss). Always-live counter;
+        // the only reorder signal worth alerting on.
+        let holdMs = Double(reorderWindowUs) / 1000.0
+        if dispMs > holdMs {
+            TelemetryCounters.shared.reorderHoldExceededTotal.increment()
+        }
+        // Distribution (telemetry-gated; ~46 observations per reference session).
+        if let tracker = FrameTimingTracker.shared {
+            tracker.reorderDisplacementMs.observe(dispMs)
+            tracker.reorderDisplacementPackets.observe(Double(dispPackets))
+        }
+    }
+
+    /// Flush the displacement gauge alongside the per-window FEC health publish
+    /// (maybeLogMetrics, ~2s cadence). Session-lifetime maxes + the live hold,
+    /// so the exporter can emit the margin without touching this thread.
+    func publishReorderDisplacementGauge() {
+        TelemetryCounters.shared.setReorderDisplacement(
+            TelemetryCounters.ReorderDisplacementSnapshot(
+                maxMs: reorderDispSessionMaxMs,
+                maxPackets: reorderDispSessionMaxPackets,
+                holdMs: Double(reorderWindowUs) / 1000.0))
+    }
+}

--- a/Glimmer/Stream/Native/RtpVideoQueue.swift
+++ b/Glimmer/Stream/Native/RtpVideoQueue.swift
@@ -204,8 +204,9 @@ final class RtpVideoQueue {
     /// counted once when the frame is submitted/dropped).
     var currentFrameNeededFec = false
     /// Datagrams seen in the window (for a packets/s sanity figure).
-    private var packetsInWindow = 0
-    private var metricsWindowStartUs: UInt64 = 0
+    var packetsInWindow = 0
+    // Module-internal: the ReorderStats extension reads the window anchor.
+    var metricsWindowStartUs: UInt64 = 0
     private static let metricsWindowUs: UInt64 = 2_000_000  // 2s
 
     // --- P1 NETWORK receive-quality accumulators (Track B, opt-in telemetry).
@@ -252,6 +253,22 @@ final class RtpVideoQueue {
     /// pure reorder never double-counts as loss across the boundary. Persists across
     /// the window reset (it is a debt against future loss, not a per-window tally).
     var pendingReorderCredit = 0
+    /// REORDER-DISPLACEMENT (measurement only - the hold value is untouched).
+    /// Single-slot open-gap anchor: when a forward jump opens a sequence gap,
+    /// remember its seq range + the overtaking packet's arrival time, so a late
+    /// filler's displacement-ms is EXACT (now − overtake time). A newer gap
+    /// overwrites the slot (single-digit-ms Block-Ack releases make overlap
+    /// rare; mis-attribution reads a NEWER anchor = shorter displacement, an
+    /// optimistic bias the seq-distance fallback bounds). Persists across the
+    /// window reset like the reorder credit (gaps straddle boundaries).
+    var gapOpenLowSeq: UInt16 = 0
+    var gapOpenHighSeq: UInt16 = 0
+    var gapOpenAtUs: UInt64 = 0
+    var haveOpenGap = false
+    /// Session-lifetime displacement stats (receive-thread only; flushed to the
+    /// gauge each ~2s window alongside the FEC health snapshot).
+    var reorderDispSessionMaxMs: Double = 0
+    var reorderDispSessionMaxPackets = 0
     /// Recent seqs for duplicate vs reorder disambiguation. A small ring of the
     /// last seqs seen this window: a behind-highest arrival that's in the ring is a
     /// DUPLICATE, otherwise a genuine reorder. Bounded + cleared per window so it
@@ -521,6 +538,10 @@ final class RtpVideoQueue {
             lossLevel: fecHeadroom.lossLevel,
             fecPercentage: fecPercentage,
             parityMargin: windowMinParityMargin == Int.max ? nil : windowMinParityMargin))
+
+        // Reorder-displacement gauge (session maxes + live hold) - same ~2s
+        // cadence, same read-only contract as the FEC health snapshot above.
+        publishReorderDisplacementGauge()
 
         framesInWindow = 0
         fecRecoveredFramesInWindow = 0

--- a/Glimmer/Stream/TelemetryCounters+Gauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+Gauges.swift
@@ -110,6 +110,25 @@ extension TelemetryCounters {
         return fecHealthValue
     }
 
+    /// REORDER-DISPLACEMENT gauge: session-max lateness of reordered packets
+    /// (ms + packets) and the live hold, so the exporter emits the invariant
+    /// margin (hold − max) without touching the receive thread. Published each
+    /// ~2s window from RtpVideoQueue; nil before the first window.
+    struct ReorderDisplacementSnapshot: Sendable {
+        var maxMs: Double
+        var maxPackets: Int
+        var holdMs: Double
+    }
+    func setReorderDisplacement(_ snapshot: ReorderDisplacementSnapshot) {
+        os_unfair_lock_lock(reorderDispLock); reorderDispValue = snapshot; os_unfair_lock_unlock(reorderDispLock)
+    }
+    /// Latest reorder-displacement gauge, or nil before the first window. Read
+    /// by the exporter on its 1Hz queue.
+    var reorderDisplacement: ReorderDisplacementSnapshot? {
+        os_unfair_lock_lock(reorderDispLock); defer { os_unfair_lock_unlock(reorderDispLock) }
+        return reorderDispValue
+    }
+
     /// AWDL-helper gauge: awdl0 parked this stream + how many times macOS re-raised
     /// it (the contention rate the routing-socket suppressor fights). nil when off.
     struct AWDLHelperSnapshot: Sendable {

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -256,6 +256,13 @@ final class TelemetryCounters: @unchecked Sendable {
     /// oscillation's visible half. not_due = staleFrameRepeatTotal − this.
     let staleEmptyQueueTotal = Counter()
 
+    /// REORDER-HOLD invariant violations (signal: NETWORK): a reordered packet
+    /// whose measured displacement exceeded the live reorder hold - it outlived
+    /// its release window and was promoted to pre-FEC loss. THE only reorder
+    /// signal worth alerting on (the raw ooo count is a physics floor on shared
+    /// spectrum; displacement < hold is the checked invariant).
+    let reorderHoldExceededTotal = Counter()
+
     /// PERCEIVED-GAP cause split (signal: PRESENT): the DROUGHT subset of
     /// `presentationGaps` - a present landed after a >100ms hold with frames
     /// still arriving (loss storm / decode starvation / pacing wedge). The
@@ -525,6 +532,10 @@ final class TelemetryCounters: @unchecked Sendable {
     // TelemetryCounters+Gauges.swift. Module-internal so those accessors reach it.
     let fecHealthLock = os_unfair_lock_t.allocate(capacity: 1)
     var fecHealthValue: FecHealthSnapshot?
+    // Live REORDER-DISPLACEMENT gauge storage (session max ms/packets + the
+    // live hold); value type + accessors in TelemetryCounters+Gauges.swift.
+    let reorderDispLock = os_unfair_lock_t.allocate(capacity: 1)
+    var reorderDispValue: ReorderDisplacementSnapshot?
 
     /// AWDL helper gauge (awdl0 parked + macOS re-raise count). Set by
     /// AWDLHelperManager on the suppress heartbeat; read by the exporter. Self-locked.
@@ -707,7 +718,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         decoderRecreateTotal, decoderRecreateFirstTotal,
                         decoderRecreateResolutionTotal, decoderRecreateColorspaceTotal,
                         staleFrameRepeatTotal, staleEmptyQueueTotal, audioNearMissTotal,
-                        presentGapDroughtTotal,
+                        presentGapDroughtTotal, reorderHoldExceededTotal,
                         pacerOverTargetReleaseTotal,
                         tickMissDescheduledTotal, tickMissCoalescedTotal,
                         tickMissPreemptedTotal, tickMissLinkskipTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -299,6 +299,14 @@ extension TelemetryExporter {
             snap.awdlSuppressing = awdl.suppressing
             snap.awdlReSuppressTotal = awdl.reSuppressTotal
         }
+        if let reorder = counters.reorderDisplacement {
+            snap.reorderDispMaxMs = reorder.maxMs
+            snap.reorderDispMaxPackets = reorder.maxPackets
+            snap.reorderDispHoldMs = reorder.holdMs
+        }
+        snap.reorderHoldExceededTotal = counters.reorderHoldExceededTotal.value
+        snap.reorderDisplacementMsHist = FrameTimingTracker.shared?.reorderDisplacementMs.snapshotValue()
+        snap.reorderDisplacementPacketsHist = FrameTimingTracker.shared?.reorderDisplacementPackets.snapshotValue()
         // Refresh the live RTT gauge the per-frame glass-to-glass computation
         // reads at present (~RTT/2 for the transit leg). Done here on the 1Hz
         // queue, never the hot path; the present-side read is the only hot-path

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -234,6 +234,8 @@ extension TelemetryRenderer {
         builder.add("fec_loss_level", snap.fecLossLevel.map(Double.init))
         builder.add("fec_percentage", snap.fecPercentage.map(Double.init))
         builder.add("fec_parity_margin", snap.fecParityMargin.map(Double.init))
+        builder.add("reorder_disp_max_ms", snap.reorderDispMaxMs)
+        builder.add("reorder_hold_exceeded", Double(snap.reorderHoldExceededTotal))
         builder.add("pkts_per_s", snap.packetsPerSecond)
         // FRACTIONAL ms (high-res local clock): emit the Double with decimals via
         // `add` (jsonNumber → %.3f) instead of truncating to Int, so a sub-ms RTT

--- a/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNetwork.swift
@@ -29,6 +29,34 @@ extension TelemetryRenderer {
         builder.emit("glimmer_fec_reorder_hold_ms",
                      "Live FEC reorder-hold window the receiver applies, ms (base 24, cap 48).",
                      snap.fecReorderHoldMs)
+        // REORDER-DISPLACEMENT invariant: displacement < hold, checked per
+        // reorder. The margin gauge (hold − session max) and the violation
+        // counter are the ONLY reorder signals worth alerting on - the raw ooo
+        // count is a physics floor on shared spectrum.
+        builder.emit("glimmer_reorder_displacement_max_ms",
+                     "Session-max lateness of a reordered packet, ms.",
+                     snap.reorderDispMaxMs)
+        builder.emit("glimmer_reorder_displacement_max_packets",
+                     "Session-max lateness of a reordered packet, sequence slots.",
+                     snap.reorderDispMaxPackets.map(Double.init))
+        if let hold = snap.reorderDispHoldMs, let maxMs = snap.reorderDispMaxMs {
+            builder.emit("glimmer_reorder_hold_margin_ms",
+                         "Reorder-hold invariant margin: live hold − session-max displacement "
+                         + "(negative = a reorder outlived the hold).",
+                         hold - maxMs)
+        }
+        builder.emitCounter("glimmer_reorder_hold_exceeded_total",
+                            "Reorders whose displacement exceeded the live hold (promoted to "
+                            + "pre-FEC loss) - the alertable invariant violation.",
+                            snap.reorderHoldExceededTotal)
+        if let stage = snap.reorderDisplacementMsHist {
+            builder.emitHistogram("glimmer_reorder_displacement_ms",
+                                  "Reordered-packet lateness distribution, ms.", stage: stage)
+        }
+        if let stage = snap.reorderDisplacementPacketsHist {
+            builder.emitHistogram("glimmer_reorder_displacement_packets",
+                                  "Reordered-packet lateness distribution, sequence slots.", stage: stage)
+        }
         builder.emit("glimmer_fec_headroom_level",
                      "FEC headroom jitter/out-of-order/retransmit axis level (0 = clean link).",
                      snap.fecHeadroomLevel.map(Double.init))

--- a/Glimmer/Stream/TelemetryLatency.swift
+++ b/Glimmer/Stream/TelemetryLatency.swift
@@ -352,6 +352,20 @@ final class FrameTimingTracker: @unchecked Sendable {
     let cruiseGainMove = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseGainBounds)
     let cruiseGainDrag = LatencyHistograms.Stage(bounds: FrameTimingTracker.cruiseGainBounds)
 
+    /// REORDER-DISPLACEMENT distributions: how late reordered packets arrive,
+    /// in ms and in sequence slots. Fed only on the rare out-of-order branch
+    /// (~46/session on the reference wifi night). Bounds concentrate where the
+    /// invariant lives: the reorder hold runs 24-48ms, Block-Ack releases land
+    /// single-digit ms. `_packets` bounds are counts, not ms.
+    static let reorderDispMsBounds: [Double] = [
+        0.25, 0.5, 1, 1.5, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96
+    ]
+    static let reorderDispPacketBounds: [Double] = [
+        1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64
+    ]
+    let reorderDisplacementMs = LatencyHistograms.Stage(bounds: FrameTimingTracker.reorderDispMsBounds)
+    let reorderDisplacementPackets = LatencyHistograms.Stage(bounds: FrameTimingTracker.reorderDispPacketBounds)
+
     /// Last-seen stage timestamps for the cadence deltas. Guarded by `mapLock`
     /// (stamped on the same calls that touch the in-flight map).
     private var lastReceiveNanos: UInt64 = 0

--- a/Glimmer/Stream/TelemetrySessionReport.swift
+++ b/Glimmer/Stream/TelemetrySessionReport.swift
@@ -286,6 +286,10 @@ struct SessionReport {
         top.append("\"latency\":\(latencyObject(aggregate.activeLatency ?? histograms))")
         top.append("\"latency_raw\":\(latencyObject(histograms))")
         top.append("\"events\":\(eventsObject())")
+        // REORDER-DISPLACEMENT invariant: how late reorders arrived vs the hold
+        // that must outlast them. hold_exceeded > 0 is the only alertable value;
+        // an empty block (wired, no reorders) omits the quantiles cleanly.
+        top.append("\"reorder_displacement\":\(reorderDisplacementObject())")
         top.append("\"worst_windows\":\(worstWindowsObject())")
         // P2 SESSION-LIFECYCLE: the connect-handshake breakdown + the disconnect
         // reason - the "how did this run open and why did it end" line.
@@ -384,6 +388,32 @@ struct SessionReport {
             stage("idr_round_trip", histograms.idrRoundTrip)
         ].compactMap { $0 }
         return "{" + entries.joined(separator: ",") + "}"
+    }
+
+    /// REORDER-DISPLACEMENT block: quantiles from the tracker's displacement
+    /// histogram (present only when reorders occurred - a wired session emits
+    /// counts + hold + exceeded with no quantiles, so downstream jq never
+    /// divides by zero), plus the always-live session maxes and the invariant
+    /// violation counter.
+    private func reorderDisplacementObject() -> String {
+        var parts: [String] = []
+        if let disp = counters.reorderDisplacement {
+            parts.append("\"hold_ms\":\(num(disp.holdMs))")
+            parts.append("\"max_ms\":\(num(disp.maxMs))")
+            parts.append("\"max_packets\":\(disp.maxPackets)")
+        }
+        parts.append("\"hold_exceeded\":\(counters.reorderHoldExceededTotal.value)")
+        if let stage = FrameTimingTracker.shared?.reorderDisplacementMs.snapshotValue(),
+           stage.hasObservations {
+            parts.append("\"count\":\(stage.observationCount)")
+            if let value = TelemetryRenderer.histogramQuantile(0.50, stage: stage) {
+                parts.append("\"p50_ms\":\(num(value))")
+            }
+            if let value = TelemetryRenderer.histogramQuantile(0.999, stage: stage) {
+                parts.append("\"p999_ms\":\(num(value))")
+            }
+        }
+        return "{" + parts.joined(separator: ",") + "}"
     }
 
     /// P2 CONNECT-HANDSHAKE breakdown - per-stage cold-open timing (ms). Read off

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -86,6 +86,15 @@ struct TelemetrySnapshot: Sendable {
     /// Steady-state audio fill dips under ~15ms that did NOT fully drain -
     /// cushion margin erosion visible before it becomes an audible under-run.
     var audioNearMissTotal: UInt64 = 0
+    /// REORDER-DISPLACEMENT invariant (measurement only): session-max lateness
+    /// of reordered packets vs the live reorder hold, the violation counter,
+    /// and the distributions. margin = holdMs − maxMs is derived at render.
+    var reorderDispMaxMs: Double?
+    var reorderDispMaxPackets: Int?
+    var reorderDispHoldMs: Double?
+    var reorderHoldExceededTotal: UInt64 = 0
+    var reorderDisplacementMsHist: LatencyHistogramSnapshot.Stage?
+    var reorderDisplacementPacketsHist: LatencyHistogramSnapshot.Stage?
     /// Power state (1Hz): governor-throttle correlation labels. `onBattery` =
     /// providing source is the internal battery; `lowPowerMode` = the user
     /// toggle. Together they test "battery predicts the ~106-tick throttle".


### PR DESCRIPTION
Two items from the 2026-07-21 wifi-tuning night (per `HANDOFF-glimmer-reorder-displacement.md`).

**Startup-ramp tune** (from the 17.5-min 4K240 wifi session's telemetry): the session still opened with 5 audible under-runs over ~70s because (a) the 6h cushion-memory half-life erased learned wifi depth across any >1-day gap — now 72h; (b) an aged-out record could undercut live link demands at resolve — now `max(stored, jitter-aware cold seed)`; (c) ramp under-runs at t+67–77s taught the floor past the 45s gate while EnvSignal still showed co-gap caution — gate now 90s.

**Reorder-displacement invariant** (measurement only, hold untouched): displacement per reordered packet (exact via a single-slot open-gap anchor; seq×mean-interval fallback), histograms in ms + packets, margin gauge (hold − session max), and the alertable `glimmer_reorder_hold_exceeded_total`. Session report gains a `reorder_displacement` block with clean empty-case semantics for wired sessions. Hot-path cost: integer work on the 0.0009%-frequency ooo branch only; zero allocation.

**Acceptance per handoff**: build clean (warnings unchanged at baseline), 163 tests pass. Field validation: next wifi session should show the displacement histogram populated, `hold_exceeded == 0`, margin positive; wired sessions emit the block with no quantiles.