### PR TITLE
feat(ui): expandable host app grid + full-tile hit targets

### DIFF
--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -173,40 +173,42 @@ private struct ConnectSurface: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            // Banner sits above the hero so it can't be missed. NOT behind
-            // the 400 ms hold: errors must surface the instant they exist.
-            ConnectBanner()
-                .padding(.horizontal, 4)
+        ScrollView(.vertical) {
+            VStack(spacing: 16) {
+                // Banner sits above the hero so it can't be missed. NOT behind
+                // the 400 ms hold: errors must surface the instant they exist.
+                ConnectBanner()
+                    .padding(.horizontal, 4)
 
-            HostHero(host: model.selectedHost)
-                .scaleEffect((showsConnectingUI && !reduceMotion) ? 1.04 : 1.0)
-                .animation(.snappy(duration: 0.35, extraBounce: 0.1), value: showsConnectingUI)
+                HostHero(host: model.selectedHost)
+                    .scaleEffect((showsConnectingUI && !reduceMotion) ? 1.04 : 1.0)
+                    .animation(.snappy(duration: 0.35, extraBounce: 0.1), value: showsConnectingUI)
 
-            // Spec chips stay put during connect. The StreamButton below
-            // morphs into the calm "Connecting to <host>... / stage" capsule -
-            // the ONE connecting surface (a separate phase line would flash
-            // duplicate affordances on fast connects).
-            SpecChipsRow()
+                // Spec chips stay put during connect. The StreamButton below
+                // morphs into the calm "Connecting to <host>... / stage" capsule -
+                // the ONE connecting surface (a separate phase line would flash
+                // duplicate affordances on fast connects).
+                SpecChipsRow()
 
-            // Hide the StreamButton entirely while the stream window owns
-            // the foreground - a disabled "Streaming..." button would just
-            // duplicate the stream window's presence and compete for visual
-            // weight against the dimmed hero. (Connecting is NOT handed off,
-            // so the capsule below stays mounted through the handshake.)
-            if !isHandedOff {
-                StreamButton(isConnecting: showsConnectingUI)
-                    .frame(maxWidth: 380)
-                    .padding(.top, 2)
-                    .transition(.opacity)
+                // Hide the StreamButton entirely while the stream window owns
+                // the foreground - a disabled "Streaming..." button would just
+                // duplicate the stream window's presence and compete for visual
+                // weight against the dimmed hero. (Connecting is NOT handed off,
+                // so the capsule below stays mounted through the handshake.)
+                if !isHandedOff {
+                    StreamButton(isConnecting: showsConnectingUI)
+                        .frame(maxWidth: 380)
+                        .padding(.top, 2)
+                        .transition(.opacity)
+                }
+
+                ContextFooter()
+
             }
-
-            ContextFooter()
-
-            Spacer(minLength: 0)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 20)
         }
-        .padding(.horizontal, 32)
-        .padding(.vertical, 20)
         // Hand off to the stream window: dim Glimmer's content so the
         // fullscreen surface visibly takes over and reverses on disconnect.
         .opacity(isHandedOff ? 0.4 : 1.0)
