### PR TITLE
chore: release 2026.8.2 (remote-path reliability, fixed-size launcher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,9 @@
 # Changelog
 
-## 2026.8.1 - 2026-08-02
-
-Fixes the launcher window, which 2026.8.0 left mostly empty.
-
-The host card was changed to grow when its app list expands, but that also let
-it grow when nothing needed the room - so the window opened with a large blank
-area under the Stream button, and dragging it taller stretched the card into an
-empty slab. The launcher is back to the layout it had in 2026.7.7.
-
-The expandable app grid that came with it is gone for now, so a PC with more
-than four apps reaches the rest through the Stream button's context menu again,
-as before. It will return once the card can grow for the right reason and stop
-growing for the wrong one.
-
-## 2026.8.0 - 2026-08-02
+## 2026.8.2 - 2026-08-02
 
 Streaming over a VPN is far more reliable, a weak link no longer freezes the
-picture indefinitely, and every app on your PC is reachable from the host card.
+picture indefinitely, and the launcher window no longer opens mostly empty.
 
 If you stream to your PC over a tunnel - Tailscale, WireGuard, or similar -
 Glimmer was sizing every video packet for a local network. Those packets are too
@@ -43,11 +29,9 @@ you'll see a brief pause and a note that quality is being reduced, then the
 picture returns. It steps down at most twice, never on a local network, and
 never raises the quality back on its own.
 
-Every app on your PC is now reachable from the host card. It used to show the
-first four and hide the rest behind the Stream button's context menu; a "+N"
-control now expands the full list into a grid, and collapses back. App tiles
-respond across their whole area rather than only where the icon sits, and a long
-list scrolls instead of pushing the Stream button off-screen.
+The launcher window is now exactly as big as what's in it, and no longer
+resizable. Nothing in it grows - one host card, a row of chips, a button - so
+dragging it larger only ever added empty space.
 
 ## 2026.7.7 - 2026-07-22
 

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.1
-CURRENT_PROJECT_VERSION = 20260803
+MARKETING_VERSION = 2026.8.2
+CURRENT_PROJECT_VERSION = 20260804

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,22 +6,6 @@
     <description>Glimmer auto-update feed</description>
     <language>en</language>
     <item>
-      <title>2026.8.1</title>
-      <pubDate>Sun, 02 Aug 2026 12:31:57 GMT</pubDate>
-      <sparkle:version>20260803</sparkle:version>
-      <sparkle:shortVersionString>2026.8.1</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://github.com/Se7enbrc/glimmer/releases/download/2026.8.1/Glimmer-2026.8.1.zip" type="application/octet-stream" sparkle:edSignature="fNaMBdkxGtkmPZ2QV+VCtBkwdtJjgkXtO9Z9Jmjj8uPCA40XtJ3uK3Zer5daByAZgbU0NIs2/MmoVcDwTPwJBg==" length="8221496" />
-    </item>
-    <item>
-      <title>2026.8.0</title>
-      <pubDate>Sun, 02 Aug 2026 11:53:44 GMT</pubDate>
-      <sparkle:version>20260802</sparkle:version>
-      <sparkle:shortVersionString>2026.8.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://github.com/Se7enbrc/glimmer/releases/download/2026.8.0/Glimmer-2026.8.0.zip" type="application/octet-stream" sparkle:edSignature="150cLBeR2LeG16NQKAlW1vxtx1if03VMfobu3iEwcMUbA+VryKxrotdTWnZHdCyj1Vh52JC5TrYZL0VKvkafAw==" length="8241475" />
-    </item>
-    <item>
       <title>2026.7.7</title>
       <pubDate>Wed, 22 Jul 2026 18:11:28 GMT</pubDate>
       <sparkle:version>20260708</sparkle:version>


### PR DESCRIPTION
Supersedes 2026.8.0 and 2026.8.1, both of which are being **deleted** rather than kept: 8.0 shipped a launcher that read as mostly empty space, 8.1 was the revert. Neither is worth preserving as a version anyone can install, and their combined content is exactly what 8.2 is.

Three things follow from deleting them:

- **CHANGELOG** consolidates both entries into one 8.2 entry. Leaving them would describe releases that can't be downloaded and send readers looking for an 8.0 that isn't there.
- **appcast.xml** drops the 8.0 and 8.1 `<item>` blocks. Their enclosure URLs point at assets that are about to 404 — a client that pinned one would fail its update rather than fall through to 8.2. Verified well-formed after the edit.
- **Build number `20260804`.** Sparkle compares `CURRENT_PROJECT_VERSION`, and `20260802`/`20260803` are burned even once the releases are gone. The single 8.0 zip download was Sparkle's own fetch, so anyone who did land there still needs a strictly higher number to be offered 8.2.

The app grid from #49 is **not** in this release — reverted in #53, and it wants a card whose height is content-driven before it can return.