### PR TITLE
fix(ui): the launcher window is its content, and no longer resizable

### DIFF
--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -50,7 +50,9 @@ struct MainWindow: View {
                   AWDLHelperManager.shared.shouldPromptToEnable else { return }
             showAWDLPrompt = true
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // No .frame: forcing either axis to .infinity gives the window an
+        // unbounded box to fill, and the only thing available to fill it with is
+        // nothing. The content states its own size; the window follows it.
         .overlay(alignment: .top) {
             // Disconnect-beat toast - a brief, calm acknowledgement after a
             // stream ends instead of the launcher just snapping back.
@@ -202,9 +204,12 @@ private struct ConnectSurface: View {
             }
 
             ContextFooter()
-
-            Spacer(minLength: 0)
         }
+        // No trailing Spacer. It existed to pin the column to the top of a
+        // window that could be taller than its content - and the space it pushed
+        // down into was the empty area under the footer. The window now sizes to
+        // this column (see .windowResizability in GlimmerApp), so there is no
+        // leftover height to absorb and nothing to pin against.
         .padding(.horizontal, 32)
         .padding(.vertical, 20)
         // Hand off to the stream window: dim Glimmer's content so the
@@ -476,7 +481,11 @@ private struct HostHero: View {
         // 248pt (was 270): content measures ~218pt, so this trims the hero's
         // dead air ("a bit too much") while keeping honest breathing room.
         .frame(height: 248)
-        .frame(maxWidth: 520)
+        // `width`, not `maxWidth`: the window is sized from this column, and a
+        // maxWidth has no size of its own to measure - which is why an earlier
+        // attempt at a content-sized window stayed resizable anyway. 520 is the
+        // width the card already had in every window wide enough to show it.
+        .frame(width: 520)
         // Right-click the hero to rename / set codec / unpair the current PC.
         .modifier(OptionalHostContextMenu(host: host))
     }

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -47,20 +47,32 @@ struct GlimmerApp: App {
         Window("Glimmer", id: "main") {
             MainWindow()
                 .environment(model)
-                // Honest minimums: the hero caps at 520pt + 64pt surface
-                // padding (~584), and the empty state's copy wraps at 440 -
-                // 720×500 keeps every layout intact with no truncation.
-                .frame(minWidth: 720, idealWidth: 860, minHeight: 500, idealHeight: 540)
+                // WIDTH FLOOR ONLY. The hero is 520pt + 64pt surface padding =
+                // 584, which is also clear of the empty state's copy (wraps at
+                // 440). No height constraint and no ideal size: the window is
+                // sized from the content below, so anything stated here would
+                // just be a second opinion for it to argue with.
+                .frame(minWidth: 584)
                 // Liquid Glass: on macOS 26 `.regularMaterial` resolves to
                 // the system material; future SDKs may expose a dedicated
                 // `.glassBackground` shape style for window containers.
                 .containerBackground(.regularMaterial, for: .window)
         }
         .windowStyle(.hiddenTitleBar)
-        // Tighter default than the old 920×580 - the launcher is one hero
-        // card + a button, not a document; the hero geometry trim (248pt
-        // card) keeps the composition centred at this size.
-        .defaultSize(width: 780, height: 540)
+        // The window is exactly its content and cannot be dragged bigger. The
+        // launcher is one fixed-height hero card, a chip row, a button and a
+        // footer - nothing in it grows, so a resize could only ever add empty
+        // space, which is precisely what it was doing.
+        //
+        // This works only because every element below now states a definite
+        // size: the card is a fixed 248x520, the column no longer ends in a
+        // Spacer, and MainWindow no longer forces itself to .infinity. An
+        // earlier attempt set this while the content was still flexible - the
+        // window stayed resizable and the card stretched to fill it.
+        //
+        // No .defaultSize: it would be a second opinion about a size the content
+        // already knows.
+        .windowResizability(.contentSize)
         // Opt OUT of window state restoration so a previously-X-closed
         // launcher always re-spawns fresh next launch (the bug that made
         // first Dock click do nothing pre-restoration-fix).


### PR DESCRIPTION
Nothing in the launcher grows: a fixed 248×520 hero card, a chip row, a button, a footer. A resize could therefore only ever add empty space — which is exactly what it did, and what made 2026.8.0 read as mostly void.

`.windowResizability(.contentSize)` only works when the content states a **definite** size, which is why an earlier attempt at this left the window resizable anyway. Three things were flexible and now aren't:

- The hero used `maxWidth: 520` — a ceiling, with no size of its own to measure. Now `width: 520`, which is what it actually rendered at in every window wide enough to show it.
- The column ended in `Spacer(minLength: 0)`, whose whole job was pinning content to the top of a window taller than itself. **The space it pushed into was the empty area under the footer.**
- `MainWindow` forced `.frame(maxWidth: .infinity, maxHeight: .infinity)`, handing the window an unbounded box whose only available filling was nothing.

The hero keeps its fixed 248pt height from 2026.7.7, so the stretching failure mode that sank the first attempt can't recur — there's no `minHeight` floor for the glass background to grow into.

Padding untouched: 32/20 on the surface, 22/24 inside the card, 16pt rhythm between elements. Window lands at ~584×440.

210 tests pass.