### PR TITLE
fix(ui): let the hero and app grid use the window's width

### DIFF
--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -394,6 +394,12 @@ var accentSurfaceGradient: LinearGradient {
 }
 
 private struct HostHero: View {
+    /// Ceiling on the hero's width. Above the window's 860pt ideal so a
+    /// comfortably-sized window still grows the card, and below the point where
+    /// a centered 34pt host name starts reading as a banner rather than a card.
+    /// Tune this one value to change how much resizing buys.
+    static let heroMaxWidth: CGFloat = 820
+
     let host: Host?
     @Environment(AppModel.self) private var model
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -479,7 +485,14 @@ private struct HostHero: View {
         // The compact presentation retains its 248pt footprint; an expanded
         // app grid grows naturally so every host app remains reachable.
         .frame(minHeight: 248)
-        .frame(maxWidth: 520)
+        // WIDTH: the hero tracks the window instead of parking at a fixed 520.
+        // The old cap dated to the first commit, when the hero held only an icon
+        // and a name and had nothing to do with extra width. The expandable app
+        // grid changed that - it has real content to flow - so a wider window now
+        // buys more apps per row rather than more empty card. The ceiling keeps a
+        // maximised window from stretching the card into a banner; it is the one
+        // number to turn if this wants to be tighter or looser.
+        .frame(maxWidth: Self.heroMaxWidth)
         // Expanding resizes the whole hero, which is exactly the kind of motion
         // Reduce Motion asks us to drop - match the connecting scaleEffect above,
         // which is already gated the same way. The layout still changes; only the

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -313,10 +313,12 @@ struct AppIconsRow: View {
     @Binding var isExpanded: Bool
     @Environment(AppModel.self) private var model
 
-    private let columns = Array(
-        repeating: GridItem(.fixed(70), spacing: 10),
-        count: 4
-    )
+    /// Flow as many 70pt tiles per row as the hero's current width allows,
+    /// rather than pinning four. Fixed-4 wasted the room the hero already had
+    /// (four tiles span 310pt inside a 472pt content box) and made widening the
+    /// window buy nothing at all. `.adaptive` with min == max keeps every tile
+    /// exactly 70pt - the columns change, the tiles never stretch.
+    private let columns = [GridItem(.adaptive(minimum: 70, maximum: 70), spacing: 10)]
 
     var body: some View {
         VStack(spacing: 8) {


### PR DESCRIPTION
Resizing the launcher did nothing to the host card. Two separate causes, and they had to be fixed together.

## Cause 1 — the hero never grew

`.frame(maxWidth: 520)` dates to the **very first commit** (`22ec0c8`), when the card held an icon and a name and genuinely had nothing to do with extra width. So this is **not an 8.0 regression** — but 8.0 is what made it matter, because the expandable app grid finally gave the hero content that wants room.

## Cause 2 — the grid wasted the width the hero already had

`GridItem(.fixed(70))` × 4 spans **310pt inside a 472pt content box**. Even at the old size there were two tiles' worth of unused space per row, and widening the window couldn't add a single column.

## Fix

- Hero tracks the window up to a named `heroMaxWidth` (820 — above the window's 860pt ideal so a comfortable window still grows the card, below where a centered 34pt host name reads as a banner rather than a card).
- Grid becomes `.adaptive(minimum: 70, maximum: 70)`, so extra width becomes **more tiles per row** instead of more empty card. `min == max` keeps every tile exactly 70pt: the column count changes, the tiles never stretch.

The compact four-app row is deliberately unchanged — that's the at-a-glance scan, not a grid.

`heroMaxWidth` is the single number to turn if this wants to be tighter or looser.

## Verification

`make app` builds clean, 210 tests pass, no new SwiftLint output (the `file_length` warnings on both files are pre-existing).

**Not visually verified by me** — this is a layout change and wants an eyeball on the real window, particularly whether 820 is the right ceiling.