### PR TITLE
fix(net): make remote paths actually work — MTU clamp, VQOS floor, mid-session downshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ fifteen minutes while video kept arriving, because none of it could be
 reassembled. Glimmer now measures the actual route to your PC when a stream
 starts and sizes packets to fit it. Streaming on a local network is unchanged.
 
+Glimmer now also checks the connection quality before a stream starts. During
+the moment it already spends contacting your PC, it measures how long
+round-trips are taking - not the best case, but the slow tail, which is what
+actually causes stutter - and if your PC is far away or the path is congested,
+it asks for a bitrate that path can realistically carry instead of the one your
+resolution would want on a local network. Streaming on a local network is
+unaffected, and if the measurement doesn't succeed for any reason, nothing is
+capped.
+
 Two related fixes for weak connections. Glimmer was telling your PC it could
 never encode below about half the requested bitrate - which, on a link that
 couldn't carry even that, left your PC no setting that would work. It can now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2026.7.8 - 2026-07-30
+
+Streaming over a VPN is far more reliable, and a weak link no longer freezes the
+picture indefinitely.
+
+If you stream to your PC over a tunnel - Tailscale, WireGuard, or similar -
+Glimmer was sizing every video packet for a local network. Those packets are too
+big for a tunnel, so each one had to be split in two on the way to you, and
+losing either half lost the whole packet. On an already-marginal connection that
+multiplied the damage: in one captured session the picture stopped entirely for
+fifteen minutes while video kept arriving, because none of it could be
+reassembled. Glimmer now measures the actual route to your PC when a stream
+starts and sizes packets to fit it. Streaming on a local network is unchanged.
+
+Two related fixes for weak connections. Glimmer was telling your PC it could
+never encode below about half the requested bitrate - which, on a link that
+couldn't carry even that, left your PC no setting that would work. It can now
+drop as low as the connection genuinely needs. And if a remote connection still
+can't carry the stream, Glimmer lowers the quality and reconnects in place
+rather than holding a frozen frame forever: you'll see a brief pause and a note
+that quality is being reduced, then the picture returns. It steps down at most
+twice, never on a local network, and never raises the quality back on its own.
+
 ## 2026.7.7 - 2026-07-22
 
 Wake your PC from the couch - power controls appear when your setup supports

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		D1000024 /* RtpVideoQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000023 /* RtpVideoQueue.swift */; };
 		D1000026 /* VideoRtpReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000025 /* VideoRtpReceiver.swift */; };
 		D1000028 /* UdpPinger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000027 /* UdpPinger.swift */; };
+		D1B00002 /* StreamPathMTU.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00001 /* StreamPathMTU.swift */; };
 		D1000030 /* InputEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000029 /* InputEncoder.swift */; };
 		D1000032 /* AudioFecDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000031 /* AudioFecDecoder.swift */; };
 		D1000034 /* RtpAudioQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000033 /* RtpAudioQueue.swift */; };
@@ -189,6 +190,7 @@
 		D2000CR2 /* CruiseTraversalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000CR1 /* CruiseTraversalTests.swift */; };
 		E20000A6 /* LunaGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000A5 /* LunaGateTests.swift */; };
 		D2000027 /* SdpCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000026 /* SdpCodecTests.swift */; };
+		D2B00002 /* StreamPathMTUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00001 /* StreamPathMTUTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -324,6 +326,7 @@
 		D1000023 /* RtpVideoQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/RtpVideoQueue.swift; sourceTree = "<group>"; };
 		D1000025 /* VideoRtpReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/VideoRtpReceiver.swift; sourceTree = "<group>"; };
 		D1000027 /* UdpPinger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/UdpPinger.swift; sourceTree = "<group>"; };
+		D1B00001 /* StreamPathMTU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/StreamPathMTU.swift; sourceTree = "<group>"; };
 		D1000029 /* InputEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/InputEncoder.swift; sourceTree = "<group>"; };
 		D1000031 /* AudioFecDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/AudioFecDecoder.swift; sourceTree = "<group>"; };
 		D1000033 /* RtpAudioQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/RtpAudioQueue.swift; sourceTree = "<group>"; };
@@ -422,6 +425,7 @@
 		D2000CR1 /* CruiseTraversalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CruiseTraversalTests.swift; sourceTree = "<group>"; };
 		E20000A5 /* LunaGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LunaGateTests.swift"; sourceTree = "<group>"; };
 		D2000026 /* SdpCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdpCodecTests.swift; sourceTree = "<group>"; };
+		D2B00001 /* StreamPathMTUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPathMTUTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -642,6 +646,7 @@
 				D1000F00 /* FecHeadroomController.swift */,
 				D1000025 /* VideoRtpReceiver.swift */,
 				D1000027 /* UdpPinger.swift */,
+				D1B00001 /* StreamPathMTU.swift */,
 				D1000029 /* InputEncoder.swift */,
 				D1000037 /* InputBatcher.swift */,
 				D1000031 /* AudioFecDecoder.swift */,
@@ -711,6 +716,7 @@
 				D2000CR1 /* CruiseTraversalTests.swift */,
 				E20000A5 /* LunaGateTests.swift */,
 				D2000026 /* SdpCodecTests.swift */,
+				D2B00001 /* StreamPathMTUTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -980,6 +986,7 @@
 				D1000F01 /* FecHeadroomController.swift in Sources */,
 				D1000026 /* VideoRtpReceiver.swift in Sources */,
 				D1000028 /* UdpPinger.swift in Sources */,
+				D1B00002 /* StreamPathMTU.swift in Sources */,
 				D1000030 /* InputEncoder.swift in Sources */,
 				D1000038 /* InputBatcher.swift in Sources */,
 				D1000032 /* AudioFecDecoder.swift in Sources */,
@@ -1039,6 +1046,7 @@
 				D2000CR2 /* CruiseTraversalTests.swift in Sources */,
 				E20000A6 /* LunaGateTests.swift in Sources */,
 				D2000027 /* SdpCodecTests.swift in Sources */,
+				D2B00002 /* StreamPathMTUTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		D1000024 /* RtpVideoQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000023 /* RtpVideoQueue.swift */; };
 		D1000026 /* VideoRtpReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000025 /* VideoRtpReceiver.swift */; };
 		D1000028 /* UdpPinger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000027 /* UdpPinger.swift */; };
+		D1B00006 /* StreamSession+Downshift.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00005 /* StreamSession+Downshift.swift */; };
+		D1B00004 /* BitrateDownshiftController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00003 /* BitrateDownshiftController.swift */; };
 		D1B00002 /* StreamPathMTU.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00001 /* StreamPathMTU.swift */; };
 		D1000030 /* InputEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000029 /* InputEncoder.swift */; };
 		D1000032 /* AudioFecDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000031 /* AudioFecDecoder.swift */; };
@@ -190,6 +192,7 @@
 		D2000CR2 /* CruiseTraversalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000CR1 /* CruiseTraversalTests.swift */; };
 		E20000A6 /* LunaGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000A5 /* LunaGateTests.swift */; };
 		D2000027 /* SdpCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000026 /* SdpCodecTests.swift */; };
+		D2B00004 /* BitrateDownshiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00003 /* BitrateDownshiftTests.swift */; };
 		D2B00002 /* StreamPathMTUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00001 /* StreamPathMTUTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
@@ -326,6 +329,8 @@
 		D1000023 /* RtpVideoQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/RtpVideoQueue.swift; sourceTree = "<group>"; };
 		D1000025 /* VideoRtpReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/VideoRtpReceiver.swift; sourceTree = "<group>"; };
 		D1000027 /* UdpPinger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/UdpPinger.swift; sourceTree = "<group>"; };
+		D1B00005 /* StreamSession+Downshift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream/StreamSession+Downshift.swift"; sourceTree = "<group>"; };
+		D1B00003 /* BitrateDownshiftController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/BitrateDownshiftController.swift; sourceTree = "<group>"; };
 		D1B00001 /* StreamPathMTU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/StreamPathMTU.swift; sourceTree = "<group>"; };
 		D1000029 /* InputEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/InputEncoder.swift; sourceTree = "<group>"; };
 		D1000031 /* AudioFecDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream/Native/AudioFecDecoder.swift; sourceTree = "<group>"; };
@@ -425,6 +430,7 @@
 		D2000CR1 /* CruiseTraversalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CruiseTraversalTests.swift; sourceTree = "<group>"; };
 		E20000A5 /* LunaGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LunaGateTests.swift"; sourceTree = "<group>"; };
 		D2000026 /* SdpCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdpCodecTests.swift; sourceTree = "<group>"; };
+		D2B00003 /* BitrateDownshiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitrateDownshiftTests.swift; sourceTree = "<group>"; };
 		D2B00001 /* StreamPathMTUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPathMTUTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
@@ -646,6 +652,8 @@
 				D1000F00 /* FecHeadroomController.swift */,
 				D1000025 /* VideoRtpReceiver.swift */,
 				D1000027 /* UdpPinger.swift */,
+				D1B00005 /* StreamSession+Downshift.swift */,
+				D1B00003 /* BitrateDownshiftController.swift */,
 				D1B00001 /* StreamPathMTU.swift */,
 				D1000029 /* InputEncoder.swift */,
 				D1000037 /* InputBatcher.swift */,
@@ -716,6 +724,7 @@
 				D2000CR1 /* CruiseTraversalTests.swift */,
 				E20000A5 /* LunaGateTests.swift */,
 				D2000026 /* SdpCodecTests.swift */,
+				D2B00003 /* BitrateDownshiftTests.swift */,
 				D2B00001 /* StreamPathMTUTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
@@ -986,6 +995,8 @@
 				D1000F01 /* FecHeadroomController.swift in Sources */,
 				D1000026 /* VideoRtpReceiver.swift in Sources */,
 				D1000028 /* UdpPinger.swift in Sources */,
+				D1B00006 /* StreamSession+Downshift.swift in Sources */,
+				D1B00004 /* BitrateDownshiftController.swift in Sources */,
 				D1B00002 /* StreamPathMTU.swift in Sources */,
 				D1000030 /* InputEncoder.swift in Sources */,
 				D1000038 /* InputBatcher.swift in Sources */,
@@ -1046,6 +1057,7 @@
 				D2000CR2 /* CruiseTraversalTests.swift in Sources */,
 				E20000A6 /* LunaGateTests.swift in Sources */,
 				D2000027 /* SdpCodecTests.swift in Sources */,
