### PR TITLE
revert(ui): restore the 2026.7.7 launcher geometry

### DIFF
--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -173,41 +173,40 @@ private struct ConnectSurface: View {
     }
 
     var body: some View {
-        ScrollView(.vertical) {
-            VStack(spacing: 16) {
-                // Banner sits above the hero so it can't be missed. NOT behind
-                // the 400 ms hold: errors must surface the instant they exist.
-                ConnectBanner()
-                    .padding(.horizontal, 4)
+        VStack(spacing: 16) {
+            // Banner sits above the hero so it can't be missed. NOT behind
+            // the 400 ms hold: errors must surface the instant they exist.
+            ConnectBanner()
+                .padding(.horizontal, 4)
 
-                HostHero(host: model.selectedHost)
-                    .scaleEffect((showsConnectingUI && !reduceMotion) ? 1.04 : 1.0)
-                    .animation(.snappy(duration: 0.35, extraBounce: 0.1), value: showsConnectingUI)
+            HostHero(host: model.selectedHost)
+                .scaleEffect((showsConnectingUI && !reduceMotion) ? 1.04 : 1.0)
+                .animation(.snappy(duration: 0.35, extraBounce: 0.1), value: showsConnectingUI)
 
-                // Spec chips stay put during connect. The StreamButton below
-                // morphs into the calm "Connecting to <host>... / stage" capsule -
-                // the ONE connecting surface (a separate phase line would flash
-                // duplicate affordances on fast connects).
-                SpecChipsRow()
+            // Spec chips stay put during connect. The StreamButton below
+            // morphs into the calm "Connecting to <host>... / stage" capsule -
+            // the ONE connecting surface (a separate phase line would flash
+            // duplicate affordances on fast connects).
+            SpecChipsRow()
 
-                // Hide the StreamButton entirely while the stream window owns
-                // the foreground - a disabled "Streaming..." button would just
-                // duplicate the stream window's presence and compete for visual
-                // weight against the dimmed hero. (Connecting is NOT handed off,
-                // so the capsule below stays mounted through the handshake.)
-                if !isHandedOff {
-                    StreamButton(isConnecting: showsConnectingUI)
-                        .frame(maxWidth: 380)
-                        .padding(.top, 2)
-                        .transition(.opacity)
-                }
-
-                ContextFooter()
+            // Hide the StreamButton entirely while the stream window owns
+            // the foreground - a disabled "Streaming..." button would just
+            // duplicate the stream window's presence and compete for visual
+            // weight against the dimmed hero. (Connecting is NOT handed off,
+            // so the capsule below stays mounted through the handshake.)
+            if !isHandedOff {
+                StreamButton(isConnecting: showsConnectingUI)
+                    .frame(maxWidth: 380)
+                    .padding(.top, 2)
+                    .transition(.opacity)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 32)
-            .padding(.vertical, 20)
+
+            ContextFooter()
+
+            Spacer(minLength: 0)
         }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 20)
         // Hand off to the stream window: dim Glimmer's content so the
         // fullscreen surface visibly takes over and reverses on disconnect.
         .opacity(isHandedOff ? 0.4 : 1.0)
@@ -396,8 +395,6 @@ var accentSurfaceGradient: LinearGradient {
 private struct HostHero: View {
     let host: Host?
     @Environment(AppModel.self) private var model
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appsExpanded = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -468,7 +465,7 @@ private struct HostHero: View {
                 // END - the hero copy used to duplicate it AND disagree).
 
                 if let host, !host.apps.isEmpty {
-                    AppIconsRow(apps: host.apps, host: host, isExpanded: $appsExpanded)
+                    AppIconsRow(apps: host.apps, host: host)
                         .padding(.top, 6)
                 }
             }
@@ -476,20 +473,10 @@ private struct HostHero: View {
             .padding(.vertical, 22)
             .padding(.horizontal, 24)
         }
-        // The compact presentation retains its 248pt footprint; an expanded
-        // app grid grows naturally so every host app remains reachable.
-        .frame(minHeight: 248)
+        // 248pt (was 270): content measures ~218pt, so this trims the hero's
+        // dead air ("a bit too much") while keeping honest breathing room.
+        .frame(height: 248)
         .frame(maxWidth: 520)
-        // Expanding resizes the whole hero, which is exactly the kind of motion
-        // Reduce Motion asks us to drop - match the connecting scaleEffect above,
-        // which is already gated the same way. The layout still changes; only the
-        // animation between the two states is suppressed.
-        .animation(
-            reduceMotion ? nil : .snappy(duration: 0.3, extraBounce: 0.1),
-            value: appsExpanded)
-        // App-list expansion is scoped to the host currently on screen. A
-        // host switch always starts in the compact four-app presentation.
-        .onChange(of: host?.id) { _, _ in appsExpanded = false }
         // Right-click the hero to rename / set codec / unpair the current PC.
         .modifier(OptionalHostContextMenu(host: host))
     }

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -310,142 +310,55 @@ struct HostPowerControls: View {
 struct AppIconsRow: View {
     let apps: [LibraryApp]
     let host: Host
-    @Binding var isExpanded: Bool
     @Environment(AppModel.self) private var model
 
-    private let columns = Array(
-        repeating: GridItem(.fixed(70), spacing: 10),
-        count: 4
-    )
-
     var body: some View {
-        VStack(spacing: 8) {
-            // One glass composite for the app tiles - see ReadinessChip's
-            // container note. The compact view preserves the four-app scan;
-            // expanding swaps it for a complete four-column grid.
-            GlassEffectContainer(spacing: 10) {
-                if isExpanded {
-                    LazyVGrid(columns: columns, alignment: .center, spacing: 12) {
-                        ForEach(apps) { app in
-                            appTile(app)
+        // One glass composite for the row - see ReadinessChip's container note.
+        GlassEffectContainer(spacing: 10) {
+            HStack(spacing: 10) {
+                ForEach(apps.prefix(4)) { app in
+                    Button {
+                        model.requestStream(app: app, on: host)
+                    } label: {
+                        VStack(spacing: 4) {
+                            Image(systemName: app.systemImage)
+                                .font(.system(size: 18, weight: .medium))
+                                .symbolRenderingMode(.hierarchical)
+                                .frame(width: 44, height: 44)
+                                .glassEffect(
+                                    .regular.interactive(),
+                                    in: .rect(cornerRadius: 10)
+                                )
+                                .overlay {
+                                    // Accent ring for the hero target (resume
+                                    // app, else default) so the ring always
+                                    // agrees with the hero button's verb.
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .stroke(
+                                            app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
+                                            lineWidth: 2
+                                        )
+                                }
+                            Text(app.name)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
                         }
+                        .frame(width: 70)
                     }
-                } else {
-                    HStack(spacing: 10) {
-                        ForEach(apps.prefix(4)) { app in
-                            appTile(app)
-                        }
-                        if apps.count > 4 {
-                            expandButton
-                        }
-                    }
+                    .buttonStyle(.plain)
+                    .help(model.isStreaming
+                        ? "Finish the current stream first" : "Stream \(app.name)")
                 }
             }
-            if isExpanded {
-                collapseButton
-            }
         }
+        // Tiles park while a session exists (connecting, live, backgrounded):
+        // a click would spawn a SECOND concurrent session - stream()'s
+        // re-entrancy guard is the wall, this is the honest affordance. Dim
+        // as the visual cue (.plain buttons don't restyle on disable).
+        .disabled(model.isStreaming)
+        .opacity(model.isStreaming ? 0.45 : 1.0)
         .animation(.snappy(duration: 0.3), value: model.isStreaming)
-    }
-
-    /// Park a LAUNCH affordance while a session exists (connecting, live,
-    /// backgrounded): a click would spawn a SECOND concurrent session -
-    /// stream()'s re-entrancy guard is the wall, this is the honest affordance.
-    /// Dim as the visual cue (.plain buttons don't restyle on disable).
-    ///
-    /// Scoped to the TILES on purpose. Expand/collapse only change what this
-    /// view shows - they can't start anything - so parking them too would strand
-    /// an already-expanded list open for the whole session and stop the user
-    /// browsing their apps while streaming, for no safety benefit.
-    private func parkedWhileStreaming(_ view: some View) -> some View {
-        view
-            .disabled(model.isStreaming)
-            .opacity(model.isStreaming ? 0.45 : 1.0)
-    }
-
-    private func appTile(_ app: LibraryApp) -> some View {
-        parkedWhileStreaming(rawAppTile(app))
-    }
-
-    private func rawAppTile(_ app: LibraryApp) -> some View {
-        Button {
-            model.requestStream(app: app, on: host)
-        } label: {
-            VStack(spacing: 4) {
-                Image(systemName: app.systemImage)
-                    .font(.system(size: 18, weight: .medium))
-                    .symbolRenderingMode(.hierarchical)
-                    .frame(width: 44, height: 44)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: .rect(cornerRadius: 10)
-                    )
-                    .overlay {
-                        // Accent ring for the hero target (resume app, else
-                        // default) so it always agrees with the hero button.
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(
-                                app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
-                                lineWidth: 2
-                            )
-                    }
-                Text(app.name)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            // A `.plain` Button only hit-tests its label. Fill the grid cell
-            // inside the label, not merely on the outer Button, so padding
-            // around the icon and name launches the app too.
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .frame(width: 70, height: 70)
-        .help(model.isStreaming
-            ? "Finish the current stream first" : "Stream \(app.name)")
-    }
-
-    private var expandButton: some View {
-        Button { isExpanded = true } label: {
-            VStack(spacing: 4) {
-                Image(systemName: "ellipsis")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 44, height: 44)
-                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
-                Text("+\(apps.count - 4)")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .frame(width: 70, height: 70)
-        .help("Show all \(apps.count) apps")
-        .accessibilityLabel("Show all \(apps.count) apps")
-        .accessibilityValue("Collapsed")
-        .accessibilityHint("Expands the host app list")
-    }
-
-    private var collapseButton: some View {
-        Button { isExpanded = false } label: {
-            VStack {
-                Image(systemName: "chevron.up")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 28, height: 22)
-                    .glassEffect(.regular.interactive(), in: .capsule)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .frame(width: 44, height: 44)
-        .help("Show fewer apps")
-        .accessibilityLabel("Show fewer apps")
-        .accessibilityValue("Expanded")
-        .accessibilityHint("Collapses the host app list")
     }
 }
 


### PR DESCRIPTION
Reverts #49's two commits (`369ced1`, `2a8ea39`) in `ContentView.swift` and `ContentViewSubviews.swift`. Both files are now **byte-identical to the `2026.7.7` tag** — nothing else touched them in between, so this is a clean revert rather than a hand-rollback.

## Why

Shipped in 2026.8.0, the launcher reads as mostly empty space.

The hero's height went from a fixed `248` to `minHeight: 248` — a **floor, not a size**. The card accepts whatever height the window offers and the glass background fills it. A `ScrollView` was masking that by handing the card its ideal height, so the two changes only worked as a pair, and the composition still left a large void under the footer in any tall window.

Two follow-up attempts to fix it in place both made it worse:

1. Widening the hero to track the window — the `maxWidth: 520` cap turned out to date from the **initial commit** and had nothing to do with #49.
2. Sizing the window to its content — which can't work while the content is flexible on both axes; the window stayed resizable *and* the card stretched.

Three guesses at a layout is enough. Back to known-good geometry, start again from there.

## What #49 got right, worth re-landing separately

- **Full-tile hit targets.** A `.plain` Button only hit-tests its label, so the padding around each icon was dead space. That diagnosis is correct and completely independent of the geometry.
- **The underlying complaint.** Reaching every host app really is gated behind the Stream button's context menu again after this revert. That's a real gap.

The grid needs the hero to have a definite height it can grow *into*, and the window to have a definite size — the right shape is a card whose height is content-driven end to end, not a floor plus a ScrollView.

210 tests pass.