@@ -395,6 +397,7 @@ var accentSurfaceGradient: LinearGradient {
 private struct HostHero: View {
     let host: Host?
     @Environment(AppModel.self) private var model
+    @State private var appsExpanded = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -465,7 +468,7 @@ private struct HostHero: View {
                 // END - the hero copy used to duplicate it AND disagree).
 
                 if let host, !host.apps.isEmpty {
-                    AppIconsRow(apps: host.apps, host: host)
+                    AppIconsRow(apps: host.apps, host: host, isExpanded: $appsExpanded)
                         .padding(.top, 6)
                 }
             }
@@ -473,10 +476,14 @@ private struct HostHero: View {
             .padding(.vertical, 22)
             .padding(.horizontal, 24)
         }
-        // 248pt (was 270): content measures ~218pt, so this trims the hero's
-        // dead air ("a bit too much") while keeping honest breathing room.
-        .frame(height: 248)
+        // The compact presentation retains its 248pt footprint; an expanded
+        // app grid grows naturally so every host app remains reachable.
+        .frame(minHeight: 248)
         .frame(maxWidth: 520)
+        .animation(.snappy(duration: 0.3, extraBounce: 0.1), value: appsExpanded)
+        // App-list expansion is scoped to the host currently on screen. A
+        // host switch always starts in the compact four-app presentation.
+        .onChange(of: host?.id) { _, _ in appsExpanded = false }
         // Right-click the hero to rename / set codec / unpair the current PC.
         .modifier(OptionalHostContextMenu(host: host))
     }

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -203,7 +203,6 @@ private struct ConnectSurface: View {
                 }
 
                 ContextFooter()
-
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 32)
@@ -397,6 +396,7 @@ var accentSurfaceGradient: LinearGradient {
 private struct HostHero: View {
     let host: Host?
     @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appsExpanded = false
 
     var body: some View {
@@ -480,7 +480,13 @@ private struct HostHero: View {
         // app grid grows naturally so every host app remains reachable.
         .frame(minHeight: 248)
         .frame(maxWidth: 520)
-        .animation(.snappy(duration: 0.3, extraBounce: 0.1), value: appsExpanded)
+        // Expanding resizes the whole hero, which is exactly the kind of motion
+        // Reduce Motion asks us to drop - match the connecting scaleEffect above,
+        // which is already gated the same way. The layout still changes; only the
+        // animation between the two states is suppressed.
+        .animation(
+            reduceMotion ? nil : .snappy(duration: 0.3, extraBounce: 0.1),
+            value: appsExpanded)
         // App-list expansion is scoped to the host currently on screen. A
         // host switch always starts in the compact four-app presentation.
         .onChange(of: host?.id) { _, _ in appsExpanded = false }

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -310,46 +310,39 @@ struct HostPowerControls: View {
 struct AppIconsRow: View {
     let apps: [LibraryApp]
     let host: Host
+    @Binding var isExpanded: Bool
     @Environment(AppModel.self) private var model
 
+    private let columns = Array(
+        repeating: GridItem(.fixed(70), spacing: 10),
+        count: 4
+    )
+
     var body: some View {
-        // One glass composite for the row - see ReadinessChip's container note.
-        GlassEffectContainer(spacing: 10) {
-            HStack(spacing: 10) {
-                ForEach(apps.prefix(4)) { app in
-                    Button {
-                        model.requestStream(app: app, on: host)
-                    } label: {
-                        VStack(spacing: 4) {
-                            Image(systemName: app.systemImage)
-                                .font(.system(size: 18, weight: .medium))
-                                .symbolRenderingMode(.hierarchical)
-                                .frame(width: 44, height: 44)
-                                .glassEffect(
-                                    .regular.interactive(),
-                                    in: .rect(cornerRadius: 10)
-                                )
-                                .overlay {
-                                    // Accent ring for the hero target (resume
-                                    // app, else default) so the ring always
-                                    // agrees with the hero button's verb.
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .stroke(
-                                            app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
-                                            lineWidth: 2
-                                        )
-                                }
-                            Text(app.name)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
+        VStack(spacing: 8) {
+            // One glass composite for the app tiles - see ReadinessChip's
+            // container note. The compact view preserves the four-app scan;
+            // expanding swaps it for a complete four-column grid.
+            GlassEffectContainer(spacing: 10) {
+                if isExpanded {
+                    LazyVGrid(columns: columns, alignment: .center, spacing: 12) {
+                        ForEach(apps) { app in
+                            appTile(app)
                         }
-                        .frame(width: 70)
                     }
-                    .buttonStyle(.plain)
-                    .help(model.isStreaming
-                        ? "Finish the current stream first" : "Stream \(app.name)")
+                } else {
+                    HStack(spacing: 10) {
+                        ForEach(apps.prefix(4)) { app in
+                            appTile(app)
+                        }
+                        if apps.count > 4 {
+                            expandButton
+                        }
+                    }
                 }
+            }
+            if isExpanded {
+                collapseButton
             }
         }
         // Tiles park while a session exists (connecting, live, backgrounded):
@@ -359,6 +352,87 @@ struct AppIconsRow: View {
         .disabled(model.isStreaming)
         .opacity(model.isStreaming ? 0.45 : 1.0)
         .animation(.snappy(duration: 0.3), value: model.isStreaming)
+    }
+
+    private func appTile(_ app: LibraryApp) -> some View {
+        Button {
+            model.requestStream(app: app, on: host)
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: app.systemImage)
+                    .font(.system(size: 18, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: 44, height: 44)
+                    .glassEffect(
+                        .regular.interactive(),
+                        in: .rect(cornerRadius: 10)
+                    )
+                    .overlay {
+                        // Accent ring for the hero target (resume app, else
+                        // default) so it always agrees with the hero button.
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(
+                                app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
+                                lineWidth: 2
+                            )
+                    }
+                Text(app.name)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            // A `.plain` Button only hit-tests its label. Fill the grid cell
+            // inside the label, not merely on the outer Button, so padding
+            // around the icon and name launches the app too.
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .frame(width: 70, height: 70)
+        .help(model.isStreaming
+            ? "Finish the current stream first" : "Stream \(app.name)")
+    }
+
+    private var expandButton: some View {
+        Button { isExpanded = true } label: {
+            VStack(spacing: 4) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 44, height: 44)
+                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
+                Text("+\(apps.count - 4)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+            .frame(width: 70, height: 70)
+        .help("Show all \(apps.count) apps")
+        .accessibilityLabel("Show all \(apps.count) apps")
+        .accessibilityValue("Collapsed")
+        .accessibilityHint("Expands the host app list")
+    }
+
+    private var collapseButton: some View {
+        Button { isExpanded = false } label: {
+            VStack {
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 22)
+                    .glassEffect(.regular.interactive(), in: .capsule)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+            .frame(width: 44, height: 44)
+        .help("Show fewer apps")
+        .accessibilityLabel("Show fewer apps")
+        .accessibilityValue("Expanded")
+        .accessibilityHint("Collapses the host app list")
     }
 }
 

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -345,16 +345,29 @@ struct AppIconsRow: View {
                 collapseButton
             }
         }
-        // Tiles park while a session exists (connecting, live, backgrounded):
-        // a click would spawn a SECOND concurrent session - stream()'s
-        // re-entrancy guard is the wall, this is the honest affordance. Dim
-        // as the visual cue (.plain buttons don't restyle on disable).
-        .disabled(model.isStreaming)
-        .opacity(model.isStreaming ? 0.45 : 1.0)
         .animation(.snappy(duration: 0.3), value: model.isStreaming)
     }
 
+    /// Park a LAUNCH affordance while a session exists (connecting, live,
+    /// backgrounded): a click would spawn a SECOND concurrent session -
+    /// stream()'s re-entrancy guard is the wall, this is the honest affordance.
+    /// Dim as the visual cue (.plain buttons don't restyle on disable).
+    ///
+    /// Scoped to the TILES on purpose. Expand/collapse only change what this
+    /// view shows - they can't start anything - so parking them too would strand
+    /// an already-expanded list open for the whole session and stop the user
+    /// browsing their apps while streaming, for no safety benefit.
+    private func parkedWhileStreaming(_ view: some View) -> some View {
+        view
+            .disabled(model.isStreaming)
+            .opacity(model.isStreaming ? 0.45 : 1.0)
+    }
+
     private func appTile(_ app: LibraryApp) -> some View {
+        parkedWhileStreaming(rawAppTile(app))
+    }
+
+    private func rawAppTile(_ app: LibraryApp) -> some View {
         Button {
             model.requestStream(app: app, on: host)
         } label: {
@@ -408,7 +421,7 @@ struct AppIconsRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-            .frame(width: 70, height: 70)
+        .frame(width: 70, height: 70)
         .help("Show all \(apps.count) apps")
         .accessibilityLabel("Show all \(apps.count) apps")
         .accessibilityValue("Collapsed")
@@ -428,7 +441,7 @@ struct AppIconsRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-            .frame(width: 44, height: 44)
+        .frame(width: 44, height: 44)
         .help("Show fewer apps")
         .accessibilityLabel("Show fewer apps")
         .accessibilityValue("Expanded")


### PR DESCRIPTION
## What

The host hero previously rendered `apps.prefix(4)`, so longer Sunshine applists
were only reachable through the Stream button’s context menu. The compact hero
now keeps its four-app scan and shows a `+N` control when more entries exist;
that control expands inline into a centered four-column grid containing every
host app. Collapse restores the compact row, and switching PCs resets the
transient expansion state.

The hero grows past its compact 248pt minimum while expanded. `ConnectSurface`
now scrolls vertically when a long applist would otherwise push the spec chips
or Stream CTA below a short launcher window. App ordering, launch routing,
hero-target accent ring, takeover behavior, and the stream-in-progress gate are
unchanged. No host persistence, applist fetch, protocol, or engine behavior
change.

Follow-up UI correctness: `.plain` Buttons hit-test their label content, not an
outer layout frame. The app tiles plus `+N` and collapse controls now make their
labels fill their declared 70×70 / 44×44 targets and define the rectangular
content shape there, so blank space inside each control is part of its tap
target rather than only the icon or text.

## How verified

`make app` builds clean.

- Compact view: `+N` expands the complete host applist in source order.
- Expanded view: collapse returns to the compact row.
- App tiles, `+N`, and collapse controls respond across their complete declared
  hit targets, including blank padding around their visible content.
- A long applist keeps the Stream CTA reachable through vertical scrolling.


## Media


https://github.com/user-attachments/assets/1576d3cb-31c3-4b0b-ad4b-b181e4b103dd

