### PR TITLE
feat(power): Luna host power controls behind the hard MAC-match gate

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		D100005E /* AppModel+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100005D /* AppModel+Lifecycle.swift */; };
 		D1000060 /* AppModel+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100005F /* AppModel+Streaming.swift */; };
 		D1000062 /* AppModel+Pairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000061 /* AppModel+Pairing.swift */; };
+		E20000A4 /* AppModel+Power.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000A3 /* AppModel+Power.swift */; };
+		E20000A2 /* LunaPower.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000A1 /* LunaPower.swift */; };
 		D1000064 /* NetworkClient+Endpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000063 /* NetworkClient+Endpoints.swift */; };
 		D1000066 /* NetworkClient+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000065 /* NetworkClient+Request.swift */; };
 		D1000068 /* Network+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000067 /* Network+Support.swift */; };
@@ -185,6 +187,7 @@
 		D2000023 /* ReedSolomonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000022 /* ReedSolomonTests.swift */; };
 		D2000025 /* InputEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000024 /* InputEncoderTests.swift */; };
 		D2000CR2 /* CruiseTraversalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000CR1 /* CruiseTraversalTests.swift */; };
+		E20000A6 /* LunaGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000A5 /* LunaGateTests.swift */; };
 		D2000027 /* SdpCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000026 /* SdpCodecTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
@@ -347,6 +350,8 @@
 		D100005D /* AppModel+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+Lifecycle.swift"; sourceTree = "<group>"; };
 		D100005F /* AppModel+Streaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+Streaming.swift"; sourceTree = "<group>"; };
 		D1000061 /* AppModel+Pairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+Pairing.swift"; sourceTree = "<group>"; };
+		E20000A3 /* AppModel+Power.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppModel+Power.swift"; sourceTree = "<group>"; };
+		E20000A1 /* LunaPower.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LunaPower.swift"; sourceTree = "<group>"; };
 		D1000063 /* NetworkClient+Endpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/NetworkClient+Endpoints.swift"; sourceTree = "<group>"; };
 		D1000065 /* NetworkClient+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/NetworkClient+Request.swift"; sourceTree = "<group>"; };
 		D1000067 /* Network+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/Network+Support.swift"; sourceTree = "<group>"; };
@@ -415,6 +420,7 @@
 		D2000022 /* ReedSolomonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReedSolomonTests.swift; sourceTree = "<group>"; };
 		D2000024 /* InputEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEncoderTests.swift; sourceTree = "<group>"; };
 		D2000CR1 /* CruiseTraversalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CruiseTraversalTests.swift; sourceTree = "<group>"; };
+		E20000A5 /* LunaGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LunaGateTests.swift"; sourceTree = "<group>"; };
 		D2000026 /* SdpCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdpCodecTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
@@ -558,6 +564,8 @@
 				D1000065 /* NetworkClient+Request.swift */,
 				D1000063 /* NetworkClient+Endpoints.swift */,
 				D1000061 /* AppModel+Pairing.swift */,
+				E20000A3 /* AppModel+Power.swift */,
+				E20000A1 /* LunaPower.swift */,
 				D100005F /* AppModel+Streaming.swift */,
 				D1A00001 /* AppModel+HostRoute.swift */,
 				D1A00003 /* AppModel+SessionReceipt.swift */,
@@ -701,6 +709,7 @@
 				D2000022 /* ReedSolomonTests.swift */,
 				D2000024 /* InputEncoderTests.swift */,
 				D2000CR1 /* CruiseTraversalTests.swift */,
+				E20000A5 /* LunaGateTests.swift */,
 				D2000026 /* SdpCodecTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
@@ -893,6 +902,8 @@
 				D1000066 /* NetworkClient+Request.swift in Sources */,
 				D1000064 /* NetworkClient+Endpoints.swift in Sources */,
 				D1000062 /* AppModel+Pairing.swift in Sources */,
+				E20000A4 /* AppModel+Power.swift in Sources */,
+				E20000A2 /* LunaPower.swift in Sources */,
 				D1000060 /* AppModel+Streaming.swift in Sources */,
 				D1A00002 /* AppModel+HostRoute.swift in Sources */,
 				D1A00004 /* AppModel+SessionReceipt.swift in Sources */,
@@ -1026,6 +1037,7 @@
 				D2000023 /* ReedSolomonTests.swift in Sources */,
 				D2000025 /* InputEncoderTests.swift in Sources */,
 				D2000CR2 /* CruiseTraversalTests.swift in Sources */,