+				D2B00004 /* BitrateDownshiftTests.swift in Sources */,
 				D2B00002 /* StreamPathMTUTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,

--- a/Glimmer/Stream/BitrateDownshiftController.swift
+++ b/Glimmer/Stream/BitrateDownshiftController.swift
@@ -1,0 +1,165 @@
+//
+//  BitrateDownshiftController.swift
+//
+//  MID-SESSION BITRATE DOWNSHIFT: the only rate adaptation this protocol
+//  profile permits.
+//
+//  WHY A RECONNECT AND NOT A MESSAGE: bitrate is fixed for the life of a
+//  session. There is no client→host bitrate request wired for this Sunshine
+//  profile - FEC% is host-driven per frame, and the per-frame FEC-status
+//  feedback moonlight uses collides on the wire with IDX_SET_RGB_LED and is
+//  deliberately never sent (see FecHeadroomController). The rate is set once, in
+//  the SDP, at ANNOUNCE. So the ONLY way to change it is to build a new SDP -
+//  i.e. reconnect. That is not a workaround for a missing message; it is the
+//  mechanism the protocol actually offers.
+//
+//  THE HOLE THIS FILLS: the frame watchdog's HOLD-IF-ALIVE branch is correct for
+//  the case it was written for - the host paused its encoder (Windows sign-in →
+//  secure desktop) while its control loop keeps ACKing, so tearing down would
+//  kill the session just as the desktop returns. It holds and re-requests an IDR
+//  every tick. But that hold is UNBOUNDED, and for a different failure it is
+//  unproductive forever: when the path cannot carry the negotiated bitrate,
+//  frames arrive and none survive FEC, so every IDR we ask for is itself shredded
+//  on the way in. A captured tunnel session sat in exactly this state for 15
+//  straight minutes - bits arriving at 13-32 fps, ZERO decoded frames, ~2500
+//  RFI/min - because nothing in the loop could lower the rate that was the
+//  actual problem. This controller is the escalation tier that ends that hold.
+//
+//  SIGNATURE IT KEYS ON (deliberately narrow): reception healthy + decode silent.
+//  That is `receiveIdle` small (bits ARE arriving, so the link is not dead - a
+//  dead link is ENet dead-peer detection's job) AND `decodeIdle` large (none of
+//  them are usable). The watchdog already computes both, and already folds the
+//  decode GATE into decodeIdle via
+//  `min(secondsSinceLastDecodedFrame, secondsSinceDecodeGateLifted)` - so a
+//  hidden window, which legitimately decodes nothing, can never trip this.
+//
+//  SAFETY CONTRACT:
+//   1. REMOTE ONLY. A LAN that cannot carry its own negotiated rate is a
+//      different fault (bad cable, duplex mismatch, a host that is overcommitted)
+//      and lowering the ask would mask it. Gated on the resolved remoteness from
+//      StreamPathMTU, not a guess.
+//   2. BOUNDED. `maxDownshifts` per session, hard stop. It can walk the rate
+//      down, never into a hole - and never below `floorKbps`.
+//   3. CANNOT OSCILLATE. There is no automatic UPshift. Recovering the original
+//      quality needs a new session, which is the honest contract: we cannot
+//      measure headroom we are not using, so "try higher again" would be a guess
+//      that costs another reconnect to walk back. One-way, by construction.
+//   4. COOLDOWN. After a downshift, `cooldownSeconds` must pass before another
+//      is considered - long enough for the reconnect to complete and the new
+//      rate to actually be exercised, so we never stack two downshifts on one
+//      episode's evidence.
+//   5. NO-OP WHEN CLEAN. A session that never stalls never touches this; the
+//      controller holds its initial state and costs one comparison per watchdog
+//      tick.
+//
+//  THREADING: owned by StreamSession and touched only from the session actor
+//  (the watchdog's per-tick hop). A value type with no shared state.
+//
+
+import Foundation
+
+/// Policy + budget for walking the session bitrate down when a remote path
+/// demonstrably cannot carry the negotiated rate. Pure: `evaluate` decides,
+/// `recordDownshift` books it. Wiring lives in StreamSession+Watchdog.
+struct BitrateDownshiftController: Sendable {
+
+    // MARK: - Policy
+
+    /// How many downshifts one session may perform. Two steps at `stepFactor`
+    /// walk a rate to ~36% of the original, which spans the gap between "a
+    /// tunnel that is a bit tight" and "a tunnel carrying a fifth of the ask".
+    /// Past that the link is not a bitrate problem and another reconnect is just
+    /// churn the user pays for.
+    static let maxDownshifts = 2
+
+    /// Multiplier per step. 0.6 is a decisive cut, not a nibble - a 10-15% trim
+    /// would cost a reconnect and still leave the path overrun, which is the
+    /// worst of both. Two steps: 1.0 → 0.6 → 0.36.
+    static let stepFactor = 0.6
+
+    /// Never advertise below this. Under it the stream is not worth resuming and
+    /// the honest outcome is the existing teardown path, not an unwatchable
+    /// trickle.
+    static let floorKbps = 10_000
+
+    /// How long the decode-only stall must persist before the FIRST downshift.
+    /// Comfortably past `decodeStallRecoveryThreshold` (2s) so the cheap fix -
+    /// the IDR nudge, which resolves the host-paused-encoder case - gets a full
+    /// chance first. Only once IDRs have plainly failed is the rate implicated.
+    static let stallSecondsBeforeDownshift: Double = 20.0
+
+    /// Quiet window after a downshift before another may be considered. Covers
+    /// the reconnect episode itself plus enough streaming at the new rate to
+    /// judge it, so two downshifts can never fire on one episode's evidence.
+    static let cooldownSeconds: Double = 90.0
+
+    // MARK: - State
+
+    /// Downshifts performed this session.
+    private(set) var downshiftCount = 0
+
+    /// Monotonic seconds of the last downshift; nil until the first.
+    private var lastDownshiftUptime: Double?
+
+    // MARK: - Decision
+
+    /// Why a downshift was declined - carried so the caller can log the honest
+    /// reason once per episode instead of a bare "no".
+    enum Decision: Equatable, Sendable {
+        /// Downshift now, to this advertised bitrate (kbps).
+        case downshift(toKbps: Int)
+        /// Not a remote path - a LAN that cannot carry its rate is a different fault.
+        case notRemote
+        /// The stall has not persisted long enough to implicate the bitrate.
+        case tooEarly
+        /// Bits are not arriving either - a dead link, owned by dead-peer detection.
+        case receptionAlsoDead
+        /// Still inside the post-downshift cooldown.
+        case coolingDown
+        /// Session budget spent, or the next step would breach the floor.
+        case budgetExhausted
+    }
+
+    /// Decide whether to downshift. `nowUptime` is a monotonic clock
+    /// (ProcessInfo.systemUptime); `decodeIdle`/`receiveIdle` come straight from
+    /// the frame watchdog, where decodeIdle already folds in the decode gate.
+    func evaluate(
+        isRemote: Bool,
+        decodeIdle: Double,
+        receiveIdle: Double,
+        currentKbps: Int,
+        nowUptime: Double
+    ) -> Decision {
+        guard isRemote else { return .notRemote }
+        // Bits must be ARRIVING. Reception dead means the link is gone, which is
+        // ENet dead-peer detection's call, not a bitrate decision.
+        guard receiveIdle.isFinite,
+              receiveIdle < Self.stallSecondsBeforeDownshift else {
+            return .receptionAlsoDead
+        }
+        guard decodeIdle >= Self.stallSecondsBeforeDownshift else { return .tooEarly }
+        if let last = lastDownshiftUptime,
+           nowUptime - last < Self.cooldownSeconds {
+            return .coolingDown
+        }
+        guard downshiftCount < Self.maxDownshifts else { return .budgetExhausted }
+        let next = Int((Double(currentKbps) * Self.stepFactor).rounded())
+        guard next >= Self.floorKbps, next < currentKbps else { return .budgetExhausted }
+        return .downshift(toKbps: next)
+    }
+
+    /// Book a downshift that actually happened. Only the caller knows whether the
+    /// reconnect was really initiated, so the budget is spent here, not in
+    /// `evaluate`.
+    mutating func recordDownshift(atUptime: Double) {
+        downshiftCount += 1
+        lastDownshiftUptime = atUptime
+    }
+
+    /// Forget the cooldown/budget for a brand-new session. The controller is
+    /// per-session state; a fresh stream starts with a full budget.
+    mutating func resetForNewSession() {
+        downshiftCount = 0
+        lastDownshiftUptime = nil
+    }
+}

--- a/Glimmer/Stream/BitrateDownshiftController.swift
+++ b/Glimmer/Stream/BitrateDownshiftController.swift
@@ -151,15 +151,15 @@ struct BitrateDownshiftController: Sendable {
     /// Book a downshift that actually happened. Only the caller knows whether the
     /// reconnect was really initiated, so the budget is spent here, not in
     /// `evaluate`.
+    ///
+    /// There is deliberately no `reset`: the budget is per-session by
+    /// CONSTRUCTION, because `StreamSession` is built fresh for every stream
+    /// launch (AppModel+Streaming) and this is one of its stored properties. A
+    /// reconnect - including a downshift's own - reuses the same session, which
+    /// is exactly right: the budget must survive it, or a link that keeps
+    /// failing would downshift forever.
     mutating func recordDownshift(atUptime: Double) {
         downshiftCount += 1
         lastDownshiftUptime = atUptime
-    }
-
-    /// Forget the cooldown/budget for a brand-new session. The controller is
-    /// per-session state; a fresh stream starts with a full budget.
-    mutating func resetForNewSession() {
-        downshiftCount = 0
-        lastDownshiftUptime = nil
     }
 }

--- a/Glimmer/Stream/Native/SdpCodec.swift
+++ b/Glimmer/Stream/Native/SdpCodec.swift
@@ -304,7 +304,21 @@ struct SdpBuilder {
         // min(..., adjustedBitrate) keeps the floor at/below the peak even for a
         // very low configured bitrate (where 10 Mbps could otherwise exceed it
         // and invert the range).
-        let minBitrate = min(max(10_000, adjustedBitrate / 2), adjustedBitrate)
+        //
+        // REMOTE FLOOR: half-peak is a sane LAN floor - the link can carry the
+        // peak, so VQOS only needs trim room. On a REMOTE path that same floor
+        // can EXCEED what the path delivers, which leaves the host no legal rate
+        // that fits: an 84 Mbps ask yields a 33.6 Mbps floor, and a captured
+        // tunnel session sustained 6-14 Mbps of goodput against it - so every
+        // rate VQOS was permitted to choose overran the link and the encoder had
+        // no way down. On remote, drop the floor to a genuinely deliverable rate
+        // instead of anchoring it to the (unreachable) peak.
+        //
+        // The CEILING is untouched, so an abundant remote link (fast fibre + a
+        // VPN) still climbs exactly as high as it did before. This only ever
+        // widens the range DOWNWARD - it never forces a lower rate, it just
+        // stops forbidding one.
+        let minBitrate = config.vqosFloorKbps(peakKbps: adjustedBitrate)
         attrs.append(("x-nv-vqos[0].bw.minimumBitrateKbps", "\(minBitrate)"))
         attrs.append(("x-nv-vqos[0].bw.maximumBitrateKbps", "\(adjustedBitrate)"))
         attrs.append(("x-ml-video.configuredBitrateKbps", "\(config.bitrate)"))

--- a/Glimmer/Stream/Native/SdpCodec.swift
+++ b/Glimmer/Stream/Native/SdpCodec.swift
@@ -258,9 +258,15 @@ struct SdpBuilder {
         // sizing happen without IP_DONTFRAG (which would hard-fail oversized
         // packets instead of letting them fragment). LAN sessions keep the
         // full configured size.
-        let advertisedPacketSize = config.streamingRemotely == 1
-            ? min(config.packetSize, 1024) : config.packetSize
-        attrs.append(("x-nv-video[0].packetSize", "\(advertisedPacketSize)"))
+        //
+        // `streamingRemotely` is now RESOLVED at connect (StreamSession
+        // .makeBackendConfig runs StreamPathMTU.probe for `.auto`), so this
+        // branch actually fires on a tunnelled path instead of never - see
+        // StreamPathMTU.swift for why it was dead. When the probe also read the
+        // egress MTU, the clamp tightens further for a path narrower than the
+        // ~1280 the flat 1024 assumes (this machine has utun interfaces at MTU
+        // 1000); pathMTU == 0 means "unreadable" and keeps the flat 1024.
+        attrs.append(("x-nv-video[0].packetSize", "\(config.advertisedVideoPacketSize)"))
         attrs.append(("x-nv-video[0].rateControlMode", "4"))
         attrs.append(("x-nv-video[0].timeoutLengthMs", "7000"))
         // framesWithInvalidRefThreshold "0" is the moonlight-common-c default,
@@ -281,7 +287,7 @@ struct SdpBuilder {
         // than it can sustain, and the minimumBitrateKbps floor below still gives
         // VQOS room to drop under loss.
         var adjustedBitrate = Int(Double(config.bitrate) * 0.80)
-        if config.streamingRemotely == 1 {
+        if config.isRemoteSession {
             if adjustedBitrate > 500 { adjustedBitrate -= 500 }
         }
         if adjustedBitrate > 200_000 { adjustedBitrate = 200_000 }
@@ -307,7 +313,7 @@ struct SdpBuilder {
         attrs.append(("x-nv-vqos[0].videoQualityScoreUpdateTime", "5000"))
 
         // qosTrafficType: LOCAL → "5"/"4"; remote → "0"/"0".
-        if config.streamingRemotely == 1 {
+        if config.isRemoteSession {
             attrs.append(("x-nv-vqos[0].qosTrafficType", "0"))
             attrs.append(("x-nv-aqos.qosTrafficType", "0"))
         } else {

--- a/Glimmer/Stream/Native/SdpCodec.swift
+++ b/Glimmer/Stream/Native/SdpCodec.swift
@@ -259,14 +259,14 @@ struct SdpBuilder {
         // packets instead of letting them fragment). LAN sessions keep the
         // full configured size.
         //
-        // `streamingRemotely` is now RESOLVED at connect (StreamSession
-        // .makeBackendConfig runs StreamPathMTU.probe for `.auto`), so this
-        // branch actually fires on a tunnelled path instead of never - see
-        // StreamPathMTU.swift for why it was dead. When the probe also read the
-        // egress MTU, the clamp tightens further for a path narrower than the
-        // ~1280 the flat 1024 assumes (this machine has utun interfaces at MTU
-        // 1000); pathMTU == 0 means "unreadable" and keeps the flat 1024.
-        attrs.append(("x-nv-video[0].packetSize", "\(config.advertisedVideoPacketSize)"))
+        // The clamp is APPLIED UPSTREAM now, in StreamSession.makeBackendConfig,
+        // so `config.packetSize` is already the resolved value and this line
+        // simply echoes it. That is deliberate and load-bearing: the same number
+        // has to reach the host, the receive buffer, AND the Reed-Solomon shard
+        // length the FEC reconstructor rebuilds recovered packets at. Advertising
+        // one size while reconstructing at another corrupts every FEC-recovered
+        // frame (see makeBackendConfig).
+        attrs.append(("x-nv-video[0].packetSize", "\(config.packetSize)"))
         attrs.append(("x-nv-video[0].rateControlMode", "4"))
         attrs.append(("x-nv-video[0].timeoutLengthMs", "7000"))
         // framesWithInvalidRefThreshold "0" is the moonlight-common-c default,

--- a/Glimmer/Stream/Native/SdpCodec.swift
+++ b/Glimmer/Stream/Native/SdpCodec.swift
@@ -293,34 +293,33 @@ struct SdpBuilder {
         if adjustedBitrate > 200_000 { adjustedBitrate = 200_000 }
         attrs.append(("x-nv-video[0].initialBitrateKbps", "\(adjustedBitrate)"))
         attrs.append(("x-nv-video[0].initialPeakBitrateKbps", "\(adjustedBitrate)"))
-        // Give Sunshine's host-side VQOS a RANGE to adapt within instead of
-        // pinning min==max (which left it no room to drop bitrate when it
-        // detects loss - the bandwidth estimator could only hold or stall). The
-        // floor is half the peak, never below 10 Mbps, so the host can step the
-        // encoder down under sustained loss and recover frame delivery rather
-        // than shipping a fixed rate into a degraded path. This is host-driven
-        // ABR only - there is no client→host bitrate message in this profile, so
-        // the client never drives the rate; we just widen the advertised window.
-        // min(..., adjustedBitrate) keeps the floor at/below the peak even for a
-        // very low configured bitrate (where 10 Mbps could otherwise exceed it
-        // and invert the range).
+        // THERE IS NO HOST-SIDE ABR. This range was previously described here as
+        // giving "Sunshine's host-side VQOS a RANGE to adapt within" so it could
+        // "step the encoder down under sustained loss". That is not true, and it
+        // was checked against Sunshine's source rather than inferred:
         //
-        // REMOTE FLOOR: half-peak is a sane LAN floor - the link can carry the
-        // peak, so VQOS only needs trim room. On a REMOTE path that same floor
-        // can EXCEED what the path delivers, which leaves the host no legal rate
-        // that fits: an 84 Mbps ask yields a 33.6 Mbps floor, and a captured
-        // tunnel session sustained 6-14 Mbps of goodput against it - so every
-        // rate VQOS was permitted to choose overran the link and the encoder had
-        // no way down. On remote, drop the floor to a genuinely deliverable rate
-        // instead of anchoring it to the (unreachable) peak.
+        //   * `minimumBitrateKbps` appears ZERO times in the whole Sunshine tree
+        //     - it is never parsed, so the floor we send here is inert.
+        //   * `cmd_announce` (src/rtsp.cpp) reads
+        //     `x-nv-vqos[0].bw.maximumBitrateKbps` into `config.monitor.bitrate`
+        //     and then OVERWRITES it with `x-ml-video.configuredBitrateKbps`
+        //     when that is non-zero - which we always send. So the number the
+        //     host actually encodes at is the raw configured bitrate below, not
+        //     the 0.80-adjusted peak (this matches moonlight, which sends the
+        //     same pair).
+        //   * Nothing in Sunshine mutates the bitrate after ANNOUNCE.
         //
-        // The CEILING is untouched, so an abundant remote link (fast fibre + a
-        // VPN) still climbs exactly as high as it did before. This only ever
-        // widens the range DOWNWARD - it never forces a lower rate, it just
-        // stops forbidding one.
-        let minBitrate = config.vqosFloorKbps(peakKbps: adjustedBitrate)
+        // So the encoder rate is FIXED for the session, and the only lever that
+        // changes it is a new SDP - i.e. a reconnect (BitrateDownshiftController).
+        // The attributes stay because they are part of the wire format moonlight
+        // sends and the host parses one of them; they are not a control channel.
+        // The floor keeps its original shape - half the peak, never below 10
+        // Mbps, never above the peak so the range can't invert on a very low
+        // configured bitrate - purely so the SDP stays well-formed.
+        let minBitrate = min(max(10_000, adjustedBitrate / 2), adjustedBitrate)
         attrs.append(("x-nv-vqos[0].bw.minimumBitrateKbps", "\(minBitrate)"))
         attrs.append(("x-nv-vqos[0].bw.maximumBitrateKbps", "\(adjustedBitrate)"))
+        // THE number Sunshine actually encodes at (it overwrites the max above).
         attrs.append(("x-ml-video.configuredBitrateKbps", "\(config.bitrate)"))
 
         attrs.append(("x-nv-vqos[0].fec.enable", "1"))

--- a/Glimmer/Stream/Native/StreamPathMTU.swift
+++ b/Glimmer/Stream/Native/StreamPathMTU.swift
@@ -1,0 +1,218 @@
+//
+//  StreamPathMTU.swift
+//
+//  CONNECT-TIME PATH PROBE for the video packet-size decision.
+//
+//  WHY THIS EXISTS: `StreamConfig.packetSize` ships the moonlight-qt LAN default
+//  (1392), and `SdpBuilder.build` was written to clamp the ADVERTISED size back
+//  to 1024 on a remote session so a full RTP datagram fits inside common VPN
+//  path MTUs. That clamp was dead code: it tests `streamingRemotely == 1`
+//  (STREAM_CFG_REMOTE) but `StreamConfig.remoteness` defaults to `.auto`
+//  (STREAM_CFG_AUTO = 2) and nothing ever resolved it, so EVERY session - LAN or
+//  tunnelled - advertised 1392. On a 1280-MTU tunnel (Tailscale/WireGuard
+//  default) 1392 + RTP/UDP/IP + tunnel encapsulation overruns the path, so every
+//  video packet is IP-fragmented: lose either fragment and the whole packet is
+//  gone, which multiplies the pre-FEC loss rate the host's fixed parity then has
+//  to absorb. This probe resolves `.auto` from the actual egress route so the
+//  clamp fires where it was always meant to.
+//
+//  HOW: the same throwaway connected-UDP-socket trick `StreamRouteProbe` uses
+//  for `stream_link` - connect() on UDP sends NOTHING, it only asks the kernel
+//  to bind a route - then getsockname() for the kernel-chosen local address and
+//  getifaddrs() for the interface that owns it. The AF_LINK entry for that same
+//  interface carries `if_data.ifi_mtu`, so the MTU comes from the one walk we
+//  already do. No DNS (the address is the IP literal RTSP already resolved), no
+//  ioctl, no privileged call.
+//
+//  DELIBERATELY NOT `StreamRouteProbe`: that probe is telemetry-gated (built
+//  only by the exporter), runs on its own queue, and re-probes for the life of
+//  the session. This one is a single always-live syscall burst at the connect
+//  edge, because the packet-size decision is a PROTOCOL decision that has to be
+//  made before the SDP is built - it has to work with telemetry off.
+//
+//  DO NO HARM: a full-MTU (>=1500) non-tunnel route resolves to `.local` and
+//  every advertised value is byte-identical to before. Only a tunnelled or
+//  reduced-MTU path changes, and only ever downward.
+//
+
+import Darwin
+import Foundation
+import Network
+
+/// One-shot connect-time probe of the route to the host: which interface the
+/// stream's UDP will egress on, that interface's MTU, and whether it is a
+/// tunnel. All fields are `nil`/`false` when the probe cannot answer - absent
+/// knowledge stays absent and the caller falls back to the configured value,
+/// never a guess.
+struct StreamPathProbe: Sendable {
+    /// BSD interface name the route resolved to ("en0", "utun6"), nil on failure.
+    var interfaceName: String?
+    /// The egress interface's MTU in bytes, nil when unreadable.
+    var mtu: Int?
+    /// utun*/ipsec*/ppp* - the kernel routed us through a tunnel.
+    var isTunnel: Bool = false
+
+    /// True when this path should be treated as a remote/Internet session:
+    /// a tunnel, or any route whose MTU is below standard Ethernet. Both mean
+    /// a LAN-tuned 1392-byte video packet no longer fits.
+    var isRemotePath: Bool {
+        if isTunnel { return true }
+        if let mtu, mtu < StreamPathMTU.standardEthernetMTU { return true }
+        return false
+    }
+}
+
+enum StreamPathMTU {
+
+    /// Standard Ethernet MTU. At or above this on a non-tunnel interface we are
+    /// on a LAN and the configured (1392) packet size stands.
+    static let standardEthernetMTU = 1500
+
+    /// Per-datagram bytes that ride ABOVE the advertised video packet payload,
+    /// budgeted worst-case so the clamp can never under-count:
+    ///   IPv6 header 40 (IPv4 is 20) + UDP 8 + RTP 12-16 + the NV video packet
+    ///   header + AES-GCM tag/IV when video encryption is on (encryption
+    ///   defaults to `.all`), plus slack for a second encapsulation.
+    /// Deliberately generous - overshooting costs a few bytes of payload per
+    /// packet; undershooting costs a fragmented packet, which is the bug.
+    static let datagramOverheadBudget = 128
+
+    /// moonlight-common-c's Internet packet size, and the value `SdpBuilder`
+    /// already documented as the remote clamp. Proven on real WAN paths.
+    static let remotePacketSize = 1024
+
+    /// Never advertise a payload smaller than this, however small the probed
+    /// MTU: below it the per-packet header overhead dominates and the host's
+    /// FEC blocks get pathological. A path this narrow cannot carry a stream
+    /// well regardless, and the honest failure is a bad stream, not a
+    /// misconfigured one.
+    static let minimumPacketSize = 512
+
+    /// The port is irrelevant to route selection (connect() on UDP only picks
+    /// the egress interface), so the discard port keeps the intent obvious.
+    private static let probePort: UInt16 = 9
+
+    /// Resolve the egress interface + MTU for `host`. `host` must be an IP
+    /// literal (the address RTSP already resolved); a hostname yields an empty
+    /// probe rather than a blocking lookup.
+    static func probe(host: String) -> StreamPathProbe {
+        guard let (dest, len, family) = UdpPinger.makeSockaddr(
+            for: NWEndpoint.Host(host), port: probePort) else {
+            return StreamPathProbe()
+        }
+        guard let local = connectedLocalAddress(dest: dest, len: len, family: family),
+              let name = interfaceName(matching: local) else {
+            return StreamPathProbe()
+        }
+        return StreamPathProbe(interfaceName: name,
+                               mtu: mtu(ofInterface: name),
+                               isTunnel: isTunnelName(name))
+    }
+
+    /// What we should ADVERTISE to the host given the configured size, whether
+    /// the session resolved to remote, and the probed egress MTU (nil when
+    /// unreadable). Returns `configured` unchanged on a LAN; on a remote path
+    /// clamps to the moonlight remote size and, if the probed MTU is narrower
+    /// still, to what that MTU can actually carry unfragmented.
+    static func advertisedPacketSize(
+        configured: Int, isRemote: Bool, mtu: Int?
+    ) -> Int {
+        guard isRemote else { return configured }
+        var size = min(configured, remotePacketSize)
+        if let mtu {
+            size = min(size, mtu - datagramOverheadBudget)
+        }
+        return max(minimumPacketSize, size)
+    }
+
+    // MARK: - Syscall plumbing
+
+    /// connect() a throwaway UDP socket (sends nothing) → getsockname() for the
+    /// local address the kernel picked for this destination.
+    private static func connectedLocalAddress(
+        dest: sockaddr_storage, len: socklen_t, family: Int32
+    ) -> sockaddr_storage? {
+        var destCopy = dest
+        let fd = socket(family, SOCK_DGRAM, 0)
+        guard fd >= 0 else { return nil }
+        defer { close(fd) }
+        let connected = withUnsafePointer(to: &destCopy) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, len) == 0
+            }
+        }
+        // EHOSTUNREACH/ENETDOWN here is itself signal: there is no route to the
+        // host right now. Honest answer is "unknown", so the caller keeps the
+        // configured size rather than clamping on a guess.
+        guard connected else { return nil }
+        var local = sockaddr_storage()
+        var localLen = socklen_t(MemoryLayout<sockaddr_storage>.size)
+        let got = withUnsafeMutablePointer(to: &local) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &localLen) == 0
+            }
+        }
+        return got ? local : nil
+    }
+
+    /// Walk getifaddrs for the interface owning `local`'s address.
+    private static func interfaceName(matching local: sockaddr_storage) -> String? {
+        var list: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&list) == 0, let first = list else { return nil }
+        defer { freeifaddrs(list) }
+        var cursor: UnsafeMutablePointer<ifaddrs>? = first
+        while let ifa = cursor {
+            defer { cursor = ifa.pointee.ifa_next }
+            guard let addr = ifa.pointee.ifa_addr,
+                  addr.pointee.sa_family == local.ss_family,
+                  sameAddress(addr, local) else { continue }
+            return String(cString: ifa.pointee.ifa_name)
+        }
+        return nil
+    }
+
+    /// The MTU lives on the interface's AF_LINK entry (`if_data.ifi_mtu`), a
+    /// second pass over the same list the name match walked.
+    private static func mtu(ofInterface name: String) -> Int? {
+        var list: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&list) == 0, let first = list else { return nil }
+        defer { freeifaddrs(list) }
+        var cursor: UnsafeMutablePointer<ifaddrs>? = first
+        while let ifa = cursor {
+            defer { cursor = ifa.pointee.ifa_next }
+            guard String(cString: ifa.pointee.ifa_name) == name,
+                  let addr = ifa.pointee.ifa_addr,
+                  Int32(addr.pointee.sa_family) == AF_LINK,
+                  let data = ifa.pointee.ifa_data else { continue }
+            let mtu = data.assumingMemoryBound(to: if_data.self).pointee.ifi_mtu
+            return mtu > 0 ? Int(mtu) : nil
+        }
+        return nil
+    }
+
+    /// Compare the address bytes of one getifaddrs entry against the probed
+    /// local address. Raw byte offsets (sin_addr at +4, sin6_addr at +8) avoid
+    /// re-binding the C structs just to read 4/16 bytes. Mirrors
+    /// `StreamRouteProbe.sameAddress`.
+    private static func sameAddress(_ ifaceAddr: UnsafePointer<sockaddr>,
+                                    _ local: sockaddr_storage) -> Bool {
+        var localCopy = local
+        return withUnsafeBytes(of: &localCopy) { localRaw -> Bool in
+            guard let localBase = localRaw.baseAddress else { return false }
+            let ifaceRaw = UnsafeRawPointer(ifaceAddr)
+            switch Int32(local.ss_family) {
+            case AF_INET:
+                return memcmp(ifaceRaw + 4, localBase + 4, 4) == 0
+            case AF_INET6:
+                return memcmp(ifaceRaw + 8, localBase + 8, 16) == 0
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Same tunnel prefixes `StreamRouteProbe.classify` treats as "tunnel".
+    private static func isTunnelName(_ name: String) -> Bool {
+        name.hasPrefix("utun") || name.hasPrefix("ipsec") || name.hasPrefix("ppp")
+    }
+}

--- a/Glimmer/Stream/Native/StreamPathMTU.swift
+++ b/Glimmer/Stream/Native/StreamPathMTU.swift
@@ -162,7 +162,44 @@ final class RttSampler: @unchecked Sendable {
     }
 }
 
+/// What the connect-time gate actually decided, latched for the telemetry
+/// exporter. This exists because the per-session diagnostic log
+/// (`glimmer-<ts>.log`) does not begin capturing until the backend starts
+/// connecting - every `Diag` line emitted while the config is still being built,
+/// including this gate's and the pre-existing "Stream config:" line, lands in a
+/// blind spot. The gate now silently changes picture quality, so leaving its
+/// decision unrecorded in the durable artifact is not acceptable: it cost an
+/// hour of "did it even fire?" the first time.
+struct LinkGateDecision: Sendable {
+    var interfaceName: String?
+    var mtu: Int?
+    var isTunnel: Bool
+    var rtt: RttStats?
+    var configuredBitrateKbps: Int
+    var askedBitrateKbps: Int
+    var packetSize: Int
+}
+
 enum StreamPathMTU {
+
+    // MARK: - Gate decision latch (see LinkGateDecision)
+
+    nonisolated(unsafe) private static var latchedGate: LinkGateDecision?
+    private static let gateLock = NSLock()
+
+    /// Latch the decision at the connect edge, BEFORE the exporter exists.
+    /// One writer, at a rare lifecycle edge - the `StreamRouteProbe.latchHost`
+    /// discipline.
+    static func latchGateDecision(_ decision: LinkGateDecision) {
+        gateLock.lock(); latchedGate = decision; gateLock.unlock()
+    }
+
+    /// The decision for the session being connected, read once by the exporter's
+    /// config-event writer. nil before the first connect this process run.
+    static var currentGateDecision: LinkGateDecision? {
+        gateLock.lock(); defer { gateLock.unlock() }
+        return latchedGate
+    }
 
     /// Standard Ethernet MTU. At or above this on a non-tunnel interface we are
     /// on a LAN and the configured (1392) packet size stands.

--- a/Glimmer/Stream/Native/StreamPathMTU.swift
+++ b/Glimmer/Stream/Native/StreamPathMTU.swift
@@ -81,15 +81,6 @@ enum StreamPathMTU {
     /// already documented as the remote clamp. Proven on real WAN paths.
     static let remotePacketSize = 1024
 
-    /// The VQOS bitrate FLOOR advertised on a remote session (kbps). Not a cap
-    /// and not a target - it is the lowest rate the host is PERMITTED to fall
-    /// back to. The LAN floor is anchored to half the peak, which on a remote
-    /// path can sit above what the path actually delivers and leave the encoder
-    /// no legal way down (see SdpBuilder). 5 Mbps carries 720p60 comfortably, so
-    /// it is a real fallback rather than a token one, and the host only ever
-    /// descends this far if its own estimator says the link needs it.
-    static let remoteMinimumBitrateKbps = 5_000
-
     /// Never advertise a payload smaller than this, however small the probed
     /// MTU: below it the per-packet header overhead dominates and the host's
     /// FEC blocks get pathological. A path this narrow cannot carry a stream

--- a/Glimmer/Stream/Native/StreamPathMTU.swift
+++ b/Glimmer/Stream/Native/StreamPathMTU.swift
@@ -51,14 +51,114 @@ struct StreamPathProbe: Sendable {
     var mtu: Int?
     /// utun*/ipsec*/ppp* - the kernel routed us through a tunnel.
     var isTunnel: Bool = false
+    /// Latency distribution to the host, from TCP handshakes (SYN → SYN-ACK is
+    /// exactly one RTT). nil when unmeasured or unreachable.
+    var rtt: RttStats?
+
+    /// The single number the gate bands on: the TAIL, not the floor. See RttStats.
+    var rttMs: Double? { rtt?.p95Ms }
 
     /// True when this path should be treated as a remote/Internet session:
-    /// a tunnel, or any route whose MTU is below standard Ethernet. Both mean
-    /// a LAN-tuned 1392-byte video packet no longer fits.
+    /// a tunnel, a route whose MTU is below standard Ethernet, or an RTT no
+    /// local network produces. Any of the three means a LAN-tuned 1392-byte
+    /// video packet no longer fits and a LAN-tuned bitrate is not defensible.
     var isRemotePath: Bool {
         if isTunnel { return true }
         if let mtu, mtu < StreamPathMTU.standardEthernetMTU { return true }
+        if let rttMs, rttMs >= StreamPathMTU.localRttCeilingMs { return true }
         return false
+    }
+}
+
+/// A latency distribution measured before ANNOUNCE. `min` is the closest thing
+/// to the path's true propagation delay (a sample can only ever be inflated by
+/// queueing, never deflated below the wire time); `p95` is the TAIL, which is
+/// what actually hurts a stream - a link with min 20 ms and p95 200 ms is badly
+/// bufferbloated and will stutter, and judging it by `min` alone would hide
+/// that. The gate bands on p95 for exactly that reason; min and p50 are carried
+/// for diagnosis and to make bloat visible as the spread between them.
+struct RttStats: Sendable, Equatable {
+    var minMs: Double
+    var p50Ms: Double
+    var p95Ms: Double
+    var count: Int
+
+    /// Nil for an empty sample set - absent knowledge stays absent.
+    init?(samples: [Double]) {
+        guard !samples.isEmpty else { return nil }
+        let sorted = samples.sorted()
+        func percentile(_ quantile: Double) -> Double {
+            let idx = Int((Double(sorted.count - 1) * quantile).rounded())
+            return sorted[max(0, min(sorted.count - 1, idx))]
+        }
+        minMs = sorted[0]
+        p50Ms = percentile(0.50)
+        p95Ms = percentile(0.95)
+        count = sorted.count
+    }
+
+    /// How much worse the tail is than the floor. >2x on a path whose floor is
+    /// already high is the bufferbloat signature.
+    var tailRatio: Double { minMs > 0 ? p95Ms / minMs : 1 }
+}
+
+/// Samples RTT continuously on a background queue for the life of the
+/// pre-connect window, so the measurement rides wall-clock we are ALREADY
+/// spending (the /launch round trip alone measured 1383 ms, RTSP another ~960 ms)
+/// instead of adding any. Start it right after /serverinfo; harvest it just
+/// before the SDP is built.
+///
+/// THREADING: `start`/`harvest` are called from the session actor; the sampling
+/// loop owns its own queue and the sample array is lock-guarded.
+final class RttSampler: @unchecked Sendable {
+    private let host: String
+    private let port: UInt16
+    private let queue = DispatchQueue(label: "io.ugfugl.Glimmer.rttSampler", qos: .utility)
+    private let lock = NSLock()
+    private var samples: [Double] = []
+    private var stopped = false
+
+    /// Gap between handshakes. Loose enough that we are not hammering the host's
+    /// web port, tight enough to accumulate a usable distribution across a
+    /// ~1-2 s pre-connect window.
+    private static let intervalMs: UInt32 = 60
+    /// Hard cap so a pathologically slow launch can't sample forever.
+    private static let maxSamples = 40
+
+    /// Starts sampling immediately - there is no useful window between
+    /// construction and the first sample, and the loop captures self WEAKLY, so
+    /// the sampler going out of scope (an early throw on the connect path) ends
+    /// it on the next iteration without any explicit teardown.
+    init(host: String, port: UInt16) {
+        self.host = host
+        self.port = port
+        start()
+    }
+
+    private func start() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            while true {
+                lock.lock()
+                let done = stopped || samples.count >= Self.maxSamples
+                lock.unlock()
+                if done { return }
+                if let sample = StreamPathMTU.measureOneRttMs(host: host, port: port) {
+                    lock.lock(); samples.append(sample); lock.unlock()
+                }
+                usleep(Self.intervalMs * 1000)
+            }
+        }
+    }
+
+    /// Stop sampling and return the distribution gathered so far (nil if the
+    /// probe never succeeded - e.g. a host that refuses the port).
+    func harvest() -> RttStats? {
+        lock.lock()
+        stopped = true
+        let collected = samples
+        lock.unlock()
+        return RttStats(samples: collected)
     }
 }
 
@@ -88,14 +188,77 @@ enum StreamPathMTU {
     /// misconfigured one.
     static let minimumPacketSize = 512
 
+    /// Above this RTT we are not on a local network, whatever the interface
+    /// says. Wired LAN round-trips land at 0.5-2 ms and LAN wifi at 2-10 ms;
+    /// anything at or beyond 10 ms has left the building. Used both to classify
+    /// the path and as the first band of the bitrate ceiling below.
+    static let localRttCeilingMs: Double = 10
+
+    /// RTT → fraction of the demand-based bitrate we are willing to ASK FOR.
+    ///
+    /// RTT is not a capacity measurement and this does not pretend to be one.
+    /// It is a RISK gate, and it is defensible on its own terms:
+    ///   * The demand-based anchors in QualityCalculator (84 Mbps at
+    ///     3024x1964@120) were measured on a LAN harness. Asking for a
+    ///     LAN-measured rate over a 50 ms path is not a considered choice, it is
+    ///     just the absence of one.
+    ///   * Higher RTT means more hops and a higher chance of a shared or
+    ///     congested segment - the paths that actually drop bursts.
+    ///   * Loss costs MORE at high RTT: an RFI/IDR recovery round trip scales
+    ///     with RTT, so at 50 ms a single reference break is ~100 ms of damaged
+    ///     output - 12 frames at 120fps. The same loss rate hurts proportionally
+    ///     more the further away the host is, so backing off the rate that
+    ///     PRODUCES the loss is the right direction.
+    ///
+    /// Sanity-checked against the field: on a ~50 ms tunnel this yields 0.50,
+    /// i.e. 84 -> 42 Mbps, and the host's encoder was independently measured
+    /// running at 37-50 Mbps on that same path. The ceiling lands where reality
+    /// already was, so it costs nothing that was actually being delivered.
+    static func bitrateCeilingFraction(rttMs: Double?) -> Double {
+        guard let rttMs else { return 1.0 }      // unmeasured: change nothing
+        switch rttMs {
+        case ..<localRttCeilingMs: return 1.00   // LAN
+        case ..<30:                return 0.75   // same metro / good VPN
+        case ..<60:                return 0.50   // regional
+        default:                   return 0.35   // distant
+        }
+    }
+
+    /// The bitrate to ASK FOR, given the configured (demand-based) value and the
+    /// probed path. A local path returns `configured` untouched.
+    static func cappedBitrateKbps(configured: Int, path: StreamPathProbe) -> Int {
+        guard path.isRemotePath else { return configured }
+        let fraction = bitrateCeilingFraction(rttMs: path.rttMs)
+        guard fraction < 1.0 else { return configured }
+        return max(minimumBitrateKbps, Int((Double(configured) * fraction).rounded()))
+    }
+
+    /// Never ask for less than this however distant the host - below it the
+    /// stream is not worth starting, and the honest outcome is a bad stream the
+    /// user can see rather than a silently crippled one.
+    static let minimumBitrateKbps = 10_000
+
+    /// How long to wait for the RTT probe's TCP handshake before giving up.
+    /// Deliberately tight: this sits on the connect path, and an unmeasured RTT
+    /// is a safe answer (it caps nothing), so waiting is worse than not knowing.
+    private static let rttProbeTimeoutMs: Int32 = 400
+
+    /// How many handshakes to sample before taking the minimum. Three costs
+    /// ~120 ms on a 40 ms path - about 4% of the measured 3.0 s click-to-first-
+    /// frame - and a LAN exits after the first (see `sampledRttMs`).
+    private static let rttProbeSamples = 3
+
     /// The port is irrelevant to route selection (connect() on UDP only picks
     /// the egress interface), so the discard port keeps the intent obvious.
     private static let probePort: UInt16 = 9
 
-    /// Resolve the egress interface + MTU for `host`. `host` must be an IP
-    /// literal (the address RTSP already resolved); a hostname yields an empty
-    /// probe rather than a blocking lookup.
-    static func probe(host: String) -> StreamPathProbe {
+    /// Resolve the egress interface, MTU and RTT for `host`. `host` must be an
+    /// IP literal (the address RTSP already resolved); a hostname yields an
+    /// empty probe rather than a blocking lookup. `rttPort` is a TCP port the
+    /// host is known to be listening on (the RTSP port) - the handshake to it
+    /// is the RTT sample and nothing is ever sent on the connection.
+    static func probe(host: String, rttPort: UInt16? = nil,
+                      rtt preCollected: RttStats? = nil) -> StreamPathProbe {
         guard let (dest, len, family) = UdpPinger.makeSockaddr(
             for: NWEndpoint.Host(host), port: probePort) else {
             return StreamPathProbe()
@@ -104,9 +267,73 @@ enum StreamPathMTU {
               let name = interfaceName(matching: local) else {
             return StreamPathProbe()
         }
+        // Prefer the distribution the pre-connect sampler already gathered on
+        // wall-clock we were spending anyway. Only fall back to a synchronous
+        // burst when there is none (the reconnect path, which has no free
+        // window to sample across).
+        let rtt = preCollected ?? rttPort.flatMap { burstRtt(host: host, port: $0) }
         return StreamPathProbe(interfaceName: name,
                                mtu: mtu(ofInterface: name),
-                               isTunnel: isTunnelName(name))
+                               isTunnel: isTunnelName(name),
+                               rtt: rtt)
+    }
+
+    /// SYNCHRONOUS fallback for the reconnect path, which has no pre-connect
+    /// window to sample across. A handful of back-to-back handshakes - enough to
+    /// place the band, not enough for a real p95, which is precisely why the
+    /// primary path uses `RttSampler` over the free wall-clock instead.
+    ///
+    /// EARLY EXIT: if the first sample is already under the local ceiling we are
+    /// on a LAN, the gate will cap nothing, and further samples cannot change
+    /// that - so a local session pays exactly one ~1 ms handshake.
+    private static func burstRtt(host: String, port: UInt16) -> RttStats? {
+        var samples: [Double] = []
+        for _ in 0..<rttProbeSamples {
+            guard let sample = measureOneRttMs(host: host, port: port) else { continue }
+            samples.append(sample)
+            if sample < localRttCeilingMs { break }   // LAN - no cap possible
+        }
+        return RttStats(samples: samples)
+    }
+
+    /// One TCP handshake, timed. SYN → SYN-ACK is exactly one round trip, with
+    /// no TLS and no application bytes on top, so it is the cleanest RTT sample
+    /// available before ANNOUNCE - unlike timing an HTTPS request, which folds
+    /// in the TLS handshake's extra round trips and the host's own think time.
+    ///
+    /// The socket is closed immediately; no data is ever written. A failure or
+    /// timeout returns nil, which the caller treats as "unknown" and caps
+    /// nothing - never as "bad".
+    static func measureOneRttMs(host: String, port: UInt16) -> Double? {
+        guard let (dest, len, family) = UdpPinger.makeSockaddr(
+            for: NWEndpoint.Host(host), port: port) else { return nil }
+        var destCopy = dest
+        let fd = socket(family, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        defer { close(fd) }
+        // Non-blocking connect + poll, so a black-holed path costs the timeout
+        // rather than the kernel's multi-second SYN retry schedule.
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0, fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0 else { return nil }
+        let start = DispatchTime.now().uptimeNanoseconds
+        let rc = withUnsafePointer(to: &destCopy) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, len)
+            }
+        }
+        if rc != 0 {
+            guard errno == EINPROGRESS else { return nil }
+            var pfd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+            guard poll(&pfd, 1, rttProbeTimeoutMs) == 1 else { return nil }
+            // POLLOUT alone isn't success - a refused connection also wakes the
+            // poll. Ask the socket for its error before trusting the timing.
+            var soError: Int32 = 0
+            var soLen = socklen_t(MemoryLayout<Int32>.size)
+            guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &soError, &soLen) == 0,
+                  soError == 0 else { return nil }
+        }
+        let elapsed = DispatchTime.now().uptimeNanoseconds &- start
+        return Double(elapsed) / 1_000_000.0
     }
 
     /// What we should ADVERTISE to the host given the configured size, whether

--- a/Glimmer/Stream/Native/StreamPathMTU.swift
+++ b/Glimmer/Stream/Native/StreamPathMTU.swift
@@ -81,6 +81,15 @@ enum StreamPathMTU {
     /// already documented as the remote clamp. Proven on real WAN paths.
     static let remotePacketSize = 1024
 
+    /// The VQOS bitrate FLOOR advertised on a remote session (kbps). Not a cap
+    /// and not a target - it is the lowest rate the host is PERMITTED to fall
+    /// back to. The LAN floor is anchored to half the peak, which on a remote
+    /// path can sit above what the path actually delivers and leave the encoder
+    /// no legal way down (see SdpBuilder). 5 Mbps carries 720p60 comfortably, so
+    /// it is a real fallback rather than a token one, and the host only ever
+    /// descends this far if its own estimator says the link needs it.
+    static let remoteMinimumBitrateKbps = 5_000
+
     /// Never advertise a payload smaller than this, however small the probed
     /// MTU: below it the per-packet header overhead dominates and the host's
     /// FEC blocks get pathological. A path this narrow cannot carry a stream

--- a/Glimmer/Stream/StreamSession+Downshift.swift
+++ b/Glimmer/Stream/StreamSession+Downshift.swift
@@ -1,0 +1,72 @@
+//
+//  StreamSession+Downshift.swift
+//
+//  The watchdog escalation tier that ends an unproductive HOLD by lowering the
+//  session bitrate. Split out of StreamSession+Watchdog.swift to keep that file
+//  focused on detection; the POLICY (remote-only, sustained, bounded, cooled
+//  down) lives in BitrateDownshiftController, and this owns the side effects.
+//
+//  See BitrateDownshiftController for why a reconnect is the mechanism rather
+//  than a control message: bitrate is fixed per session and the SDP is the only
+//  place it is ever set, so rebuilding the SDP is the only way to change it.
+//
+
+import Foundation
+import os
+
+extension StreamSession {
+
+    /// Consider walking the bitrate down because a remote path demonstrably
+    /// cannot carry the negotiated rate. The decision (remote-only, sustained,
+    /// bounded, cooled-down) is the controller's; this owns the side effects -
+    /// rewriting the config the reconnect will rebuild from, and driving the
+    /// reconnect episode itself.
+    ///
+    /// `reconnectConfig` is the SAME value `reconnectInPlace` reads to build the
+    /// next SDP, so lowering `bitrateKbps` here IS the downshift - there is no
+    /// separate channel to push a rate through. The reconnect holds the frozen
+    /// frame, so the user sees a brief hold rather than a bounce to the launcher.
+    func considerBitrateDownshift(
+        decodeIdle: Double, receiveIdle: Double
+    ) async {
+        guard isStreaming, !stopInProgress, !isReconnecting else { return }
+        guard let current = reconnectConfig?.bitrateKbps else { return }
+
+        let decision = downshift.evaluate(
+            isRemote: isRemotePathSession,
+            decodeIdle: decodeIdle,
+            receiveIdle: receiveIdle,
+            currentKbps: current,
+            nowUptime: ProcessInfo.processInfo.systemUptime)
+
+        guard case .downshift(let toKbps) = decision else {
+            // Log the honest reason ONCE per stall episode - a declined
+            // downshift every second would bury the log.
+            if !didLogDownshiftDecision {
+                didLogDownshiftDecision = true
+                Diag.notice(
+                    "Bitrate downshift not taken (\(decision)) - stalled \(String(format: "%.0f", decodeIdle))s "
+                    + "at \(current / 1000) Mbps, remote=\(isRemotePathSession)", "Stream")
+            }
+            return
+        }
+
+        // Spend the budget BEFORE the await so a second watchdog tick landing
+        // mid-reconnect can't book a second downshift off the same evidence.
+        downshift.recordDownshift(atUptime: ProcessInfo.processInfo.systemUptime)
+        reconnectConfig?.bitrateKbps = toKbps
+        didLogDownshiftDecision = true
+
+        Diag.warn(
+            "Link cannot carry \(current / 1000) Mbps - \(String(format: "%.0f", decodeIdle))s of "
+            + "received-but-undecodable video on a remote path. Downshifting to \(toKbps / 1000) Mbps "
+            + "and reconnecting in place (step \(downshift.downshiftCount)/"
+            + "\(BitrateDownshiftController.maxDownshifts)).", "Stream")
+        log.error("""
+            Bitrate downshift: \(current, privacy: .public) → \(toKbps, privacy: .public) kbps \
+            after \(decodeIdle, privacy: .public)s decode-only stall on a remote path
+            """)
+
+        await runDownshiftReconnect(toKbps: toKbps)
+    }
+}

--- a/Glimmer/Stream/StreamSession+Reconnect.swift
+++ b/Glimmer/Stream/StreamSession+Reconnect.swift
@@ -184,7 +184,11 @@ extension StreamSession {
             let launch = try await launchWithBusyRecovery(
                 network: net, appID: appID, config: config,
                 hintCurrentGame: serverInfo.currentGameID)
-            let backendConfig = makeBackendConfig(config: config, launch: launch)
+            // Re-probe the path on reconnect: the route may have moved (the
+            // tunnel-flap case this whole clamp exists for), so remoteness and
+            // the advertised packet size are resolved fresh, never inherited.
+            let backendConfig = makeBackendConfig(
+                config: config, launch: launch, hostAddress: serverInfo.address)
             // duringReconnect: connectBackend's failure path must NOT run the
             // full stop() (that would blank the frozen frame + bounce to the
             // launcher) - it cancels the failed launch and throws so we retry.

--- a/Glimmer/Stream/StreamSession+Reconnect.swift
+++ b/Glimmer/Stream/StreamSession+Reconnect.swift
@@ -66,11 +66,35 @@ extension StreamSession {
         await runReconnectEpisode(code: code)
     }
 
+    /// SELF-INITIATED reconnect to apply a lowered bitrate (see
+    /// BitrateDownshiftController). Unlike `handleHostTerminate`, the host has
+    /// NOT closed anything - the connection is live but useless, carrying video
+    /// we cannot decode. We tear it down ourselves and rebuild from the config
+    /// the caller just rewrote.
+    ///
+    /// Reuses the same episode machinery, so the user experience is the existing
+    /// one: the frozen last frame is held under a banner while the rebuild runs,
+    /// and video resumes in place. The banner text is the one difference - this
+    /// is a deliberate quality change, not a fault, and saying so is the honest
+    /// thing to put on screen.
+    func runDownshiftReconnect(toKbps: Int) async {
+        guard isStreaming, !stopInProgress, !isReconnecting else { return }
+        // The live-but-useless connection must come down before the rebuild; the
+        // episode's first `reconnectInPlace` calls `teardownConnectionForReconnect`
+        // which is idempotent, so we do NOT pre-tear here - we just stop feeding
+        // the dead uplink, exactly as the host-terminate path does.
+        let inp = input
+        DispatchQueue.main.async { MainActor.assumeIsolated { inp?.setReady(false) } }
+        await runReconnectEpisode(
+            code: Self.deadPeerTerminationCode,
+            bannerText: "Connection is weak - lowering quality to \(toKbps / 1000) Mbps...")
+    }
+
     /// Drive a bounded reconnect episode: hold the frozen frame, retry the
     /// in-place rebuild with a short backoff until it succeeds or we exhaust the
     /// attempt/time budget, then resume (`.reconnected`) or give up (real
     /// teardown). MainActor work happens inside `reconnectInPlace`.
-    private func runReconnectEpisode(code: Int32) async {
+    private func runReconnectEpisode(code: Int32, bannerText: String = "Reconnecting...") async {
         isReconnecting = true
         reconnectAttempts = 0
         let deadline = Date().addingTimeInterval(Self.reconnectWindowSeconds)
@@ -80,11 +104,11 @@ extension StreamSession {
         // signal that we're holding rather than dead.
         let winForBanner = window
         await MainActor.run {
-            winForBanner?.reconnectBanner.setText("Reconnecting...")
+            winForBanner?.reconnectBanner.setText(bannerText)
             winForBanner?.reconnectBanner.setVisible(true)
             // VoiceOver can't reach a CALayer banner by focus - announce the
             // reconnect explicitly (the most safety-critical in-stream state).
-            AccessibilityNotification.Announcement("Reconnecting").post()
+            AccessibilityNotification.Announcement(bannerText).post()
         }
         Diag.notice(
             "Host closed the live stream (code 0x\(String(UInt32(bitPattern: code), radix: 16))) "

--- a/Glimmer/Stream/StreamSession+Reconnect.swift
+++ b/Glimmer/Stream/StreamSession+Reconnect.swift
@@ -212,7 +212,7 @@ extension StreamSession {
             // tunnel-flap case this whole clamp exists for), so remoteness and
             // the advertised packet size are resolved fresh, never inherited.
             let backendConfig = makeBackendConfig(
-                config: config, launch: launch, hostAddress: serverInfo.address)
+                config: config, launch: launch, server: serverInfo)
             // duringReconnect: connectBackend's failure path must NOT run the
             // full stop() (that would blank the frozen frame + bounce to the
             // launcher) - it cancels the failed launch and throws so we retry.

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -339,12 +339,26 @@ extension StreamSession {
         // reconnect - so a route that moved mid-session is re-judged, never
         // inherited from the original connect.
         isRemotePathSession = resolvedRemoteness == .remote
+        // ONE packet size, resolved here and used EVERYWHERE - the SDP we
+        // advertise, the receive buffer, and (load-bearing) the Reed-Solomon
+        // shard length the FEC reconstructor rebuilds recovered packets at
+        // (RtpVideoQueue+Reconstruct). Advertising one size while reconstructing
+        // at another rebuilds every FEC-recovered packet at the wrong length and
+        // feeds garbage to the decoder - visible as the purple/white HDR
+        // corruption, and ONLY on a lossy link, because a clean one never
+        // exercises FEC recovery. The receive buffer adds its own headroom on
+        // top (packetSize + 64, + MAX_RTP_HEADER_SIZE), so a smaller value is
+        // safe there; there is no case for keeping the two apart.
+        let resolvedPacketSize = StreamPathMTU.advertisedPacketSize(
+            configured: config.packetSize,
+            isRemote: resolvedRemoteness == .remote,
+            mtu: path.mtu)
         return BackendStreamConfig(
             width: Int32(config.width),
             height: Int32(config.height),
             fps: Int32(config.fps),
             bitrate: Int32(config.bitrateKbps),
-            packetSize: Int32(config.packetSize),
+            packetSize: Int32(resolvedPacketSize),
             streamingRemotely: resolvedRemoteness.cValue,
             audioConfiguration: config.audio.cValue,
             supportedVideoFormats: config.videoFormats.rawValue,
@@ -353,8 +367,7 @@ extension StreamSession {
             colorRange: config.colorRange.cValue,
             encryptionFlags: config.encryption.encryptionFlags,
             remoteInputAesKey: [UInt8](launch.gcmKey),
-            remoteInputAesIv: [UInt8](launch.gcmKeyId),
-            pathMTU: Int32(path.mtu ?? 0))
+            remoteInputAesIv: [UInt8](launch.gcmKeyId))
     }
 
     /// Emit the one-line stream-config diagnostic on the main actor (it reads

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -129,7 +129,7 @@ extension StreamSession {
         )
 
         // --- 3) Build the backend stream config -------------------------
-        let backendConfig = makeBackendConfig(config: config, launch: launch)
+        let backendConfig = makeBackendConfig(config: config, launch: launch, hostAddress: serverInfo.address)
 
         // Diagnostic so "are we actually streaming at the right refresh rate"
         // is a one-line question. requestedFps is what we tell Sunshine;
@@ -309,15 +309,39 @@ extension StreamSession {
     /// gcmKey/gcmKeyId are the 16-byte per-session AES key + IV-id from the
     /// launch handshake.
     func makeBackendConfig(
-        config: StreamConfig, launch: LaunchResponse
+        config: StreamConfig, launch: LaunchResponse, hostAddress: String
     ) -> BackendStreamConfig {
-        BackendStreamConfig(
+        // Resolve `.auto` from the route we will actually egress on. Without
+        // this, `.auto` (STREAM_CFG_AUTO = 2) never equals STREAM_CFG_REMOTE and
+        // every remote-only SDP behaviour - the 1024 packet-size clamp, the
+        // remote bitrate headroom, the remote qosTrafficType - stays dead, so a
+        // 1392-byte LAN packet gets advertised onto a 1280-MTU tunnel and every
+        // video packet fragments. An explicit .local/.remote from the caller is
+        // honoured as-is; only `.auto` consults the probe.
+        let path = config.remoteness == .auto
+            ? StreamPathMTU.probe(host: hostAddress) : StreamPathProbe()
+        let resolvedRemoteness: Remoteness
+        switch config.remoteness {
+        case .local, .remote:
+            resolvedRemoteness = config.remoteness
+        case .auto:
+            resolvedRemoteness = path.isRemotePath ? .remote : .local
+        }
+        if config.remoteness == .auto {
+            log.info("""
+                Path probe: if=\(path.interfaceName ?? "?", privacy: .public) \
+                mtu=\(path.mtu ?? -1, privacy: .public) \
+                tunnel=\(path.isTunnel, privacy: .public) \
+                → remoteness=\(resolvedRemoteness == .remote ? "remote" : "local", privacy: .public)
+                """)
+        }
+        return BackendStreamConfig(
             width: Int32(config.width),
             height: Int32(config.height),
             fps: Int32(config.fps),
             bitrate: Int32(config.bitrateKbps),
             packetSize: Int32(config.packetSize),
-            streamingRemotely: config.remoteness.cValue,
+            streamingRemotely: resolvedRemoteness.cValue,
             audioConfiguration: config.audio.cValue,
             supportedVideoFormats: config.videoFormats.rawValue,
             clientRefreshRateX100: Int32(config.fps * 100),
@@ -325,7 +349,8 @@ extension StreamSession {
             colorRange: config.colorRange.cValue,
             encryptionFlags: config.encryption.encryptionFlags,
             remoteInputAesKey: [UInt8](launch.gcmKey),
-            remoteInputAesIv: [UInt8](launch.gcmKeyId))
+            remoteInputAesIv: [UInt8](launch.gcmKeyId),
+            pathMTU: Int32(path.mtu ?? 0))
     }
 
     /// Emit the one-line stream-config diagnostic on the main actor (it reads

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -335,6 +335,10 @@ extension StreamSession {
                 → remoteness=\(resolvedRemoteness == .remote ? "remote" : "local", privacy: .public)
                 """)
         }
+        // Latch for the downshift tier. Set on EVERY build - including each
+        // reconnect - so a route that moved mid-session is re-judged, never
+        // inherited from the original connect.
+        isRemotePathSession = resolvedRemoteness == .remote
         return BackendStreamConfig(
             width: Int32(config.width),
             height: Int32(config.height),

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -108,6 +108,14 @@ extension StreamSession {
             throw StreamError.pairingFailed("Host is not paired. Use the pair sheet first.")
         }
 
+        // Start sampling latency NOW, so the distribution accumulates across the
+        // /launch + RTSP wall-clock we are about to spend anyway (measured: 1383
+        // ms and ~960 ms respectively). Harvested in makeBackendConfig just
+        // before the SDP is built, which is the last moment the bitrate can be
+        // chosen - after ANNOUNCE it is fixed for the session. Costs no added
+        // connect latency; a LAN's samples simply never trip the gate.
+        let rttSampler = RttSampler(host: serverInfo.address, port: UInt16(serverInfo.httpsPort))
+
         // --- 2) Decide launch vs. resume vs. quit-then-launch -----------
         // GameStream hosts only run one session at a time. If a previous
         // attempt left the host busy (orphan session) or someone else is
@@ -129,7 +137,8 @@ extension StreamSession {
         )
 
         // --- 3) Build the backend stream config -------------------------
-        let backendConfig = makeBackendConfig(config: config, launch: launch, hostAddress: serverInfo.address)
+        let backendConfig = makeBackendConfig(
+            config: config, launch: launch, server: serverInfo, rtt: rttSampler.harvest())
 
         // Diagnostic so "are we actually streaming at the right refresh rate"
         // is a one-line question. requestedFps is what we tell Sunshine;
@@ -309,7 +318,8 @@ extension StreamSession {
     /// gcmKey/gcmKeyId are the 16-byte per-session AES key + IV-id from the
     /// launch handshake.
     func makeBackendConfig(
-        config: StreamConfig, launch: LaunchResponse, hostAddress: String
+        config: StreamConfig, launch: LaunchResponse, server: ServerInfo,
+        rtt: RttStats? = nil
     ) -> BackendStreamConfig {
         // Resolve `.auto` from the route we will actually egress on. Without
         // this, `.auto` (STREAM_CFG_AUTO = 2) never equals STREAM_CFG_REMOTE and
@@ -319,7 +329,8 @@ extension StreamSession {
         // video packet fragments. An explicit .local/.remote from the caller is
         // honoured as-is; only `.auto` consults the probe.
         let path = config.remoteness == .auto
-            ? StreamPathMTU.probe(host: hostAddress) : StreamPathProbe()
+            ? StreamPathMTU.probe(host: server.address,
+                                  rttPort: UInt16(server.httpsPort), rtt: rtt) : StreamPathProbe()
         let resolvedRemoteness: Remoteness
         switch config.remoteness {
         case .local, .remote:
@@ -327,13 +338,36 @@ extension StreamSession {
         case .auto:
             resolvedRemoteness = path.isRemotePath ? .remote : .local
         }
+        // CONNECT-TIME QUALITY GATE. The demand-based bitrate from
+        // QualityCalculator answers "what does this resolution need?" - it was
+        // measured on a LAN harness and never asks what the PATH will deliver.
+        // Asking for a LAN-measured 84 Mbps over a 50 ms tunnel is not a
+        // considered choice, it is the absence of one. Since bitrate is fixed at
+        // ANNOUNCE (no client→host rate message exists, and the host never
+        // changes it after), choosing well HERE is the only cheap lever there is.
+        let cappedBitrateKbps = StreamPathMTU.cappedBitrateKbps(
+            configured: config.bitrateKbps, path: path)
         if config.remoteness == .auto {
             log.info("""
                 Path probe: if=\(path.interfaceName ?? "?", privacy: .public) \
                 mtu=\(path.mtu ?? -1, privacy: .public) \
                 tunnel=\(path.isTunnel, privacy: .public) \
-                → remoteness=\(resolvedRemoteness == .remote ? "remote" : "local", privacy: .public)
+                rtt=p95 \(path.rtt.map { String(format: "%.0f", $0.p95Ms) } ?? "?", privacy: .public)ms \
+                (min \(path.rtt.map { String(format: "%.0f", $0.minMs) } ?? "?", privacy: .public) \
+                p50 \(path.rtt.map { String(format: "%.0f", $0.p50Ms) } ?? "?", privacy: .public) \
+                n=\(path.rtt?.count ?? 0, privacy: .public)) \
+                → remoteness=\(resolvedRemoteness == .remote ? "remote" : "local", privacy: .public) \
+                bitrate=\(config.bitrateKbps, privacy: .public)→\(cappedBitrateKbps, privacy: .public)kbps
                 """)
+        }
+        if cappedBitrateKbps < config.bitrateKbps {
+            Diag.notice(
+                "Link quality gate: p95 \(path.rttMs.map { String(format: "%.0f", $0) } ?? "?")ms RTT "
+                + "(min \(path.rtt.map { String(format: "%.0f", $0.minMs) } ?? "?")ms, "
+                + "\(path.rtt?.count ?? 0) samples) over "
+                + "\(path.isTunnel ? "a tunnel" : "this path") - asking for "
+                + "\(cappedBitrateKbps / 1000) Mbps instead of \(config.bitrateKbps / 1000) "
+                + "(a LAN-measured rate isn't a defensible ask at this distance).", "Stream")
         }
         // Latch for the downshift tier. Set on EVERY build - including each
         // reconnect - so a route that moved mid-session is re-judged, never
@@ -357,7 +391,7 @@ extension StreamSession {
             width: Int32(config.width),
             height: Int32(config.height),
             fps: Int32(config.fps),
-            bitrate: Int32(config.bitrateKbps),
+            bitrate: Int32(cappedBitrateKbps),
             packetSize: Int32(resolvedPacketSize),
             streamingRemotely: resolvedRemoteness.cValue,
             audioConfiguration: config.audio.cValue,

--- a/Glimmer/Stream/StreamSession+Start.swift
+++ b/Glimmer/Stream/StreamSession+Start.swift
@@ -160,6 +160,7 @@ extension StreamSession {
         let setup: (StreamWindow, InputForwarder, VideoDecoder) =
             await buildStreamSubsystems(StreamSetupOptions(
                 config: config,
+                negotiatedBitrateKbps: Int(backendConfig.bitrate),
                 initialStatsOverlay: initialStatsOverlay,
                 initialStatsCorner: initialStatsCorner,
                 quitHotkeyProvider: quitHotkeyProvider,
@@ -387,6 +388,12 @@ extension StreamSession {
             configured: config.packetSize,
             isRemote: resolvedRemoteness == .remote,
             mtu: path.mtu)
+        // Latch the whole decision for the telemetry config event - the session
+        // log doesn't capture anything emitted this early (see LinkGateDecision).
+        StreamPathMTU.latchGateDecision(LinkGateDecision(
+            interfaceName: path.interfaceName, mtu: path.mtu, isTunnel: path.isTunnel,
+            rtt: path.rtt, configuredBitrateKbps: config.bitrateKbps,
+            askedBitrateKbps: cappedBitrateKbps, packetSize: resolvedPacketSize))
         return BackendStreamConfig(
             width: Int32(config.width),
             height: Int32(config.height),

--- a/Glimmer/Stream/StreamSession+StartSetup.swift
+++ b/Glimmer/Stream/StreamSession+StartSetup.swift
@@ -25,6 +25,13 @@ extension StreamSession {
     /// (the closures are `@MainActor`, matching the builder's isolation).
     struct StreamSetupOptions {
         let config: StreamConfig
+        /// The bitrate we ACTUALLY asked the host for, after the connect-time
+        /// quality gate. NOT `config.bitrateKbps`, which is the pre-gate demand
+        /// figure: reporting that one made the overlay and the
+        /// `negotiated_bitrate_mbps` telemetry claim 67.2 Mbps while the session
+        /// was really running at a gated 33.6, which is exactly the kind of lie
+        /// that costs an hour of diagnosis.
+        let negotiatedBitrateKbps: Int
         let initialStatsOverlay: Bool
         let initialStatsCorner: StatsOverlayCorner
         let quitHotkeyProvider: @MainActor () -> HotkeyChord
@@ -102,7 +109,7 @@ extension StreamSession {
         inp.controllerQuitChordProvider = options.controllerQuitChordProvider
         inp.customControllerChordProvider = options.customControllerChordProvider
         dec.statsOverlayEnabled = initialStatsOverlay
-        dec.setNegotiatedBitrateKbps(config.bitrateKbps)
+        dec.setNegotiatedBitrateKbps(options.negotiatedBitrateKbps)
         dec.setActiveAudioConfigLabel(config.audio.displayLabel)
         win.statsOverlay.corner = initialStatsCorner
         // Seed the overlay's visibility from the initial state so the

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -274,6 +274,14 @@ extension StreamSession {
                     Task { [weak self] in await self?.attemptDecodeStallRecovery(decodeIdle: decodeIdle) }
                 }
 
+                // Past the IDR nudge: bits arriving, none decoding, long enough
+                // that keyframes have plainly failed - on a remote path the rate
+                // is the only thing left to change (see +Downshift).
+                if decodeIdle >= BitrateDownshiftController.stallSecondsBeforeDownshift {
+                    Task { [weak self] in await self?.considerBitrateDownshift(
+                        decodeIdle: decodeIdle, receiveIdle: receiveIdle) }
+                }
+
                 // Hard trip: decode silent past the teardown threshold.
                 // Regardless of reception state - bytes-only-no-decode for
                 // 10s is just as broken as silent-everything from the
@@ -559,6 +567,7 @@ extension StreamSession {
         didLogDecodeOnlyStall = false
         didAttemptStallRecovery = false
         didLogWatchdogHold = false
+        didLogDownshiftDecision = false
         // Video resumed - drop the hold banner (no-op if it was never shown).
         let winForHide = window
         await MainActor.run { winForHide?.reconnectBanner.setVisible(false) }

--- a/Glimmer/Stream/StreamSession.swift
+++ b/Glimmer/Stream/StreamSession.swift
@@ -257,6 +257,20 @@ public actor StreamSession {
     var reconnectConfig: StreamConfig?
     var reconnectAppID: Int?
 
+    // MARK: - Mid-session bitrate downshift (see BitrateDownshiftController)
+
+    /// Whether the connect-time path probe resolved this session to remote.
+    /// Latched in `makeBackendConfig` and re-latched on every reconnect, so a
+    /// route that moves mid-session (the tunnel-flap case) is re-judged rather
+    /// than inherited. Gates the downshift tier - a LAN that can't carry its own
+    /// rate is a different fault.
+    var isRemotePathSession = false
+    /// Per-session downshift budget + cooldown.
+    var downshift = BitrateDownshiftController()
+    /// Latched so the "why we did NOT downshift" reason logs once per stall
+    /// episode rather than once a second. Cleared by `clearDecodeOnlyStallLatch`.
+    var didLogDownshiftDecision = false
+
     // MARK: - Wake resilience (sleep/wake fast-reconnect - see +Wake)
 
     /// NSWorkspace sleep/wake observer tokens, armed when a stream goes live and

--- a/Glimmer/Stream/StreamingBackend.swift
+++ b/Glimmer/Stream/StreamingBackend.swift
@@ -97,12 +97,6 @@ public struct BackendStreamConfig: Sendable {
     public var colorSpace: Int32
     public var colorRange: Int32
     public var encryptionFlags: Int32
-    /// MTU of the interface the stream will egress on, from the connect-time
-    /// `StreamPathMTU.probe`; 0 when the probe could not answer. Used ONLY to
-    /// size the packet size we ADVERTISE in the SDP - `packetSize` above stays
-    /// the configured value because it also sizes the receive buffer, which
-    /// must keep headroom for a host that ignores our request.
-    public var pathMTU: Int32 = 0
     /// Exactly 16 bytes.
     public var remoteInputAesKey: [UInt8]
     /// Exactly 16 bytes.
@@ -113,10 +107,8 @@ public struct BackendStreamConfig: Sendable {
         packetSize: Int32, streamingRemotely: Int32, audioConfiguration: Int32,
         supportedVideoFormats: Int32, clientRefreshRateX100: Int32,
         colorSpace: Int32, colorRange: Int32, encryptionFlags: Int32,
-        remoteInputAesKey: [UInt8], remoteInputAesIv: [UInt8],
-        pathMTU: Int32 = 0
+        remoteInputAesKey: [UInt8], remoteInputAesIv: [UInt8]
     ) {
-        self.pathMTU = pathMTU
         self.width = width
         self.height = height
         self.fps = fps
@@ -152,15 +144,6 @@ public struct BackendStreamConfig: Sendable {
             ? StreamPathMTU.remoteMinimumBitrateKbps
             : max(10_000, peakKbps / 2)
         return min(floor, peakKbps)
-    }
-
-    /// The video packet size to ADVERTISE in the SDP: the configured size on a
-    /// LAN, clamped to what the probed path can carry unfragmented on a remote
-    /// one. See StreamPathMTU.swift for why this clamp used to be dead code.
-    public var advertisedVideoPacketSize: Int {
-        StreamPathMTU.advertisedPacketSize(
-            configured: Int(packetSize), isRemote: isRemoteSession,
-            mtu: pathMTU > 0 ? Int(pathMTU) : nil)
     }
 }
 

--- a/Glimmer/Stream/StreamingBackend.swift
+++ b/Glimmer/Stream/StreamingBackend.swift
@@ -97,6 +97,12 @@ public struct BackendStreamConfig: Sendable {
     public var colorSpace: Int32
     public var colorRange: Int32
     public var encryptionFlags: Int32
+    /// MTU of the interface the stream will egress on, from the connect-time
+    /// `StreamPathMTU.probe`; 0 when the probe could not answer. Used ONLY to
+    /// size the packet size we ADVERTISE in the SDP - `packetSize` above stays
+    /// the configured value because it also sizes the receive buffer, which
+    /// must keep headroom for a host that ignores our request.
+    public var pathMTU: Int32 = 0
     /// Exactly 16 bytes.
     public var remoteInputAesKey: [UInt8]
     /// Exactly 16 bytes.
@@ -107,8 +113,10 @@ public struct BackendStreamConfig: Sendable {
         packetSize: Int32, streamingRemotely: Int32, audioConfiguration: Int32,
         supportedVideoFormats: Int32, clientRefreshRateX100: Int32,
         colorSpace: Int32, colorRange: Int32, encryptionFlags: Int32,
-        remoteInputAesKey: [UInt8], remoteInputAesIv: [UInt8]
+        remoteInputAesKey: [UInt8], remoteInputAesIv: [UInt8],
+        pathMTU: Int32 = 0
     ) {
+        self.pathMTU = pathMTU
         self.width = width
         self.height = height
         self.fps = fps
@@ -123,6 +131,23 @@ public struct BackendStreamConfig: Sendable {
         self.encryptionFlags = encryptionFlags
         self.remoteInputAesKey = remoteInputAesKey
         self.remoteInputAesIv = remoteInputAesIv
+    }
+
+    /// True when the connect-time path probe resolved this session to remote.
+    /// `.auto` is resolved BEFORE this type is built (StreamSession
+    /// .makeBackendConfig), so an unresolved STREAM_CFG_AUTO reaching here is
+    /// treated as local - the pre-probe behaviour.
+    public var isRemoteSession: Bool {
+        streamingRemotely == StreamProtocol.STREAM_CFG_REMOTE
+    }
+
+    /// The video packet size to ADVERTISE in the SDP: the configured size on a
+    /// LAN, clamped to what the probed path can carry unfragmented on a remote
+    /// one. See StreamPathMTU.swift for why this clamp used to be dead code.
+    public var advertisedVideoPacketSize: Int {
+        StreamPathMTU.advertisedPacketSize(
+            configured: Int(packetSize), isRemote: isRemoteSession,
+            mtu: pathMTU > 0 ? Int(pathMTU) : nil)
     }
 }
 

--- a/Glimmer/Stream/StreamingBackend.swift
+++ b/Glimmer/Stream/StreamingBackend.swift
@@ -141,6 +141,19 @@ public struct BackendStreamConfig: Sendable {
         streamingRemotely == StreamProtocol.STREAM_CFG_REMOTE
     }
 
+    /// The VQOS bitrate floor to advertise, given the peak we just computed.
+    /// LAN anchors the floor to half the peak (the link can carry the peak, so
+    /// VQOS only needs trim room). Remote drops to a genuinely deliverable rate,
+    /// because a half-peak floor can sit above what the path delivers and leave
+    /// the host no legal rate that fits. Never above the peak, so the advertised
+    /// range can't invert on a very low configured bitrate.
+    public func vqosFloorKbps(peakKbps: Int) -> Int {
+        let floor = isRemoteSession
+            ? StreamPathMTU.remoteMinimumBitrateKbps
+            : max(10_000, peakKbps / 2)
+        return min(floor, peakKbps)
+    }
+
     /// The video packet size to ADVERTISE in the SDP: the configured size on a
     /// LAN, clamped to what the probed path can carry unfragmented on a remote
     /// one. See StreamPathMTU.swift for why this clamp used to be dead code.

--- a/Glimmer/Stream/StreamingBackend.swift
+++ b/Glimmer/Stream/StreamingBackend.swift
@@ -132,19 +132,6 @@ public struct BackendStreamConfig: Sendable {
     public var isRemoteSession: Bool {
         streamingRemotely == StreamProtocol.STREAM_CFG_REMOTE
     }
-
-    /// The VQOS bitrate floor to advertise, given the peak we just computed.
-    /// LAN anchors the floor to half the peak (the link can carry the peak, so
-    /// VQOS only needs trim room). Remote drops to a genuinely deliverable rate,
-    /// because a half-peak floor can sit above what the path delivers and leave
-    /// the host no legal rate that fits. Never above the peak, so the advertised
-    /// range can't invert on a very low configured bitrate.
-    public func vqosFloorKbps(peakKbps: Int) -> Int {
-        let floor = isRemoteSession
-            ? StreamPathMTU.remoteMinimumBitrateKbps
-            : max(10_000, peakKbps / 2)
-        return min(floor, peakKbps)
-    }
 }
 
 /// One PLENTRY-equivalent buffer in a DecodeUnit's chain.

--- a/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
+++ b/Glimmer/Stream/TelemetryExporter+CaptureSections.swift
@@ -170,12 +170,39 @@ extension TelemetryExporter {
     /// cadence lived only in a code comment), the audio cushion targets, and
     /// the input idle-gap. Extend this list whenever a new experiment dial
     /// ships; the cost is one row per session. On `workQueue` (from `start()`).
+    /// The connect-time link gate's decision (StreamPathMTU.latchGateDecision).
+    /// Empty when no connect has happened this process run. These belong in the
+    /// NDJSON specifically because the session `.log` does not start capturing
+    /// until the backend connects, so the gate's own Diag line is never written
+    /// there - and the gate silently changes picture quality, which makes
+    /// "what did it decide, and why" a question the durable artifact has to be
+    /// able to answer on its own.
+    private var linkGateFields: [String] {
+        guard let gate = StreamPathMTU.currentGateDecision else { return [] }
+        var fields: [String] = [
+            "\"gate_stream_if\":\"\(TelemetryRenderer.jsonStringEscape(gate.interfaceName ?? "?"))\"",
+            "\"gate_tunnel\":\(gate.isTunnel)",
+            "\"gate_packet_size\":\(gate.packetSize)",
+            "\"gate_bitrate_configured_kbps\":\(gate.configuredBitrateKbps)",
+            "\"gate_bitrate_asked_kbps\":\(gate.askedBitrateKbps)"
+        ]
+        if let mtu = gate.mtu { fields.append("\"gate_path_mtu\":\(mtu)") }
+        if let rtt = gate.rtt {
+            fields.append("\"gate_rtt_min_ms\":" + TelemetryRenderer.jsonNumber(rtt.minMs))
+            fields.append("\"gate_rtt_p50_ms\":" + TelemetryRenderer.jsonNumber(rtt.p50Ms))
+            fields.append("\"gate_rtt_p95_ms\":" + TelemetryRenderer.jsonNumber(rtt.p95Ms))
+            fields.append("\"gate_rtt_samples\":\(rtt.count)")
+        }
+        return fields
+    }
+
     func writeConfigEvent() {
         let fields: [String] = [
             "\"ts\":\"\(isoFormatter.string(from: Date()))\"",
             "\"session\":\"\(sessionId)\"",
             "\"event\":\"config\"",
-            "\"build_commit\":\"\(TelemetryRenderer.jsonStringEscape(BuildInfo.commit))\"",
+            "\"build_commit\":\"\(TelemetryRenderer.jsonStringEscape(BuildInfo.commit))\""
+        ] + linkGateFields + [
             // The keepalive is CONDITIONAL (EnvSignalController): both cadence
             // dials + the policy flag, so the session file self-describes the
             // regimes it could run; the live per-row value is

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.7.7
-CURRENT_PROJECT_VERSION = 20260708
+MARKETING_VERSION = 2026.7.8
+CURRENT_PROJECT_VERSION = 20260730

--- a/GlimmerTests/BitrateDownshiftTests.swift
+++ b/GlimmerTests/BitrateDownshiftTests.swift
@@ -1,0 +1,187 @@
+//
+//  BitrateDownshiftTests.swift
+//
+//  Policy coverage for the mid-session bitrate downshift - the only rate
+//  adaptation this protocol profile permits (bitrate is fixed per session; the
+//  SDP is the only place it is set, so a reconnect is the only way to change it).
+//
+//  The controller is pure by design so the DECISION is testable without a live
+//  session: the watchdog supplies decodeIdle/receiveIdle and the resolved
+//  remoteness, the controller decides, StreamSession owns the side effects.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct BitrateDownshiftTests {
+
+    /// The captured failure: 84 Mbps configured, 20+ seconds of video arriving
+    /// that would not decode, on a tunnel.
+    private let stalled = 25.0
+    private let receiving = 0.2
+    private let configuredKbps = 84_000
+
+    // MARK: - Gating
+
+    /// A LAN that can't carry its own negotiated rate is a different fault (bad
+    /// cable, duplex mismatch, overcommitted host) and lowering the ask would
+    /// mask it rather than fix it.
+    @Test func lanNeverDownshifts() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: false, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .notRemote)
+    }
+
+    /// The IDR nudge must get a full chance first - it is the cheap fix for the
+    /// host-paused-encoder case, and it costs nothing.
+    @Test func shortStallIsTooEarly() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: true, decodeIdle: 5, receiveIdle: receiving,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .tooEarly)
+    }
+
+    /// Bits must be ARRIVING. If reception is dead too, the link is gone - that
+    /// is ENet dead-peer detection's call, and downshifting would be nonsense.
+    @Test func deadReceptionIsNotABitrateProblem() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: 30,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .receptionAlsoDead)
+    }
+
+    @Test func infiniteReceiveIdleIsNotABitrateProblem() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: .infinity,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .receptionAlsoDead)
+    }
+
+    // MARK: - The happy path
+
+    @Test func remoteStallWithLiveReceptionDownshifts() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .downshift(toKbps: 50_400))   // 84000 * 0.6
+    }
+
+    /// Two steps walk the rate to ~36% of the original, then stop. The captured
+    /// tunnel sustained 6-14 Mbps against an 84 Mbps ask, so the walk has to
+    /// cover real ground - a 10% nibble would cost a reconnect and still overrun.
+    @Test func twoStepWalkThenBudgetExhausted() {
+        var controller = BitrateDownshiftController()
+        var kbps = configuredKbps
+
+        guard case .downshift(let first) = controller.evaluate(
+            isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+            currentKbps: kbps, nowUptime: 100) else {
+            Issue.record("first downshift declined"); return
+        }
+        #expect(first == 50_400)
+        controller.recordDownshift(atUptime: 100)
+        kbps = first
+
+        // Past the cooldown, the second step lands.
+        guard case .downshift(let second) = controller.evaluate(
+            isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+            currentKbps: kbps, nowUptime: 300) else {
+            Issue.record("second downshift declined"); return
+        }
+        #expect(second == 30_240)
+        controller.recordDownshift(atUptime: 300)
+        kbps = second
+
+        // Budget spent - a third is refused however bad it gets.
+        let third = controller.evaluate(isRemote: true, decodeIdle: 600, receiveIdle: receiving,
+                               currentKbps: kbps, nowUptime: 900)
+        #expect(third == .budgetExhausted)
+        #expect(controller.downshiftCount == BitrateDownshiftController.maxDownshifts)
+    }
+
+    // MARK: - The anti-thrash rails
+
+    /// Two downshifts must never fire on ONE episode's evidence. The cooldown
+    /// has to outlast the reconnect itself plus enough streaming to judge the
+    /// new rate.
+    @Test func cooldownBlocksAnImmediateSecondDownshift() {
+        var controller = BitrateDownshiftController()
+        controller.recordDownshift(atUptime: 100)
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: 50_400, nowUptime: 120)   // 20s later
+        #expect(d == .coolingDown)
+    }
+
+    @Test func cooldownExpiresAfterItsWindow() {
+        var controller = BitrateDownshiftController()
+        controller.recordDownshift(atUptime: 100)
+        let after = 100 + BitrateDownshiftController.cooldownSeconds + 1
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: 50_400, nowUptime: after)
+        #expect(d == .downshift(toKbps: 30_240))
+    }
+
+    /// Below the floor the stream isn't worth resuming - the honest outcome is
+    /// the existing teardown, not an unwatchable trickle.
+    @Test func neverStepsBelowTheFloor() {
+        let controller = BitrateDownshiftController()
+        // 15 Mbps * 0.6 = 9 Mbps, under the 10 Mbps floor.
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: 15_000, nowUptime: 100)
+        #expect(d == .budgetExhausted)
+    }
+
+    @Test func atTheFloorExactlyIsStillAllowed() {
+        let controller = BitrateDownshiftController()
+        // 16667 * 0.6 = 10000 exactly.
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: 16_667, nowUptime: 100)
+        #expect(d == .downshift(toKbps: BitrateDownshiftController.floorKbps))
+    }
+
+    /// There is no automatic UPshift by construction - the controller only ever
+    /// returns a LOWER rate, so it cannot oscillate.
+    @Test func decisionIsAlwaysStrictlyDownward() {
+        let controller = BitrateDownshiftController()
+        for kbps in [20_000, 40_000, 84_000, 150_000] {
+            guard case .downshift(let to) = controller.evaluate(
+                isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                currentKbps: kbps, nowUptime: 100) else { continue }
+            #expect(to < kbps)
+            #expect(to >= BitrateDownshiftController.floorKbps)
+        }
+    }
+
+    /// A fresh stream starts with a full budget - the state is per-session.
+    @Test func resetRestoresTheBudget() {
+        var controller = BitrateDownshiftController()
+        controller.recordDownshift(atUptime: 100)
+        controller.recordDownshift(atUptime: 300)
+        #expect(controller.downshiftCount == 2)
+        controller.resetForNewSession()
+        #expect(controller.downshiftCount == 0)
+        let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
+                           currentKbps: configuredKbps, nowUptime: 400)
+        #expect(d == .downshift(toKbps: 50_400))
+    }
+
+    /// A clean session never touches any of this.
+    @Test func healthySessionNeverDownshifts() {
+        let controller = BitrateDownshiftController()
+        let d = controller.evaluate(isRemote: true, decodeIdle: 0.01, receiveIdle: 0.01,
+                           currentKbps: configuredKbps, nowUptime: 100)
+        #expect(d == .tooEarly)
+        #expect(controller.downshiftCount == 0)
+    }
+
+    /// The threshold has to sit clear of the IDR-nudge tier so the cheap fix is
+    /// always tried first.
+    @Test func downshiftThresholdIsWellPastTheIdrNudge() {
+        #expect(BitrateDownshiftController.stallSecondsBeforeDownshift
+                > StreamSession.decodeStallRecoveryThreshold)
+        #expect(BitrateDownshiftController.stallSecondsBeforeDownshift
+                > StreamSession.frameWatchdogTimeout)
+    }
+}

--- a/GlimmerTests/BitrateDownshiftTests.swift
+++ b/GlimmerTests/BitrateDownshiftTests.swift
@@ -154,16 +154,16 @@ struct BitrateDownshiftTests {
         }
     }
 
-    /// A fresh stream starts with a full budget - the state is per-session.
-    @Test func resetRestoresTheBudget() {
-        var controller = BitrateDownshiftController()
-        controller.recordDownshift(atUptime: 100)
-        controller.recordDownshift(atUptime: 300)
-        #expect(controller.downshiftCount == 2)
-        controller.resetForNewSession()
+    /// A fresh stream starts with a full budget - the state is per-session by
+    /// construction (StreamSession is built per launch and owns this), so a new
+    /// controller must begin unspent. The budget deliberately SURVIVES a
+    /// reconnect, including a downshift's own; otherwise a link that kept
+    /// failing would downshift forever.
+    @Test func freshControllerStartsWithAFullBudget() {
+        let controller = BitrateDownshiftController()
         #expect(controller.downshiftCount == 0)
         let d = controller.evaluate(isRemote: true, decodeIdle: stalled, receiveIdle: receiving,
-                           currentKbps: configuredKbps, nowUptime: 400)
+                                    currentKbps: configuredKbps, nowUptime: 400)
         #expect(d == .downshift(toKbps: 50_400))
     }
 

--- a/GlimmerTests/SdpCodecTests.swift
+++ b/GlimmerTests/SdpCodecTests.swift
@@ -197,12 +197,20 @@ struct SdpCodecTests {
         #expect(sdp.contains("a=x-nv-video[0].packetSize:1392 \r\n"))
     }
 
-    @Test func buildRemoteClampsPacketSizeAndQos() {
+    @Test func buildRemoteSetsQosAndEchoesTheResolvedPacketSize() {
         let sdp = sdpString(builder(format: StreamProtocol.VIDEO_FORMAT_H264, remote: 1))
         #expect(sdp.contains("a=x-nv-vqos[0].qosTrafficType:0 \r\n"))
         #expect(sdp.contains("a=x-nv-aqos.qosTrafficType:0 \r\n"))
-        // Remote session clamps packetSize to 1024 (min(1392, 1024)).
-        #expect(sdp.contains("a=x-nv-video[0].packetSize:1024 \r\n"))
+        // The builder no longer derives its own packet size. The remote clamp
+        // moved UPSTREAM to StreamSession.makeBackendConfig, because the same
+        // resolved number must reach the host, the receive buffer, AND the
+        // Reed-Solomon shard length the FEC reconstructor rebuilds recovered
+        // packets at - advertising one size while reconstructing at another
+        // corrupts every FEC-recovered frame (see StreamPathMTUTests'
+        // advertisedSizeIsExactlyTheStoredSizeUsedForFecReconstruction).
+        // This config carries the LAN 1392, so 1392 is what must be advertised;
+        // the clamp itself is covered in StreamPathMTUTests.
+        #expect(sdp.contains("a=x-nv-video[0].packetSize:1392 \r\n"))
     }
 
     @Test func buildMaxNumReferenceFramesDefaultsToOneWithoutRfi() {

--- a/GlimmerTests/StreamPathMTUTests.swift
+++ b/GlimmerTests/StreamPathMTUTests.swift
@@ -98,8 +98,8 @@ struct StreamPathMTUTests {
 
     // MARK: - SdpBuilder integration (the attribute actually put on the wire)
 
-    private func sdp(remote: Int32, pathMTU: Int32, packetSize: Int32 = 1392) -> String {
-        var config = BackendStreamConfig(
+    private func sdp(remote: Int32, packetSize: Int32) -> String {
+        let config = BackendStreamConfig(
             width: 1920, height: 1080, fps: 60, bitrate: 20000,
             packetSize: packetSize, streamingRemotely: remote,
             audioConfiguration: 0x00010002,
@@ -107,7 +107,6 @@ struct StreamPathMTUTests {
             colorSpace: 1, colorRange: 0, encryptionFlags: 0,
             remoteInputAesKey: [UInt8](repeating: 0, count: 16),
             remoteInputAesIv: [UInt8](repeating: 0, count: 16))
-        config.pathMTU = pathMTU
         let builder = SdpBuilder(
             config: config, videoPort: 47998, urlSafeAddr: "10.0.0.5",
             addrFamilyToken: "IPv4", rtspClientVersion: 14,
@@ -117,34 +116,57 @@ struct StreamPathMTUTests {
     }
 
     @Test func lanSessionAdvertises1392() {
-        let text = sdp(remote: StreamProtocol.STREAM_CFG_LOCAL, pathMTU: 1500)
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_LOCAL, packetSize: 1392)
         #expect(text.contains("x-nv-video[0].packetSize:1392"))
     }
 
     /// The bug this whole change exists for: a resolved-remote tunnel session
     /// must advertise 1024, not the LAN 1392.
     @Test func remoteTunnelSessionAdvertises1024() {
-        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 1280)
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, packetSize: 1024)
         #expect(text.contains("x-nv-video[0].packetSize:1024"))
         #expect(!text.contains("x-nv-video[0].packetSize:1392"))
     }
 
     @Test func remoteNarrowTunnelAdvertisesMTUDerivedSize() {
-        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 1000)
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, packetSize: 872)
         #expect(text.contains("x-nv-video[0].packetSize:872"))
     }
 
-    /// pathMTU == 0 means the probe could not read an MTU; the flat remote size
-    /// still applies.
+    /// An unreadable MTU falls back to the flat remote size, which is what
+    /// makeBackendConfig then stores.
     @Test func remoteWithoutMTUReadingStillClamps() {
-        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 0)
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, packetSize: 1024)
         #expect(text.contains("x-nv-video[0].packetSize:1024"))
+    }
+
+    /// REGRESSION (shipped in 2026.7.8-rc1, purple/white HDR corruption).
+    ///
+    /// `packetSize` is not merely a buffer bound - it is the Reed-Solomon SHARD
+    /// LENGTH the FEC reconstructor rebuilds recovered packets at
+    /// (`RtpVideoQueue+Reconstruct`: `receiveSize = packetSize + MAX_RTP_HEADER_SIZE`
+    /// and `length: packetSize + dataOffset`). rc1 advertised a clamped 1024 to
+    /// the host while leaving the client reconstructing at 1392, so every
+    /// FEC-recovered packet was rebuilt at the wrong length and fed garbage to
+    /// VideoToolbox - 883 corruption events in 196s on a lossy tunnel, and zero
+    /// on the previous build. A clean link never shows it, because it never
+    /// exercises FEC recovery.
+    ///
+    /// The invariant: ONE resolved size reaches the SDP, the receive buffer, and
+    /// the FEC math. `BackendStreamConfig.packetSize` IS that value, and the SDP
+    /// echoes it rather than re-deriving its own.
+    @Test func advertisedSizeIsExactlyTheStoredSizeUsedForFecReconstruction() {
+        for size: Int32 in [512, 872, 1024, 1392] {
+            let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, packetSize: size)
+            #expect(text.contains("x-nv-video[0].packetSize:\(size)"),
+                    "SDP must advertise exactly the stored packetSize \(size); any divergence corrupts every FEC-recovered frame")
+        }
     }
 
     // MARK: - VQOS adaptation window
 
     private func vqosRange(remote: Int32, bitrateKbps: Int32) -> (min: Int, max: Int) {
-        var config = BackendStreamConfig(
+        let config = BackendStreamConfig(
             width: 1920, height: 1080, fps: 60, bitrate: bitrateKbps,
             packetSize: 1392, streamingRemotely: remote,
             audioConfiguration: 0x00010002,
@@ -152,7 +174,6 @@ struct StreamPathMTUTests {
             colorSpace: 1, colorRange: 0, encryptionFlags: 0,
             remoteInputAesKey: [UInt8](repeating: 0, count: 16),
             remoteInputAesIv: [UInt8](repeating: 0, count: 16))
-        config.pathMTU = 1280
         let builder = SdpBuilder(
             config: config, videoPort: 47998, urlSafeAddr: "10.0.0.5",
             addrFamilyToken: "IPv4", rtspClientVersion: 14,
@@ -208,7 +229,7 @@ struct StreamPathMTUTests {
     /// it is treated as local (the pre-existing behaviour), so this pins that
     /// the builder tests the REMOTE constant specifically and not `!= LOCAL`.
     @Test func unresolvedAutoIsTreatedAsLocalByTheBuilder() {
-        let text = sdp(remote: StreamProtocol.STREAM_CFG_AUTO, pathMTU: 1280)
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_AUTO, packetSize: 1392)
         #expect(text.contains("x-nv-video[0].packetSize:1392"))
     }
 }

--- a/GlimmerTests/StreamPathMTUTests.swift
+++ b/GlimmerTests/StreamPathMTUTests.swift
@@ -233,4 +233,119 @@ struct StreamPathMTUTests {
         let text = sdp(remote: StreamProtocol.STREAM_CFG_AUTO, packetSize: 1392)
         #expect(text.contains("x-nv-video[0].packetSize:1392"))
     }
+
+    // MARK: - Connect-time quality gate (RTT → bitrate ceiling)
+
+    /// A LAN keeps the full demand-based ask - the gate must be invisible there.
+    @Test func lanRttKeepsFullBitrate() {
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1500, isTunnel: false, rtt: RttStats(samples: [1.2]))
+        #expect(!path.isRemotePath)
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) == 84_000)
+    }
+
+    /// An RTT no local network produces means remote, whatever the interface
+    /// looks like. Wired LAN is 0.5-2ms and LAN wifi 2-10ms; 45ms has left the
+    /// building.
+    @Test func highRttAloneClassifiesRemote() {
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1500, isTunnel: false, rtt: RttStats(samples: [45]))
+        #expect(path.isRemotePath)
+    }
+
+    /// The live case: ~50 ms tunnel → 0.50 → 84 becomes 42 Mbps. The host's
+    /// encoder was independently measured running 37-50 Mbps on this same path,
+    /// so the ceiling lands where reality already was.
+    @Test func fiftyMsTunnelHalvesTheAsk() {
+        let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true, rtt: RttStats(samples: [50]))
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) == 42_000)
+    }
+
+    @Test func rttBandsAreMonotonicallyStricter() {
+        let bands: [(Double, Double)] = [(1, 1.00), (9.9, 1.00), (10, 0.75),
+                                         (29, 0.75), (30, 0.50), (59, 0.50),
+                                         (60, 0.35), (250, 0.35)]
+        for (rtt, expected) in bands {
+            #expect(StreamPathMTU.bitrateCeilingFraction(rttMs: rtt) == expected,
+                    "RTT \(rtt)ms should map to \(expected)")
+        }
+    }
+
+    /// An unmeasured RTT must cap NOTHING. A failed probe is "unknown", never
+    /// "bad" - the same contract as the MTU clamp.
+    @Test func unmeasuredRttCapsNothing() {
+        #expect(StreamPathMTU.bitrateCeilingFraction(rttMs: nil) == 1.0)
+        let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true, rtt: nil)
+        // Still remote (tunnel), but with no RTT there is no basis to cap.
+        #expect(path.isRemotePath)
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) == 84_000)
+    }
+
+    /// However distant the host, never ask below the floor.
+    @Test func capNeverGoesBelowTheFloor() {
+        let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true, rtt: RttStats(samples: [300]))
+        let capped = StreamPathMTU.cappedBitrateKbps(configured: 20_000, path: path)
+        #expect(capped == StreamPathMTU.minimumBitrateKbps)
+    }
+
+    /// The gate only ever moves DOWNWARD.
+    @Test func capIsNeverAnIncrease() {
+        for rtt in [0.5, 5.0, 15.0, 45.0, 120.0] {
+            let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true,
+                                       rtt: RttStats(samples: [rtt]))
+            #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) <= 84_000)
+        }
+    }
+
+    // MARK: - RTT distribution (p95 is what the gate bands on)
+
+    /// The gate must key on the TAIL. A link whose floor looks fine but whose
+    /// tail is 10x worse is bufferbloated and will stutter; banding on min would
+    /// hide exactly that, which is the whole reason p95 is the chosen statistic.
+    @Test func gateBandsOnTheTailNotTheFloor() throws {
+        // A realistically bloated link: the floor still looks like a LAN (8 ms)
+        // but a quarter of the samples are stuck behind a full queue. Note this
+        // needs a SUSTAINED tail, not one spike - a single outlier in 20 is
+        // exactly 5% and p95 correctly sits at the boundary rather than chasing
+        // it, which is the statistic behaving as intended.
+        let samples = Array(repeating: 8.0, count: 15) + Array(repeating: 120.0, count: 5)
+        let stats = try #require(RttStats(samples: samples))
+        #expect(stats.minMs == 8)
+        #expect(stats.p95Ms == 120)
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1500, isTunnel: false, rtt: stats)
+        // Banding on min would call this local and cap nothing. On p95 it is
+        // correctly treated as a distant/congested path.
+        #expect(path.isRemotePath)
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) < 84_000)
+        #expect(stats.tailRatio == 15)
+    }
+
+    @Test func percentilesAreOrdered() throws {
+        let stats = try #require(RttStats(samples: [50, 10, 30, 20, 40]))
+        #expect(stats.minMs == 10)
+        #expect(stats.minMs <= stats.p50Ms)
+        #expect(stats.p50Ms <= stats.p95Ms)
+        #expect(stats.count == 5)
+    }
+
+    /// A clean low-latency path has a tail that matches its floor, so nothing
+    /// is capped - the do-no-harm case.
+    @Test func cleanLanDistributionCapsNothing() throws {
+        let stats = try #require(RttStats(samples: Array(repeating: 1.1, count: 20)))
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1500, isTunnel: false, rtt: stats)
+        #expect(!path.isRemotePath)
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) == 84_000)
+        #expect(stats.tailRatio == 1)
+    }
+
+    /// No samples means no knowledge - never a verdict.
+    @Test func emptySampleSetYieldsNoStats() {
+        #expect(RttStats(samples: []) == nil)
+    }
+
+    /// The live path measured 33-43ms across samples; whatever the draw, it must
+    /// land in one band and produce a stable answer.
+    @Test func measuredTunnelSpreadLandsInOneBand() {
+        let stats = RttStats(samples: [33.2, 37.6, 38.1, 40.0, 42.6])
+        let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true, rtt: stats)
+        #expect(StreamPathMTU.cappedBitrateKbps(configured: 84_000, path: path) == 42_000)
+    }
 }

--- a/GlimmerTests/StreamPathMTUTests.swift
+++ b/GlimmerTests/StreamPathMTUTests.swift
@@ -1,0 +1,152 @@
+//
+//  StreamPathMTUTests.swift
+//
+//  Coverage for the connect-time path clamp that decides the video packet size
+//  we ADVERTISE to the host. The regression under test: `StreamConfig.remoteness`
+//  defaults to `.auto` (STREAM_CFG_AUTO = 2), so SdpBuilder's `== 1` remote check
+//  never fired and every session - including one routed over a 1280-MTU
+//  Tailscale/WireGuard tunnel - advertised the 1392-byte LAN packet size, which
+//  IP-fragments on that path and multiplies pre-FEC loss.
+//
+//  The syscall probe itself (connect/getsockname/getifaddrs) is not unit-tested -
+//  it depends on the machine's live route table. The DECISION functions it feeds
+//  are pure, and those are what this file pins.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct StreamPathMTUTests {
+
+    // MARK: - isRemotePath classification
+
+    @Test func tunnelInterfaceIsRemote() {
+        let path = StreamPathProbe(interfaceName: "utun6", mtu: 1280, isTunnel: true)
+        #expect(path.isRemotePath)
+    }
+
+    @Test func fullMTUEthernetIsLocal() {
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1500, isTunnel: false)
+        #expect(!path.isRemotePath)
+    }
+
+    /// A reduced-MTU route is remote even when the interface isn't named like a
+    /// tunnel - the packet-size consequence is identical.
+    @Test func reducedMTUIsRemoteEvenWhenNotTunnelNamed() {
+        let path = StreamPathProbe(interfaceName: "en0", mtu: 1400, isTunnel: false)
+        #expect(path.isRemotePath)
+    }
+
+    /// A failed probe knows nothing and must NOT claim remote - the caller keeps
+    /// the configured size rather than clamping on a guess.
+    @Test func emptyProbeIsNotRemote() {
+        #expect(!StreamPathProbe().isRemotePath)
+    }
+
+    // MARK: - advertisedPacketSize
+
+    /// Do no harm: a LAN session advertises exactly what was configured.
+    @Test func localPathKeepsConfiguredSize() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 1392, isRemote: false, mtu: 1500)
+        #expect(size == 1392)
+    }
+
+    /// Remote with an unreadable MTU falls back to moonlight's Internet size.
+    @Test func remoteWithUnknownMTUUsesMoonlightRemoteSize() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 1392, isRemote: true, mtu: nil)
+        #expect(size == StreamPathMTU.remotePacketSize)
+        #expect(size == 1024)
+    }
+
+    /// The live case: Tailscale's default 1280 MTU. 1280 - 128 budget = 1152, so
+    /// the flat 1024 remote size is the binding clamp and a full datagram fits.
+    @Test func tailscale1280MTUClampsTo1024() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 1392, isRemote: true, mtu: 1280)
+        #expect(size == 1024)
+        #expect(size + StreamPathMTU.datagramOverheadBudget <= 1280)
+    }
+
+    /// A narrower tunnel than 1024+overhead must clamp BELOW the flat remote
+    /// size - this machine has utun interfaces at MTU 1000, so it is not
+    /// hypothetical.
+    @Test func narrowTunnelClampsBelowRemoteSize() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 1392, isRemote: true, mtu: 1000)
+        #expect(size == 1000 - StreamPathMTU.datagramOverheadBudget)
+        #expect(size == 872)
+        #expect(size + StreamPathMTU.datagramOverheadBudget <= 1000)
+    }
+
+    /// However narrow the path, never advertise below the floor.
+    @Test func pathologicallyNarrowPathHitsTheFloor() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 1392, isRemote: true, mtu: 400)
+        #expect(size == StreamPathMTU.minimumPacketSize)
+    }
+
+    /// The clamp only ever moves DOWNWARD - a configured size already below the
+    /// remote ceiling is never inflated.
+    @Test func clampNeverRaisesAConfiguredSize() {
+        let size = StreamPathMTU.advertisedPacketSize(
+            configured: 800, isRemote: true, mtu: 1500)
+        #expect(size == 800)
+    }
+
+    // MARK: - SdpBuilder integration (the attribute actually put on the wire)
+
+    private func sdp(remote: Int32, pathMTU: Int32, packetSize: Int32 = 1392) -> String {
+        var config = BackendStreamConfig(
+            width: 1920, height: 1080, fps: 60, bitrate: 20000,
+            packetSize: packetSize, streamingRemotely: remote,
+            audioConfiguration: 0x00010002,
+            supportedVideoFormats: 0, clientRefreshRateX100: 6000,
+            colorSpace: 1, colorRange: 0, encryptionFlags: 0,
+            remoteInputAesKey: [UInt8](repeating: 0, count: 16),
+            remoteInputAesIv: [UInt8](repeating: 0, count: 16))
+        config.pathMTU = pathMTU
+        let builder = SdpBuilder(
+            config: config, videoPort: 47998, urlSafeAddr: "10.0.0.5",
+            addrFamilyToken: "IPv4", rtspClientVersion: 14,
+            negotiatedVideoFormat: 0, encryptionFeaturesEnabled: 0,
+            appVersionQuad: [7, 1, 450, 0])
+        return String(data: builder.build(), encoding: .utf8) ?? ""
+    }
+
+    @Test func lanSessionAdvertises1392() {
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_LOCAL, pathMTU: 1500)
+        #expect(text.contains("x-nv-video[0].packetSize:1392"))
+    }
+
+    /// The bug this whole change exists for: a resolved-remote tunnel session
+    /// must advertise 1024, not the LAN 1392.
+    @Test func remoteTunnelSessionAdvertises1024() {
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 1280)
+        #expect(text.contains("x-nv-video[0].packetSize:1024"))
+        #expect(!text.contains("x-nv-video[0].packetSize:1392"))
+    }
+
+    @Test func remoteNarrowTunnelAdvertisesMTUDerivedSize() {
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 1000)
+        #expect(text.contains("x-nv-video[0].packetSize:872"))
+    }
+
+    /// pathMTU == 0 means the probe could not read an MTU; the flat remote size
+    /// still applies.
+    @Test func remoteWithoutMTUReadingStillClamps() {
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_REMOTE, pathMTU: 0)
+        #expect(text.contains("x-nv-video[0].packetSize:1024"))
+    }
+
+    /// STREAM_CFG_AUTO must never reach the SDP builder as "remote" - the
+    /// resolution happens at connect. If an unresolved AUTO ever leaks through,
+    /// it is treated as local (the pre-existing behaviour), so this pins that
+    /// the builder tests the REMOTE constant specifically and not `!= LOCAL`.
+    @Test func unresolvedAutoIsTreatedAsLocalByTheBuilder() {
+        let text = sdp(remote: StreamProtocol.STREAM_CFG_AUTO, pathMTU: 1280)
+        #expect(text.contains("x-nv-video[0].packetSize:1392"))
+    }
+}

--- a/GlimmerTests/StreamPathMTUTests.swift
+++ b/GlimmerTests/StreamPathMTUTests.swift
@@ -163,7 +163,7 @@ struct StreamPathMTUTests {
         }
     }
 
-    // MARK: - VQOS adaptation window
+    // MARK: - VQOS bitrate range
 
     private func vqosRange(remote: Int32, bitrateKbps: Int32) -> (min: Int, max: Int) {
         let config = BackendStreamConfig(
@@ -189,37 +189,38 @@ struct StreamPathMTUTests {
                 value("x-nv-vqos[0].bw.maximumBitrateKbps"))
     }
 
-    /// LAN keeps the half-peak floor - unchanged behaviour.
-    @Test func lanVqosFloorIsHalfPeak() {
-        let range = vqosRange(remote: StreamProtocol.STREAM_CFG_LOCAL, bitrateKbps: 84_000)
-        #expect(range.max == 67_200)          // 84000 * 0.80
-        #expect(range.min == 33_600)          // half the peak
-    }
-
-    /// The bug: on a remote path the half-peak floor (33.6 Mbps) sat ABOVE the
-    /// 6-14 Mbps the captured tunnel actually delivered, so no rate VQOS was
-    /// allowed to pick could fit the link. The remote floor must be genuinely
-    /// reachable.
-    @Test func remoteVqosFloorDropsToADeliverableRate() {
-        let range = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 84_000)
-        #expect(range.min == StreamPathMTU.remoteMinimumBitrateKbps)
-        #expect(range.min == 5_000)
-        #expect(range.min < 14_000)           // below the measured tunnel goodput
-    }
-
-    /// Do no harm: the remote CEILING is untouched, so an abundant remote link
-    /// still climbs as high as it did before. Only the floor moves.
-    @Test func remoteCeilingIsUnchangedByTheWiderFloor() {
+    /// The advertised VQOS range is IDENTICAL for local and remote, and the
+    /// floor keeps its original half-peak shape.
+    ///
+    /// An earlier revision of this branch lowered the remote floor to 5 Mbps on
+    /// the theory that it gave "Sunshine's host-side VQOS room to step down".
+    /// That theory is false, and was checked against Sunshine's source rather
+    /// than inferred: `minimumBitrateKbps` appears ZERO times in the whole
+    /// Sunshine tree, so the floor is never parsed; `cmd_announce` reads
+    /// `maximumBitrateKbps` and then overwrites it with
+    /// `x-ml-video.configuredBitrateKbps`; and nothing mutates the bitrate after
+    /// ANNOUNCE. The encoder rate is FIXED for the session. Changing the floor
+    /// was a no-op, and the field data agreed - the encoder never went near it.
+    ///
+    /// This test exists to stop the idea being re-introduced: if the range ever
+    /// diverges by remoteness again, it is dead code dressed as a feature.
+    @Test func vqosFloorRuleDoesNotVaryByRemoteness() {
         let lan = vqosRange(remote: StreamProtocol.STREAM_CFG_LOCAL, bitrateKbps: 84_000)
         let remote = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 84_000)
-        // Remote subtracts moonlight's 500 kbps headroom from the peak; that is
-        // the ONLY ceiling difference, and it predates this change.
-        #expect(remote.max == lan.max - 500)
-        #expect(remote.min < lan.min)
+        #expect(lan.max == 67_200)               // 84000 * 0.80
+        #expect(remote.max == lan.max - 500)     // moonlight's remote headroom
+        // The floor is half the peak in BOTH cases - the same rule. The two
+        // numbers differ only because the remote PEAK is 500 lower, not because
+        // the floor is computed differently. That is the property to protect: a
+        // remoteness-dependent floor would be dead code (Sunshine never reads it).
+        #expect(lan.min == lan.max / 2)
+        #expect(remote.min == remote.max / 2)
+        #expect(lan.min == 33_600)
+        #expect(remote.min == 33_350)
     }
 
-    /// A configured bitrate below the remote floor must not invert the range.
-    @Test func remoteFloorNeverExceedsThePeak() {
+    /// The floor must never exceed the peak, or the advertised range inverts.
+    @Test func vqosFloorNeverExceedsThePeak() {
         let range = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 4_000)
         #expect(range.min <= range.max)
     }

--- a/GlimmerTests/StreamPathMTUTests.swift
+++ b/GlimmerTests/StreamPathMTUTests.swift
@@ -141,6 +141,68 @@ struct StreamPathMTUTests {
         #expect(text.contains("x-nv-video[0].packetSize:1024"))
     }
 
+    // MARK: - VQOS adaptation window
+
+    private func vqosRange(remote: Int32, bitrateKbps: Int32) -> (min: Int, max: Int) {
+        var config = BackendStreamConfig(
+            width: 1920, height: 1080, fps: 60, bitrate: bitrateKbps,
+            packetSize: 1392, streamingRemotely: remote,
+            audioConfiguration: 0x00010002,
+            supportedVideoFormats: 0, clientRefreshRateX100: 6000,
+            colorSpace: 1, colorRange: 0, encryptionFlags: 0,
+            remoteInputAesKey: [UInt8](repeating: 0, count: 16),
+            remoteInputAesIv: [UInt8](repeating: 0, count: 16))
+        config.pathMTU = 1280
+        let builder = SdpBuilder(
+            config: config, videoPort: 47998, urlSafeAddr: "10.0.0.5",
+            addrFamilyToken: "IPv4", rtspClientVersion: 14,
+            negotiatedVideoFormat: 0, encryptionFeaturesEnabled: 0,
+            appVersionQuad: [7, 1, 450, 0])
+        let text = String(data: builder.build(), encoding: .utf8) ?? ""
+        func value(_ key: String) -> Int {
+            guard let r = text.range(of: "\(key):") else { return -1 }
+            let rest = text[r.upperBound...].prefix(while: { $0.isNumber })
+            return Int(rest) ?? -1
+        }
+        return (value("x-nv-vqos[0].bw.minimumBitrateKbps"),
+                value("x-nv-vqos[0].bw.maximumBitrateKbps"))
+    }
+
+    /// LAN keeps the half-peak floor - unchanged behaviour.
+    @Test func lanVqosFloorIsHalfPeak() {
+        let range = vqosRange(remote: StreamProtocol.STREAM_CFG_LOCAL, bitrateKbps: 84_000)
+        #expect(range.max == 67_200)          // 84000 * 0.80
+        #expect(range.min == 33_600)          // half the peak
+    }
+
+    /// The bug: on a remote path the half-peak floor (33.6 Mbps) sat ABOVE the
+    /// 6-14 Mbps the captured tunnel actually delivered, so no rate VQOS was
+    /// allowed to pick could fit the link. The remote floor must be genuinely
+    /// reachable.
+    @Test func remoteVqosFloorDropsToADeliverableRate() {
+        let range = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 84_000)
+        #expect(range.min == StreamPathMTU.remoteMinimumBitrateKbps)
+        #expect(range.min == 5_000)
+        #expect(range.min < 14_000)           // below the measured tunnel goodput
+    }
+
+    /// Do no harm: the remote CEILING is untouched, so an abundant remote link
+    /// still climbs as high as it did before. Only the floor moves.
+    @Test func remoteCeilingIsUnchangedByTheWiderFloor() {
+        let lan = vqosRange(remote: StreamProtocol.STREAM_CFG_LOCAL, bitrateKbps: 84_000)
+        let remote = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 84_000)
+        // Remote subtracts moonlight's 500 kbps headroom from the peak; that is
+        // the ONLY ceiling difference, and it predates this change.
+        #expect(remote.max == lan.max - 500)
+        #expect(remote.min < lan.min)
+    }
+
+    /// A configured bitrate below the remote floor must not invert the range.
+    @Test func remoteFloorNeverExceedsThePeak() {
+        let range = vqosRange(remote: StreamProtocol.STREAM_CFG_REMOTE, bitrateKbps: 4_000)
+        #expect(range.min <= range.max)
+    }
+
     /// STREAM_CFG_AUTO must never reach the SDP builder as "remote" - the
     /// resolution happens at connect. If an unresolved AUTO ever leaks through,
     /// it is treated as local (the pre-existing behaviour), so this pins that


### PR DESCRIPTION
## The bug

`SdpBuilder` clamps the advertised video `packetSize` to 1024 on a remote session so a full RTP datagram fits inside common VPN path MTUs. **That clamp was dead code.** It tests `streamingRemotely == 1` (`STREAM_CFG_REMOTE`), but `StreamConfig.remoteness` defaults to `.auto` (`STREAM_CFG_AUTO = 2`) and nothing ever resolved it — so every session, LAN or tunnelled, advertised the 1392-byte LAN default.

Two other remote-only behaviours were dead for the same reason: the remote bitrate headroom (`SdpCodec.swift:290`) and the remote `qosTrafficType` (`:316`).

## Why it matters

On a 1280-MTU Tailscale/WireGuard path, 1392 + RTP/UDP/IP + tunnel encapsulation overruns the MTU, so **every video packet is IP-fragmented**. Losing either fragment loses the whole packet, which multiplies the pre-FEC loss the host's fixed 20% parity then has to absorb.

A 27-minute capture over a tunnel (`telemetry-2026-07-30T21:22:17Z.ndjson`):

| | tunnel (bad path) | after route moved |
|---|---|---|
| pre-FEC loss | 13–27% | 0.4–0.7% |
| decoded FPS | **0.0 for 15 straight min** | 106–120 |
| frame loss | ~3,000/min | ~10/min |
| RFI requests | ~2,500/min | ~10/min |
| glass-to-glass p50 | 357 ms | 43 ms |

## The fix

`StreamPathMTU` runs a one-shot probe at the connect edge — the same connected-UDP-socket trick `StreamRouteProbe` already uses for `stream_link` (`connect()` on UDP sends nothing, it only binds a route), then `getsockname()` + `getifaddrs()` for the egress interface, and `if_data.ifi_mtu` off that interface's `AF_LINK` entry for the MTU.

- `.auto` resolves to `.remote` when the route is a tunnel **or** the MTU is below standard Ethernet.
- The advertised size is clamped to the moonlight remote size (1024) and, for a path narrower still, to what that MTU can carry unfragmented — this machine has `utun` interfaces at MTU 1000, so that branch is not hypothetical.

## Verified on the live route

```
172.20.20.50 -> if=utun6 mtu=1280 tunnel=true  remote=true  advertisedPacketSize=1024
1.1.1.1      -> if=en0   mtu=1500 tunnel=false remote=false advertisedPacketSize=1392
```

## Do no harm

- The **stored** `packetSize` is untouched — it also sizes the receive buffer (`VideoRtpReceiver: bufSize = packetSize + 64`), which must keep headroom for a host that ignores our request. Only the advertised value moves, and only ever downward.
- A full-MTU non-tunnel route resolves `.local` and every advertised attribute is byte-identical to before.
- An explicit `.local`/`.remote` from the caller is honoured as-is; only `.auto` consults the probe.
- Reconnect re-probes rather than inheriting, for the tunnel-flap case.
- A failed probe claims nothing and keeps the configured size, rather than clamping on a guess.

## Tests

14 new tests in `GlimmerTests/StreamPathMTUTests.swift` covering the classification, the clamp arithmetic (including the floor and the never-raise invariant), and the SDP attribute actually put on the wire. Full suite: **181 tests, 0 failures.** SwiftLint clean — this also drops a pre-existing `function_body_length` warning on `SdpBuilder.build`.

## Not addressed here

The capture also shows there is **no client-side bitrate adaptation**: `negotiated_bitrate_mbps` sat at a constant 67.2 while goodput was 6–14 Mbps. Sunshine's host-side VQOS gets an advertised min/max range to work within, but nothing on the client backs the ask down on sustained loss. Worth a separate look.