### PR TITLE
chore: release 2026.8.1 (revert the launcher geometry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026.8.1 - 2026-08-02
+
+Fixes the launcher window, which 2026.8.0 left mostly empty.
+
+The host card was changed to grow when its app list expands, but that also let
+it grow when nothing needed the room - so the window opened with a large blank
+area under the Stream button, and dragging it taller stretched the card into an
+empty slab. The launcher is back to the layout it had in 2026.7.7.
+
+The expandable app grid that came with it is gone for now, so a PC with more
+than four apps reaches the rest through the Stream button's context menu again,
+as before. It will return once the card can grow for the right reason and stop
+growing for the wrong one.
+
 ## 2026.8.0 - 2026-08-02
 
 Streaming over a VPN is far more reliable, a weak link no longer freezes the

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.0
-CURRENT_PROJECT_VERSION = 20260802
+MARKETING_VERSION = 2026.8.1
+CURRENT_PROJECT_VERSION = 20260803


### PR DESCRIPTION
Version bump + changelog for 2026.8.1, shipping the #53 revert to users.

**Build number is `20260803`, not `20260802`.** 2026.8.0 already shipped that stamp, and Sparkle compares updates on `CURRENT_PROJECT_VERSION` — reusing it would leave every 8.0 install unaware 8.1 exists. Despite the name, the field is a monotonic counter that merely *looks* like a date: 2026.7.4 through 7.7 ran `20260705/06/07/08` across different release days. So the next value is simply +1.

210 tests pass.