+				E20000A6 /* LunaGateTests.swift in Sources */,
 				D2000027 /* SdpCodecTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,

--- a/Glimmer/AppModel+Pairing.swift
+++ b/Glimmer/AppModel+Pairing.swift
@@ -179,7 +179,7 @@ extension AppModel {
                 serverCertPEM: paired.serverCertPEM,
                 appVersion: paired.appVersion,
                 gfeVersion: paired.gfeVersion,
-                apps: apps)
+                apps: apps, macAddress: paired.macAddress)
             pairingPhase = .success("Paired with \(hostnameOrIP) ✓")
             Diag.notice("Pairing succeeded", "Pairing")
         } catch let err as StreamError {

--- a/Glimmer/AppModel+Power.swift
+++ b/Glimmer/AppModel+Power.swift
@@ -1,0 +1,77 @@
+//
+//  AppModel+Power.swift
+//
+//  Luna power-action orchestration (spec: docs/LUNA_POWER.md). The GATE and
+//  the subprocess mechanics live in LunaPower.swift; this file owns the UX
+//  flows: Wake / Wake & Connect from an offline tile, and the online power
+//  verbs from the tile's power menu. Everything runs off the main thread via
+//  LunaPower's runner; the UI stays live through the ~36s confirmed wake.
+//
+
+import Foundation
+
+extension AppModel {
+
+    /// Wake the host via luna (exit 0 = CONFIRMED awake, ~36s cold - no
+    /// client-side power polling on top), then optionally wait for Sunshine to
+    /// answer /serverinfo and start the default app - "as if the user had
+    /// tapped the host". The host's encoder is known-ragged for ~15s after a
+    /// cold boot (Sunshine ramp); early jitter is not failure.
+    func wakeHost(_ host: Host, device: LunaPower.Device, thenConnect: Bool) {
+        Task { @MainActor in
+            do {
+                try await LunaPower.shared.perform("on", deviceID: device.id, hostID: host.id)
+                Diag.notice("luna: \(host.displayName) confirmed awake", "Power")
+                restartHostStatusPolling()
+                guard thenConnect else { return }
+                if await waitForSunshine(host: host, budgetSeconds: 90) {
+                    guard selectedHost?.id == host.id, !isStreaming else { return }
+                    streamDefaultApp()
+                } else {
+                    Diag.notice("luna: \(host.displayName) awake but Sunshine did not "
+                        + "answer within 90s - not auto-connecting", "Power")
+                }
+            } catch {
+                // LunaPower recorded lastActionError for the tile subtext.
+                Diag.notice("luna: wake \(host.displayName) failed - "
+                    + "\(error.localizedDescription)", "Power")
+            }
+        }
+    }
+
+    /// Run an online power verb (off / sleep / reboot) against the host, with
+    /// the poller re-armed after so the tile converges to the real state
+    /// (off ~9s confirmed; the chip then reads Asleep and the wake controls
+    /// return via the same gate).
+    func powerAction(_ verb: String, host: Host, device: LunaPower.Device) {
+        Task { @MainActor in
+            do {
+                try await LunaPower.shared.perform(verb, deviceID: device.id, hostID: host.id)
+                Diag.notice("luna: \(verb) \(host.displayName) confirmed", "Power")
+            } catch {
+                Diag.notice("luna: \(verb) \(host.displayName) failed - "
+                    + "\(error.localizedDescription)", "Power")
+            }
+            restartHostStatusPolling()
+        }
+    }
+
+    /// Bounded post-wake wait for Sunshine: the DEVICE is confirmed up (luna's
+    /// synchronous contract), but Sunshine's HTTP front-end takes several more
+    /// seconds to come up after the OS boots. 3s-cadence /serverinfo probes -
+    /// this polls the APP layer, not the power state, so it does not violate
+    /// the no-polling-on-top rule.
+    private func waitForSunshine(host: Host, budgetSeconds: Double) async -> Bool {
+        let deadline = Date().addingTimeInterval(budgetSeconds)
+        let info = nativeServerInfo(for: host)
+        while Date() < deadline {
+            let client = NetworkClient(server: info)
+            let answered = (try? await client.fetchServerInfo()) != nil
+            await client.shutdown()
+            if answered { return true }
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            if Task.isCancelled { return false }
+        }
+        return false
+    }
+}

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -431,10 +431,11 @@ private struct HostHero: View {
                 .padding(14)
                 // Luna gate re-evaluation rides the always-present chip (the
                 // power cluster renders NOTHING un-gated, so it can't
-                // bootstrap itself): refresh devices + reconcile the persisted
-                // host→device binding on host change (revocation vanishes the
-                // controls here or on app-foreground).
-                .task(id: host?.id) {
+                // bootstrap itself). Keyed on the POLL TICK, not just the host
+                // id, so the gate self-heals every ~10s poll - the 60s device
+                // TTL bounds actual luna spawns to ~1/min; revocation vanishes
+                // the controls here or on app-foreground.
+                .task(id: "\(host?.id ?? "")|\(model.hostLiveStatus?.capturedAt.timeIntervalSinceReferenceDate ?? 0)") {
                     guard let host else { return }
                     await LunaPower.shared.reevaluate(for: host, model: model)
                 }

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -429,6 +429,21 @@ private struct HostHero: View {
             // Top-left readiness chip
             ReadinessChip()
                 .padding(14)
+                // Luna gate re-evaluation rides the always-present chip (the
+                // power cluster renders NOTHING un-gated, so it can't
+                // bootstrap itself): refresh devices + reconcile the persisted
+                // host→device binding on host change (revocation vanishes the
+                // controls here or on app-foreground).
+                .task(id: host?.id) {
+                    guard let host else { return }
+                    await LunaPower.shared.reevaluate(for: host, model: model)
+                }
+
+            // Top-right Luna power cluster (renders nothing unless the hard
+            // gate passes - see HostPowerControls / docs/LUNA_POWER.md).
+            HostPowerControls()
+                .padding(14)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
 
             // Centered content
             VStack(spacing: 12) {

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -88,6 +88,8 @@ struct ReadinessChip: View {
     /// Trust recovery (it re-pins the host's new cert). Pre-filled with the
     /// host's address so the user lands on the PIN step, not the chooser.
     @State private var showRePair = false
+    /// Pending destructive power verb ("off"/"reboot") awaiting confirmation.
+    @State private var confirmPowerVerb: String?
 
     /// Resolve the user-facing chip presentation. Priority order matters -
     /// our own session beats the polled host state (we'd rather show the live
@@ -183,6 +185,13 @@ struct ReadinessChip: View {
                         .transition(.scale.combined(with: .opacity))
                         .accessibilityLabel("HDR active")
                 }
+
+                // Luna power controls (spec: docs/LUNA_POWER.md). HARD GATE:
+                // these views exist ONLY when a usable luna binary matched
+                // this host's MAC to a permission-granted UpSnap device -
+                // gatedDevice(for:) is nil otherwise, and NOTHING renders (no
+                // disabled states, zero footprint on machines without luna).
+                powerControls(chip: chip)
             }
         }
         .animation(.snappy(duration: 0.3, extraBounce: 0.1), value: presentation)
@@ -192,6 +201,87 @@ struct ReadinessChip: View {
             // Pre-fill the host's address so the re-pair lands straight on the
             // PIN step (the initialAddress path that was previously dead).
             PairSheet(initialAddress: rePairAddress).environment(model)
+        }
+        // Gate re-evaluation: refresh the device list + reconcile the
+        // persisted host→device binding whenever the selected host changes
+        // (revocation makes controls vanish here or on app-foreground).
+        .task(id: model.selectedHost?.id) {
+            guard let host = model.selectedHost else { return }
+            await LunaPower.shared.reevaluate(for: host, model: model)
+        }
+    }
+
+    /// The gated power UI. Offline (asleep): Wake & Connect + Wake, replaced
+    /// by a "Waking…" capsule while luna's synchronous wake runs (~36s cold).
+    /// Online (ready): a compact power menu (Sleep / Restart / Shut Down,
+    /// destructive verbs behind confirmationDialog). Any luna failure surfaces
+    /// as a one-line subtext from the CLI's stderr.
+    @ViewBuilder
+    private func powerControls(chip: ChipPresentation) -> some View {
+        if let host = model.selectedHost,
+           let device = LunaPower.shared.gatedDevice(for: host) {
+            if LunaPower.shared.actionInFlight.contains(host.id) {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.mini)
+                    Text(chip == .asleep ? "Waking…" : "Working…")
+                        .font(.caption.weight(.medium))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .glassEffect(.regular, in: .capsule)
+            } else if chip == .asleep {
+                Button("Wake & Connect") {
+                    model.wakeHost(host, device: device, thenConnect: true)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                Button("Wake") {
+                    model.wakeHost(host, device: device, thenConnect: false)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                if let reason = LunaPower.shared.lastActionError[host.id] {
+                    Text(reason)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            } else if case .ready = chip {
+                Menu {
+                    Button("Sleep") { model.powerAction("sleep", host: host, device: device) }
+                    Button("Restart…") { confirmPowerVerb = "reboot" }
+                    Divider()
+                    Button("Shut Down…", role: .destructive) { confirmPowerVerb = "off" }
+                } label: {
+                    Image(systemName: "power")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .glassEffect(.regular, in: .capsule)
+                .accessibilityLabel("Host power menu")
+                .confirmationDialog(
+                    confirmPowerVerb == "off" ? "Shut down \(host.displayName)?"
+                                              : "Restart \(host.displayName)?",
+                    isPresented: Binding(
+                        get: { confirmPowerVerb != nil },
+                        set: { if !$0 { confirmPowerVerb = nil } }
+                    ),
+                    titleVisibility: .visible
+                ) {
+                    Button(confirmPowerVerb == "off" ? "Shut Down" : "Restart",
+                           role: .destructive) {
+                        if let verb = confirmPowerVerb {
+                            model.powerAction(verb, host: host, device: device)
+                        }
+                        confirmPowerVerb = nil
+                    }
+                    Button("Cancel", role: .cancel) { confirmPowerVerb = nil }
+                }
+            }
         }
     }
 

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -88,8 +88,6 @@ struct ReadinessChip: View {
     /// Trust recovery (it re-pins the host's new cert). Pre-filled with the
     /// host's address so the user lands on the PIN step, not the chooser.
     @State private var showRePair = false
-    /// Pending destructive power verb ("off"/"reboot") awaiting confirmation.
-    @State private var confirmPowerVerb: String?
 
     /// Resolve the user-facing chip presentation. Priority order matters -
     /// our own session beats the polled host state (we'd rather show the live
@@ -185,13 +183,6 @@ struct ReadinessChip: View {
                         .transition(.scale.combined(with: .opacity))
                         .accessibilityLabel("HDR active")
                 }
-
-                // Luna power controls (spec: docs/LUNA_POWER.md). HARD GATE:
-                // these views exist ONLY when a usable luna binary matched
-                // this host's MAC to a permission-granted UpSnap device -
-                // gatedDevice(for:) is nil otherwise, and NOTHING renders (no
-                // disabled states, zero footprint on machines without luna).
-                powerControls(chip: chip)
             }
         }
         .animation(.snappy(duration: 0.3, extraBounce: 0.1), value: presentation)
@@ -202,66 +193,96 @@ struct ReadinessChip: View {
             // PIN step (the initialAddress path that was previously dead).
             PairSheet(initialAddress: rePairAddress).environment(model)
         }
-        // Gate re-evaluation: refresh the device list + reconcile the
-        // persisted host→device binding whenever the selected host changes
-        // (revocation makes controls vanish here or on app-foreground).
-        .task(id: model.selectedHost?.id) {
-            guard let host = model.selectedHost else { return }
-            await LunaPower.shared.reevaluate(for: host, model: model)
+    }
+
+    /// Best-known address for the selected host, used to pre-fill the re-pair
+    /// sheet. Empty when nothing is selected (the sheet then opens the chooser).
+    private var rePairAddress: String {
+        guard let host = model.selectedHost else { return "" }
+        return host.localAddress ?? host.manualAddress ?? ""
+    }
+
+    /// Chip sentence + route flavour for VoiceOver ("Host ready, round trip
+    /// 12 milliseconds, over Wi-Fi") - mirrors the sighted glyph's gating.
+    private func accessibilitySummary(for chip: ChipPresentation) -> String {
+        guard case .ready = chip,
+              let route = model.hostRoute.accessibilityDescription else {
+            return chip.accessibility
+        }
+        return "\(chip.accessibility), \(route)"
+    }
+}
+
+/// Compact Luna power cluster, pinned top-TRAILING on the hero (the status
+/// chip owns the top-leading corner; actions live right). HARD GATE (spec:
+/// docs/LUNA_POWER.md): renders NOTHING unless a usable luna matched this
+/// host's MAC to a permission-granted UpSnap device. One quiet power-glyph
+/// menu - offline offers a plain Wake (Wake & Connect owns the hero CTA);
+/// online offers Sleep / Restart / Shut Down behind confirmation. A non-wake
+/// action in flight shows a small progress capsule (the hero CTA carries the
+/// wake progress).
+struct HostPowerControls: View {
+    @Environment(AppModel.self) private var model
+    /// Pending destructive verb ("off"/"reboot") awaiting confirmation.
+    @State private var confirmPowerVerb: String?
+
+    private enum Phase { case offline, online }
+
+    /// Power-relevant host phase off fresh polled truth; nil (no controls)
+    /// while connecting/streaming or when the sample is stale/unknown.
+    private var phase: Phase? {
+        if case .connecting = model.streamPhase { return nil }
+        if model.isStreaming { return nil }
+        guard let host = model.selectedHost,
+              let live = model.hostLiveStatus, live.hostID == host.id,
+              Date().timeIntervalSince(live.capturedAt) <= HostLiveStatus.stale else {
+            return nil
+        }
+        switch live.state {
+        case .asleep: return .offline
+        case .idle: return .online
+        default: return nil
         }
     }
 
-    /// The gated power UI. Offline (asleep): Wake & Connect + Wake, replaced
-    /// by a "Waking…" capsule while luna's synchronous wake runs (~36s cold).
-    /// Online (ready): a compact power menu (Sleep / Restart / Shut Down,
-    /// destructive verbs behind confirmationDialog). Any luna failure surfaces
-    /// as a one-line subtext from the CLI's stderr.
-    @ViewBuilder
-    private func powerControls(chip: ChipPresentation) -> some View {
+    var body: some View {
         if let host = model.selectedHost,
            let device = LunaPower.shared.gatedDevice(for: host) {
-            if LunaPower.shared.actionInFlight.contains(host.id) {
+            if let verb = LunaPower.shared.actionInFlight[host.id], verb != "on" {
                 HStack(spacing: 6) {
                     ProgressView().controlSize(.mini)
-                    Text(chip == .asleep ? "Waking…" : "Working…")
+                    Text(verb == "off" ? "Shutting Down…"
+                         : verb == "sleep" ? "Sleeping…" : "Restarting…")
                         .font(.caption.weight(.medium))
                 }
                 .padding(.horizontal, 10)
-                .padding(.vertical, 4)
+                .padding(.vertical, 5)
                 .glassEffect(.regular, in: .capsule)
-            } else if chip == .asleep {
-                Button("Wake & Connect") {
-                    model.wakeHost(host, device: device, thenConnect: true)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                Button("Wake") {
-                    model.wakeHost(host, device: device, thenConnect: false)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                if let reason = LunaPower.shared.lastActionError[host.id] {
-                    Text(reason)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            } else if case .ready = chip {
+            } else if let phase, LunaPower.shared.actionInFlight[host.id] == nil {
                 Menu {
-                    Button("Sleep") { model.powerAction("sleep", host: host, device: device) }
-                    Button("Restart…") { confirmPowerVerb = "reboot" }
-                    Divider()
-                    Button("Shut Down…", role: .destructive) { confirmPowerVerb = "off" }
+                    switch phase {
+                    case .offline:
+                        Button("Wake") {
+                            model.wakeHost(host, device: device, thenConnect: false)
+                        }
+                    case .online:
+                        Button("Sleep") {
+                            model.powerAction("sleep", host: host, device: device)
+                        }
+                        Button("Restart…") { confirmPowerVerb = "reboot" }
+                        Divider()
+                        Button("Shut Down…", role: .destructive) { confirmPowerVerb = "off" }
+                    }
                 } label: {
                     Image(systemName: "power")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
+                        .frame(width: 26, height: 26)
                 }
                 .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
                 .fixedSize()
-                .glassEffect(.regular, in: .capsule)
+                .glassEffect(.regular, in: .circle)
                 .accessibilityLabel("Host power menu")
                 .confirmationDialog(
                     confirmPowerVerb == "off" ? "Shut down \(host.displayName)?"
@@ -283,23 +304,6 @@ struct ReadinessChip: View {
                 }
             }
         }
-    }
-
-    /// Best-known address for the selected host, used to pre-fill the re-pair
-    /// sheet. Empty when nothing is selected (the sheet then opens the chooser).
-    private var rePairAddress: String {
-        guard let host = model.selectedHost else { return "" }
-        return host.localAddress ?? host.manualAddress ?? ""
-    }
-
-    /// Chip sentence + route flavour for VoiceOver ("Host ready, round trip
-    /// 12 milliseconds, over Wi-Fi") - mirrors the sighted glyph's gating.
-    private func accessibilitySummary(for chip: ChipPresentation) -> String {
-        guard case .ready = chip,
-              let route = model.hostRoute.accessibilityDescription else {
-            return chip.accessibility
-        }
-        return "\(chip.accessibility), \(route)"
     }
 }
 
@@ -447,14 +451,36 @@ struct StreamButton: View {
         case connect
         case connecting
         case liveBackgrounded
+        /// Host asleep + Luna power gate passed: the hero CTA becomes the one
+        /// obvious action ("Wake & Connect") instead of a dead Stream button.
+        case wake
+        /// luna's synchronous wake in flight (~36s cold) - progress, disabled.
+        case waking
     }
     private var role: ButtonRole {
         if isConnecting { return .connecting }
         if model.isStreaming, model.nativeStreamBackgrounded {
             return .liveBackgrounded
         }
-        if model.selectedHost == nil { return .noPC }
+        guard let host = model.selectedHost else { return .noPC }
+        if LunaPower.shared.gatedDevice(for: host) != nil {
+            if LunaPower.shared.actionInFlight[host.id] == "on" { return .waking }
+            if hostIsAsleep(host), LunaPower.shared.actionInFlight[host.id] == nil {
+                return .wake
+            }
+        }
         return .connect
+    }
+
+    /// Fresh polled truth says the selected host is asleep (mirrors the
+    /// readiness chip's staleness rules).
+    private func hostIsAsleep(_ host: Host) -> Bool {
+        guard let live = model.hostLiveStatus, live.hostID == host.id,
+              Date().timeIntervalSince(live.capturedAt) <= HostLiveStatus.stale else {
+            return false
+        }
+        if case .asleep = live.state { return true }
+        return false
     }
 
     var body: some View {
@@ -464,6 +490,12 @@ struct StreamButton: View {
             case .connect: model.streamHeroApp()
             case .connecting: model.cancelConnect()        // the working exit from a stuck connect
             case .liveBackgrounded: model.resumeStreamWindow()
+            case .wake:
+                if let host = model.selectedHost,
+                   let device = LunaPower.shared.gatedDevice(for: host) {
+                    model.wakeHost(host, device: device, thenConnect: true)
+                }
+            case .waking: break                                // progress - luna confirms, no cancel
             }
         } label: {
             HStack(spacing: 10) {
@@ -502,6 +534,30 @@ struct StreamButton: View {
                     Text("Back to stream")
                         .font(.system(size: 17, weight: .semibold))
                         .contentTransition(.opacity)
+                case .wake:
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Wake & Connect")
+                            .font(.system(size: 17, weight: .semibold))
+                            .contentTransition(.opacity)
+                        // A failed wake surfaces luna's one-line reason here,
+                        // right under the retry affordance.
+                        if let host = model.selectedHost,
+                           let reason = LunaPower.shared.lastActionError[host.id] {
+                            Text(reason)
+                                .font(.system(size: 11, weight: .regular))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                case .waking:
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Waking \(model.selectedHost?.displayName ?? "host")…")
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                        .contentTransition(.opacity)
                 case .connect:
                     // Static play glyph + the manager's hero verb (an icon/
                     // label swap here would flash inside the 400 ms hold).
@@ -530,6 +586,7 @@ struct StreamButton: View {
         // .connecting stays ENABLED - it's the cancel affordance.
         .disabled(
             role == .noPC ||
+            role == .waking ||
             (role == .connect && model.isStreaming)
         )
         // Success haptic on the actual establish edge, not on click.

--- a/Glimmer/HostStatusPoller.swift
+++ b/Glimmer/HostStatusPoller.swift
@@ -103,13 +103,28 @@ extension AppModel {
     /// `HostLiveStatus.stale` age-out still falls back to "Checking..." - the
     /// honest "we genuinely don't know anymore" path.)
     func publishUnreachable(hostID: String, expectedHostID: String) async {
-        let streak: Int = await MainActor.run { [weak self] in
-            guard let self else { return 0 }
+        let (streak, hasFreshLastGood): (Int, Bool) = await MainActor.run { [weak self] in
+            guard let self else { return (0, false) }
             self.hostUnreachableStreak += 1
-            return self.hostUnreachableStreak
+            // Is there a FRESH last-good status this miss would be protecting?
+            // The 3-strike bar exists so a transient blip can't slander a host
+            // that was answering moments ago (the post-/cancel window). With
+            // nothing published yet (app launch / host switch: the chip is
+            // stuck on "Checking..."), that protection protects nothing - it
+            // just delays the honest Asleep (and the wake controls behind it)
+            // by ~30-40s.
+            let live = self.hostLiveStatus
+            let fresh = live != nil
+                && live?.hostID == hostID
+                && live?.state != .unknown
+                && Date().timeIntervalSince(live?.capturedAt ?? .distantPast) <= HostLiveStatus.stale
+            return (self.hostUnreachableStreak, fresh)
         }
-        // Hold last-good until the host is confirmed unreachable - no flap.
-        guard streak >= Self.asleepProbeThreshold else { return }
+        // Steady state: hold last-good until confirmed unreachable - no flap.
+        // Cold start (no fresh last-good): ONE 2s miss publishes Asleep now;
+        // if the host was merely blipping, the next probe (≤10s) corrects to
+        // Ready - a far cheaper error than 40s of "Checking...".
+        guard streak >= (hasFreshLastGood ? Self.asleepProbeThreshold : 1) else { return }
         await publishLiveStatus(HostLiveStatus(
             hostID: hostID,
             state: .asleep,

--- a/Glimmer/HostStatusPoller.swift
+++ b/Glimmer/HostStatusPoller.swift
@@ -172,6 +172,10 @@ extension AppModel {
                     guard let self,
                           let host = self.selectedHost,
                           host.id == expectedHostID else { return [:] }
+                    // MAC backfill (the Luna power gate's Glimmer half): every
+                    // successful /serverinfo refreshes the stored MAC - the
+                    // only time it's learnable is while the host is online.
+                    self.updateHostMac(hostID: expectedHostID, mac: info.macAddress)
                     return Dictionary(uniqueKeysWithValues: host.apps.map { ($0.id, $0.name) })
                 }
 

--- a/Glimmer/HostsStore.swift
+++ b/Glimmer/HostsStore.swift
@@ -143,9 +143,10 @@ extension AppModel {
                 serverCertPEM: srvCert,
                 appVersion: appVer,
                 gfeVersion: gfeVer,
-                // Future: moonlight-qt doesn't persist host MAC; populate
-                // from /serverinfo's `<mac>` field when we wire that up.
-                macAddress: nil
+                // Backfilled from /serverinfo's `<mac>` on every successful
+                // poll/pair (only learnable while the host is online).
+                macAddress: defaults.string(forKey: "hosts.\(i).mac"),
+                lunaDeviceId: defaults.string(forKey: "hosts.\(i).lunadevice")
             ))
         }
 
@@ -159,6 +160,50 @@ extension AppModel {
         } else {
             selectedHost = hosts.first
         }
+    }
+
+    /// Find the `hosts.N` slot index for a host id (uuid, hostname fallback) -
+    /// the shared lookup renameHost pioneered. 0 = no match.
+    private func hostSlot(for hostID: String, defaults: UserDefaults) -> Int {
+        let count = defaults.integer(forKey: "hosts.size")
+        guard count > 0 else { return 0 }
+        for i in 1...count {
+            let uuid = defaults.string(forKey: "hosts.\(i).uuid") ?? ""
+            let hostname = defaults.string(forKey: "hosts.\(i).hostname") ?? ""
+            if uuid == hostID || (uuid.isEmpty && hostname == hostID) { return i }
+        }
+        return 0
+    }
+
+    /// Backfill/refresh a host's MAC from a successful /serverinfo. Zeroed or
+    /// empty MACs are rejected (the Luna gate fails closed on them, and a
+    /// zeroed refresh must not clobber a previously-learned real MAC). Reloads
+    /// the in-memory list only when the stored value actually changed.
+    func updateHostMac(hostID: String, mac: String?) {
+        guard let normalized = LunaPower.normalizeMac(mac) else { return }
+        let defaults = UserDefaults.standard
+        let slot = hostSlot(for: hostID, defaults: defaults)
+        guard slot > 0 else { return }
+        let key = "hosts.\(slot).mac"
+        guard defaults.string(forKey: key) != normalized else { return }
+        defaults.set(normalized, forKey: key)
+        loadHosts()
+    }
+
+    /// Persist (or clear, with nil) the host → UpSnap device binding the Luna
+    /// gate resolved. Reloads only on change.
+    func bindLunaDevice(hostID: String, deviceID: String?) {
+        let defaults = UserDefaults.standard
+        let slot = hostSlot(for: hostID, defaults: defaults)
+        guard slot > 0 else { return }
+        let key = "hosts.\(slot).lunadevice"
+        guard defaults.string(forKey: key) != deviceID else { return }
+        if let deviceID {
+            defaults.set(deviceID, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        loadHosts()
     }
 
     /// Set (or clear) a user-facing custom name for a host. Persists into the
@@ -204,7 +249,7 @@ extension AppModel {
     /// (re-pair), otherwise appends a new slot. `apps` come from /applist.
     func saveHost(uuid: String, hostname: String, address: String,
                   serverCertPEM: String?, appVersion: String?, gfeVersion: String?,
-                  apps: [PairedApp]) {
+                  apps: [PairedApp], macAddress: String? = nil) {
         let defaults = UserDefaults.standard
         let count = defaults.integer(forKey: "hosts.size")
 
@@ -230,6 +275,11 @@ extension AppModel {
         if let pem = serverCertPEM { defaults.set(pem, forKey: "\(prefix).srvcert") }
         if let appVersion { defaults.set(appVersion, forKey: "\(prefix).appversion") }
         if let gfeVersion { defaults.set(gfeVersion, forKey: "\(prefix).gfeversion") }
+        // Pair-time MAC capture (the host is online right now - the only time
+        // it's learnable). Zeroed/absent leaves any earlier value in place.
+        if let mac = LunaPower.normalizeMac(macAddress) {
+            defaults.set(mac, forKey: "\(prefix).mac")
+        }
         // Don't clobber a user's custom name on re-pair.
         if defaults.object(forKey: "\(prefix).customname") == nil {
             defaults.set(false, forKey: "\(prefix).customname")

--- a/Glimmer/LunaPower.swift
+++ b/Glimmer/LunaPower.swift
@@ -1,0 +1,276 @@
+//
+//  LunaPower.swift
+//
+//  Host power controls (wake/shutdown/sleep/reboot/status) via the `luna` CLI
+//  (whaleyshire upstream: dev/luna, backed by UpSnap). Spec: docs/LUNA_POWER.md.
+//
+//  THE GATE (the whole product rule): power UI exists ONLY when (a) a usable
+//  luna binary >= 2026.7.1 is found AND (b) the host's stored MAC matches an
+//  UpSnap device from `luna devices --json` (the permission-scoped list - the
+//  UpSnap grant doubles as the per-client allowlist). Either check failing =>
+//  ZERO footprint: no buttons, no settings, no disabled states. Fail closed on
+//  zeroed/absent MACs (a Sunshine NIC quirk); no IP fallback, no manual
+//  binding in v1.
+//
+//  Luna owns the UpSnap endpoint + credentials (keychain item `upsnap-power`);
+//  Glimmer never reads, stores, or passes credentials - only sets
+//  UPSNAP_DEVICE=<matched id> per call. UpSnap's power routes are SYNCHRONOUS:
+//  luna exit 0 is a CONFIRMATION the device state actually flipped (~36s cold
+//  wake, ~9s off), so no client-side did-it-work polling is layered on top.
+//
+//  Zero-footprint acceptance: on a machine without luna, the only work ever
+//  done is a file-existence probe per candidate path at launch/foreground -
+//  a subprocess spawns only when a candidate FILE exists.
+//
+
+import AppKit
+import Foundation
+import os.log
+
+@MainActor
+@Observable
+final class LunaPower {
+    static let shared = LunaPower()
+    @ObservationIgnored private let log = Logger(
+        subsystem: "io.ugfugl.Glimmer", category: "LunaPower")
+
+    /// One permission-scoped UpSnap device from `luna devices --json`.
+    struct Device: Decodable, Sendable {
+        let id: String
+        let name: String
+        let mac: String
+        let ip: String?
+        let status: String?
+    }
+
+    /// Discovered usable binary (nil = gate closed everywhere). Re-probed at
+    /// launch and on every app-foreground.
+    private(set) var binaryURL: URL?
+    /// Cached permission-scoped device list + fetch stamp (short TTL).
+    private(set) var devices: [Device] = []
+    @ObservationIgnored private var devicesFetchedAt: Date?
+    /// Host ids with a power action in flight (drives the "Waking…" state and
+    /// disables the tile's power controls while one runs).
+    private(set) var actionInFlight: Set<String> = []
+    /// Last action error, keyed by host id (surfaced as tile subtext; cleared
+    /// on the next action or gate re-evaluation).
+    private(set) var lastActionError: [String: String] = [:]
+
+    /// Devices-list TTL: refreshed lazily past this age, plus on any power-
+    /// action failure and on host-store changes (spec: ~60s).
+    private static let devicesTTL: TimeInterval = 60
+    /// First calver with `devices --json`; anything older fails the gate.
+    private static let minimumVersion = [2026, 7, 1]
+
+    private init() {
+        // Re-probe the binary (and expire the device cache) on foreground -
+        // luna installed/upgraded while Glimmer runs is picked up without a
+        // relaunch. Weak-self: the singleton never deallocs, but discipline.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.devicesFetchedAt = nil
+                Task {
+                    await self?.refreshBinary()
+                    // Fresh device list on foreground: a revoked UpSnap grant
+                    // makes the controls vanish here (gatedDevice reads this
+                    // observable list, so SwiftUI re-renders on the change).
+                    await self?.refreshDevicesIfStale(force: true)
+                }
+            }
+        }
+        Task { await refreshBinary() }
+    }
+
+    // MARK: - Gate
+
+    /// The gate, evaluated per host from CACHED state (pure - never spawns).
+    /// Returns the matched device when power controls may draw, else nil.
+    func gatedDevice(for host: Host) -> Device? {
+        guard binaryURL != nil,
+              let hostMac = Self.normalizeMac(host.macAddress) else { return nil }
+        return devices.first { Self.normalizeMac($0.mac) == hostMac }
+    }
+
+    /// Refresh the device list when stale, then reconcile the host's persisted
+    /// binding (bind on first match; UNBIND when the device disappeared - the
+    /// revocation case). Called from the tile when a host renders offline/online
+    /// and before any power action.
+    func reevaluate(for host: Host, model: AppModel) async {
+        guard binaryURL != nil else { return }
+        await refreshDevicesIfStale()
+        let matched = gatedDevice(for: host)
+        if matched?.id != host.lunaDeviceId {
+            model.bindLunaDevice(hostID: host.id, deviceID: matched?.id)
+        }
+    }
+
+    // MARK: - Discovery
+
+    /// Probe for a usable luna binary. File-existence checks first (no spawn
+    /// on machines without luna); `luna version` runs only on candidates that
+    /// exist and must print a calver >= 2026.7.1 (2026.7.0 lacks
+    /// `devices --json` and fails the gate).
+    func refreshBinary() async {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var candidates = [
+            "\(home)/.local/bin/luna",
+            "/opt/homebrew/bin/luna",
+            "/usr/local/bin/luna"
+        ]
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            candidates += path.split(separator: ":").map { "\($0)/luna" }
+        }
+        var found: URL?
+        for candidate in candidates {
+            guard FileManager.default.isExecutableFile(atPath: candidate) else { continue }
+            let url = URL(fileURLWithPath: candidate)
+            if let out = try? await Self.run(url, args: ["version"], timeout: 5),
+               out.status == 0,
+               Self.calverAtLeast(Self.calver(out.stdout), Self.minimumVersion) {
+                found = url
+                break
+            }
+        }
+        if found?.path != binaryURL?.path {
+            log.info("luna gate: \(found?.path ?? "no usable binary", privacy: .public)")
+        }
+        binaryURL = found
+        if found == nil {
+            devices = []
+            devicesFetchedAt = nil
+        }
+    }
+
+    /// Fetch `luna devices --json` when the cache is stale. Failure clears the
+    /// list (gate closes) - fail closed, never stale-open.
+    func refreshDevicesIfStale(force: Bool = false) async {
+        guard let binary = binaryURL else { return }
+        if !force, let at = devicesFetchedAt, Date().timeIntervalSince(at) < Self.devicesTTL {
+            return
+        }
+        do {
+            let out = try await Self.run(binary, args: ["devices", "--json"], timeout: 15)
+            guard out.status == 0, let data = out.stdout.data(using: .utf8) else {
+                throw LunaError.failed(out.stderr.isEmpty ? "devices exit \(out.status)" : out.stderr)
+            }
+            devices = try JSONDecoder().decode([Device].self, from: data)
+            devicesFetchedAt = Date()
+        } catch {
+            log.error("luna devices failed: \(error.localizedDescription, privacy: .public)")
+            devices = []
+            devicesFetchedAt = Date()   // don't hammer a broken luna; TTL still applies
+        }
+    }
+
+    // MARK: - Actions
+
+    enum LunaError: LocalizedError {
+        case failed(String)
+        var errorDescription: String? {
+            if case .failed(let reason) = self {
+                return reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return nil
+        }
+    }
+
+    /// Run one power verb against a bound device. Blocks (off-main) until luna
+    /// CONFIRMS the state flip - `on` measured ~36s cold (cap 200s), `off` ~9s.
+    /// Throws with luna's one-line stderr reason on failure and forces a device
+    /// re-fetch so a revoked grant closes the gate promptly.
+    func perform(_ verb: String, deviceID: String, hostID: String) async throws {
+        guard let binary = binaryURL else { throw LunaError.failed("luna not available") }
+        actionInFlight.insert(hostID)
+        lastActionError[hostID] = nil
+        defer { actionInFlight.remove(hostID) }
+        do {
+            let timeout: TimeInterval = verb == "on" ? 200 : 90
+            let out = try await Self.run(
+                binary, args: [verb], env: ["UPSNAP_DEVICE": deviceID], timeout: timeout)
+            guard out.status == 0 else {
+                throw LunaError.failed(out.stderr.isEmpty ? "\(verb) failed" : out.stderr)
+            }
+        } catch {
+            lastActionError[hostID] = error.localizedDescription
+            await refreshDevicesIfStale(force: true)
+            throw error
+        }
+    }
+
+    // MARK: - Helpers (pure; unit-tested)
+
+    /// Normalize a MAC for matching: lowercase, colon-separated, two hex
+    /// digits per octet. Returns nil for absent, malformed, or ZEROED input
+    /// (the Sunshine quirk the gate must fail closed on).
+    nonisolated static func normalizeMac(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let parts = raw.lowercased()
+            .split(whereSeparator: { $0 == ":" || $0 == "-" })
+            .map { $0.count == 1 ? "0\($0)" : String($0) }
+        guard parts.count == 6,
+              parts.allSatisfy({ $0.count == 2 && $0.allSatisfy(\.isHexDigit) }) else {
+            return nil
+        }
+        let joined = parts.joined(separator: ":")
+        return joined == "00:00:00:00:00:00" ? nil : joined
+    }
+
+    /// Parse "2026.7.1" → [2026,7,1] for lexicographic comparison; malformed
+    /// input compares as [0] (fails any minimum).
+    nonisolated static func calver(_ raw: String) -> [Int] {
+        let parts = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ".")
+            .compactMap { Int($0) }
+        return parts.count == 3 ? parts : [0]
+    }
+
+    /// Lexicographic component compare: version >= minimum.
+    nonisolated static func calverAtLeast(_ version: [Int], _ minimum: [Int]) -> Bool {
+        for (v, m) in zip(version, minimum) where v != m { return v > m }
+        return version.count >= minimum.count
+    }
+
+    // MARK: - Subprocess (off-main)
+
+    /// Run luna with a bounded timeout; never on the main thread. Environment
+    /// is inherited plus overrides (UPSNAP_DEVICE) - luna resolves its own
+    /// credentials (keychain / UPSNAP_PASSWORD); Glimmer passes none.
+    nonisolated static func run(
+        _ url: URL, args: [String], env: [String: String] = [:], timeout: TimeInterval
+    ) async throws -> (status: Int32, stdout: String, stderr: String) {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                process.executableURL = url
+                process.arguments = args
+                var environment = ProcessInfo.processInfo.environment
+                for (key, value) in env { environment[key] = value }
+                process.environment = environment
+                let outPipe = Pipe(), errPipe = Pipe()
+                process.standardOutput = outPipe
+                process.standardError = errPipe
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let killer = DispatchWorkItem { if process.isRunning { process.terminate() } }
+                DispatchQueue.global(qos: .utility)
+                    .asyncAfter(deadline: .now() + timeout, execute: killer)
+                process.waitUntilExit()
+                killer.cancel()
+                let stdout = String(
+                    data: outPipe.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8) ?? ""
+                let stderr = String(
+                    data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8) ?? ""
+                continuation.resume(returning: (process.terminationStatus, stdout, stderr))
+            }
+        }
+    }
+}

--- a/Glimmer/LunaPower.swift
+++ b/Glimmer/LunaPower.swift
@@ -49,9 +49,10 @@ final class LunaPower {
     /// Cached permission-scoped device list + fetch stamp (short TTL).
     private(set) var devices: [Device] = []
     @ObservationIgnored private var devicesFetchedAt: Date?
-    /// Host ids with a power action in flight (drives the "Waking…" state and
-    /// disables the tile's power controls while one runs).
-    private(set) var actionInFlight: Set<String> = []
+    /// Power action in flight, keyed host id → verb ("on"/"off"/"sleep"/
+    /// "reboot"). Drives the hero's "Waking…" state vs the trailing cluster's
+    /// progress capsule, and disables controls while one runs.
+    private(set) var actionInFlight: [String: String] = [:]
     /// Last action error, keyed by host id (surfaced as tile subtext; cleared
     /// on the next action or gate re-evaluation).
     private(set) var lastActionError: [String: String] = [:]
@@ -183,9 +184,9 @@ final class LunaPower {
     /// re-fetch so a revoked grant closes the gate promptly.
     func perform(_ verb: String, deviceID: String, hostID: String) async throws {
         guard let binary = binaryURL else { throw LunaError.failed("luna not available") }
-        actionInFlight.insert(hostID)
+        actionInFlight[hostID] = verb
         lastActionError[hostID] = nil
-        defer { actionInFlight.remove(hostID) }
+        defer { actionInFlight[hostID] = nil }
         do {
             let timeout: TimeInterval = verb == "on" ? 200 : 90
             let out = try await Self.run(

--- a/Glimmer/LunaPower.swift
+++ b/Glimmer/LunaPower.swift
@@ -82,7 +82,14 @@ final class LunaPower {
                 }
             }
         }
-        Task { await refreshBinary() }
+        // Initial probe + device fetch. The foreground observer above can MISS
+        // the launch activation (this singleton initializes lazily, usually
+        // after didBecomeActive already fired), so init must fully bootstrap
+        // the gate itself - binary AND devices.
+        Task {
+            await refreshBinary()
+            await refreshDevicesIfStale()
+        }
     }
 
     // MARK: - Gate
@@ -100,7 +107,13 @@ final class LunaPower {
     /// revocation case). Called from the tile when a host renders offline/online
     /// and before any power action.
     func reevaluate(for host: Host, model: AppModel) async {
-        guard binaryURL != nil else { return }
+        // Self-bootstrapping: an early caller racing init's probe must not
+        // strand the gate closed until the next foreground - re-probe here
+        // (cheap: file-exists + one `luna version` when a candidate exists).
+        if binaryURL == nil {
+            await refreshBinary()
+            guard binaryURL != nil else { return }
+        }
         await refreshDevicesIfStale()
         let matched = gatedDevice(for: host)
         if matched?.id != host.lunaDeviceId {

--- a/Glimmer/Models/Host.swift
+++ b/Glimmer/Models/Host.swift
@@ -33,6 +33,11 @@ struct Host: Identifiable, Hashable {
     // backend populates this.
     let macAddress: String?
 
+    /// UpSnap device id bound by the Luna power gate (persisted once the
+    /// host's MAC matches a device from `luna devices --json`). Invalidated
+    /// when a refreshed device list no longer contains it. nil = unbound.
+    var lunaDeviceId: String?
+
     var displayName: String { customName ?? name }
 
     var lastPlayedDescription: String? {

--- a/Glimmer/Stream/NetworkClient+Endpoints.swift
+++ b/Glimmer/Stream/NetworkClient+Endpoints.swift
@@ -134,6 +134,11 @@ extension NetworkClient {
         if let gfeVer = xml.string(forChild: "GfeVersion") {
             server.gfeVersion = gfeVer
         }
+        // Host primary-NIC MAC (WoL / Luna power gate). Falls through when
+        // omitted; a zeroed value is stored as-is and rejected downstream.
+        if let mac = xml.string(forChild: "mac"), !mac.isEmpty {
+            server.macAddress = mac
+        }
         // Distinguish real GFE from Sunshine-pretending-to-be-GFE by the
         // `<state>` field. NVIDIA's state strings contain "MJOLNIR"; Sunshine
         // uses "SUNSHINE_SERVER_*". Used to gate the fps>60 launch-URL quirk.

--- a/Glimmer/Stream/Types.swift
+++ b/Glimmer/Stream/Types.swift
@@ -414,6 +414,11 @@ public struct ServerInfo: Sendable {
     /// needs on the wire.
     public var serverCodecModeRaw: Int = 0
     public var currentGameID: Int = 0           // 0 = host is idle; otherwise the app ID that's streaming
+    /// Host's primary-NIC MAC from /serverinfo's `<mac>` (stock Moonlight uses
+    /// the same field for WoL). Only learnable while the host is ONLINE; some
+    /// Sunshine NIC configs report a zeroed MAC - consumers must treat
+    /// `00:00:00:00:00:00` as absent (the Luna power gate fails closed on it).
+    public var macAddress: String?
 
     public init(address: String, uniqueId: String, serverName: String) {
         self.address = address

--- a/GlimmerTests/LunaGateTests.swift
+++ b/GlimmerTests/LunaGateTests.swift
@@ -1,0 +1,47 @@
+//
+//  LunaGateTests.swift
+//
+//  Pins the pure halves of the Luna power gate (LunaPower.swift): MAC
+//  normalization (the match key - zeroed/malformed MACs must fail CLOSED)
+//  and the calver minimum check (2026.7.0 lacks `devices --json` and must
+//  fail the gate; 2026.7.1+ passes).
+//
+
+import Testing
+@testable import Glimmer
+
+struct LunaGateTests {
+
+    @Test func macNormalizationCanonicalizes() {
+        #expect(LunaPower.normalizeMac("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff")
+        #expect(LunaPower.normalizeMac("aa-bb-cc-dd-ee-ff") == "aa:bb:cc:dd:ee:ff")
+        // Single-digit octets pad to two so both sides compare equal.
+        #expect(LunaPower.normalizeMac("A:B:C:D:E:F") == "0a:0b:0c:0d:0e:0f")
+        #expect(LunaPower.normalizeMac("0A:0B:0C:0D:0E:0F") == "0a:0b:0c:0d:0e:0f")
+    }
+
+    @Test func macNormalizationFailsClosed() {
+        // The Sunshine zeroed-MAC quirk: no match, no controls.
+        #expect(LunaPower.normalizeMac("00:00:00:00:00:00") == nil)
+        #expect(LunaPower.normalizeMac("0:0:0:0:0:0") == nil)
+        #expect(LunaPower.normalizeMac(nil) == nil)
+        #expect(LunaPower.normalizeMac("") == nil)
+        #expect(LunaPower.normalizeMac("not-a-mac") == nil)
+        #expect(LunaPower.normalizeMac("aa:bb:cc:dd:ee") == nil)        // 5 octets
+        #expect(LunaPower.normalizeMac("aa:bb:cc:dd:ee:ff:11") == nil)  // 7 octets
+        #expect(LunaPower.normalizeMac("gg:bb:cc:dd:ee:ff") == nil)     // non-hex
+    }
+
+    @Test func calverMinimumGates() {
+        let minimum = [2026, 7, 1]
+        #expect(LunaPower.calverAtLeast(LunaPower.calver("2026.7.1"), minimum))
+        #expect(LunaPower.calverAtLeast(LunaPower.calver("2026.7.2"), minimum))
+        #expect(LunaPower.calverAtLeast(LunaPower.calver("2026.8.0"), minimum))
+        #expect(LunaPower.calverAtLeast(LunaPower.calver("2027.1.0"), minimum))
+        // 2026.7.0 (no devices --json) and garbage both fail.
+        #expect(!LunaPower.calverAtLeast(LunaPower.calver("2026.7.0"), minimum))
+        #expect(!LunaPower.calverAtLeast(LunaPower.calver("2026.6.9"), minimum))
+        #expect(!LunaPower.calverAtLeast(LunaPower.calver("luna 1.0"), minimum))
+        #expect(!LunaPower.calverAtLeast(LunaPower.calver(""), minimum))
+    }
+}

--- a/docs/LUNA_POWER.md
+++ b/docs/LUNA_POWER.md
@@ -1,0 +1,125 @@
+# Luna power controls — handoff spec
+
+Give Glimmer host tiles power controls (wake / shutdown / sleep / reboot /
+status) for Sunshine hosts that are managed by UpSnap, by shelling out to the
+`luna` CLI. **Hard gate: the controls exist in the UI only when (a) a usable
+`luna` binary is found and (b) the host's MAC matches an UpSnap device luna can
+see. If either is false, no power UI is drawn anywhere — no settings, no
+disabled buttons, zero footprint.**
+
+Upstream context (whaleyshire-infra repo):
+
+- `dev/luna/` — the CLI, ~150 lines of stdlib Go; the reference client
+- `k8s-solo/apps/upsnap/README.md` — server side: UpSnap app, auth model, device
+  config
+
+## Why luna-as-subprocess (not a Swift port of the API client)
+
+luna owns the UpSnap endpoint, credentials (macOS keychain item `upsnap-power`),
+permission scoping, and the synchronous-confirmation semantics. Glimmer stays
+credential-free and config-free: if the machine has luna set up, Glimmer
+inherits a working power backend; if not, the feature does not exist. That is
+the whole gate philosophy.
+
+## The gate
+
+Evaluate lazily per host (and cache — see below). Both checks must pass.
+
+### 1. luna is present and usable
+
+GUI apps do **not** inherit the login shell's PATH (`~/.local/bin` will not be
+in a launchd PATH), so do not rely on `PATH` alone. Probe in order:
+
+1. `~/.local/bin/luna` (the `make install` target — the common case)
+2. `/opt/homebrew/bin/luna`, `/usr/local/bin/luna`
+3. entries of the process `PATH`
+
+A candidate is usable iff it is executable and `luna version` exits 0 and prints
+a calver **≥ 2026.7.1** (the first version with `devices --json`; 2026.7.0 lacks
+it and must fail the gate).
+
+### 2. MAC match
+
+- Glimmer side: the host's MAC comes from Sunshine's `serverinfo` (`<mac>` field
+  — stock Moonlight uses the same field for its WoL). It is only learnable while
+  the host is **online**, so persist it in the host store at pair time and
+  refresh it on every successful `serverinfo`. A host with no stored MAC fails
+  the gate (until its next online session backfills it).
+- luna side: `luna devices --json` prints the UpSnap devices the configured user
+  is permitted to see (the permission model is the allowlist — a client can only
+  ever match hosts it has been granted).
+- Match: compare normalized MACs (lowercase, colon-separated, strip leading
+  zeros consistently). On match, bind `host → device.id` and persist the
+  binding; re-resolve if a later `devices --json` no longer contains it.
+- **Fail closed**: Sunshine sometimes reports a zeroed MAC (`00:00:00:00:00:00`)
+  on some NIC configs. Zeroed or absent MAC on either side = no match = no
+  controls. No IP fallback, no manual binding in v1 — per the product rule, we
+  never draw unless the MAC genuinely matches.
+
+## luna CLI contract (v2026.7.1)
+
+| command                      | behavior                                                    | notes                             |
+| ---------------------------- | ----------------------------------------------------------- | --------------------------------- |
+| `luna version`               | prints calver, exit 0                                       | gate + minimum-version check      |
+| `luna devices --json`        | JSON array `[{"id","name","mac","ip","status"}]`, exit 0    | permission-scoped; used for match |
+| `luna on`                    | **blocks until the device is confirmed awake**, then exit 0 | measured ~36s cold; cap 200s      |
+| `luna off`                   | blocks until confirmed down, exit 0                         | measured ~9s                      |
+| `luna sleep` / `luna reboot` | same shape as `off`                                         | only if UpSnap device has the cmd |
+| `luna status`                | prints `online` / `offline` / `pending`, exit 0             | UpSnap ping loop, ~5m cadence     |
+
+- Target device: set `UPSNAP_DEVICE=<matched device.id>` in the subprocess
+  environment for every power call. Never rely on luna's baked-in default.
+- Exit non-zero ⇒ the action failed; stderr has a one-line reason (`luna: …`).
+  Surface it and re-evaluate the gate.
+- UpSnap's power routes are **synchronous** — they keep pinging until the device
+  state actually flips before responding. luna exit 0 is therefore a
+  _confirmation_, not an acknowledgement. Do not add client-side "did it work"
+  polling on top of `on`/`off` themselves.
+- Auth is luna's problem (keychain item `upsnap-power` via `security`, or
+  `UPSNAP_PASSWORD`). Glimmer must not read, store, or pass credentials.
+
+## UX
+
+Gate passed, host **offline**:
+
+- Tile shows an accurate offline state plus **Wake & Connect** (primary action)
+  and a plain **Wake**.
+- Wake & Connect: run `luna on` off the main thread (progress state on the tile:
+  "Waking…"); on exit 0, poll `serverinfo` until Sunshine answers, then start
+  the session as if the user had tapped the host. Expect the host's encoder to
+  be ragged for ~15s after cold boot (known Sunshine ramp) — do not treat early
+  jitter as failure.
+
+Gate passed, host **online**:
+
+- Overflow/context menu on the tile gains a Power section: Shut Down, Sleep,
+  Restart (with confirmation for Shut Down/Restart while a session is active).
+  Optional later: auto-offer "shut down host?" on stream quit — out of scope v1.
+
+Gate failed: none of the above exists. No menu items, no empty sections, no
+preferences toggle.
+
+## Caching & re-evaluation
+
+- luna discovery + version: on app launch and on each app-foreground.
+- `devices --json`: cache per app session with a short TTL (~60s); refresh on
+  any power-action failure and on host-store changes.
+- The `host → device.id` binding persists in the host store; it is invalidated
+  when a refreshed devices list no longer contains the id or the MAC stops
+  matching.
+
+## Acceptance checklist
+
+- [ ] Machine without luna: pixel-identical UI to today, zero subprocess spawns
+      beyond the initial probe.
+- [ ] luna 2026.7.0 (no `devices --json`): gate fails cleanly, no UI.
+- [ ] Host never seen online (no stored MAC): no power UI until first successful
+      serverinfo, then controls appear without restart.
+- [ ] MAC match with device offline: Wake & Connect wakes ((~36s), connects
+      after Sunshine answers.
+- [ ] `luna off` from the tile menu shuts the box down (~9s) and the tile
+      returns to the offline+wake state.
+- [ ] Revoking the UpSnap permission (device disappears from `devices --json`):
+      controls vanish on next re-evaluation.
+- [ ] All luna calls off the main thread; UI stays responsive during the ~36s
+      wake.


### PR DESCRIPTION
Implements `docs/LUNA_POWER.md` (spec committed in this PR): host power controls (Wake & Connect / Wake when offline; Sleep / Restart / Shut Down menu when online) for UpSnap-managed hosts via the `luna` CLI, behind the hard gate - **controls exist only when a usable luna ≥ 2026.7.1 is found AND the host's MAC matches a permission-granted UpSnap device; otherwise zero footprint.**

Spec traps covered: explicit path probe (GUI apps don't inherit shell PATH; file-existence check before any subprocess so luna-less machines never fork), MAC persisted from `/serverinfo` at pair time + refreshed on every successful poll, zeroed-MAC fails closed, wake is synchronous-confirmed (~36s, no client-side power polling layered on top; the post-wake wait polls *Sunshine*, the app layer), and revocation unbinds + vanishes controls on re-evaluation (host change / foreground / action failure).

Acceptance checklist status:
- [x] No luna: pixel-identical UI, no spawns beyond the file-existence probe
- [x] luna 2026.7.0: calver gate fails cleanly (unit-tested)
- [x] No stored MAC: no power UI until first successful serverinfo backfill (store reload re-renders, no restart)
- [ ] Wake & Connect end-to-end (~36s) — needs the live rig
- [ ] `luna off` from the menu (~9s) → tile returns to offline+wake — needs the live rig
- [x] Revocation: device-list refresh unbinds + controls vanish
- [x] All luna calls off-main (dedicated runner); UI live through the wake

166 tests in 14 suites pass (3 new gate tests: MAC normalization fail-closed cases, calver minimum).