### PR TITLE
fix(ui): actually stop the vertical resize - minHeight floors were the leak

### DIFF
--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -212,6 +212,15 @@ private struct ConnectSurface: View {
         // leftover height to absorb and nothing to pin against.
         .padding(.horizontal, 32)
         .padding(.vertical, 20)
+        // TAKE THE IDEAL HEIGHT, NOT THE OFFERED ONE. Removing the Spacer was
+        // not enough on its own: StreamButton's label carries
+        // `.frame(maxWidth: .infinity, minHeight: 46)`, and a minHeight is a
+        // FLOOR - the button will accept any height it is offered, which made
+        // this column vertically flexible and gave the window something to grow
+        // into. That is why 2026.8.2 still resized vertically. `fixedSize`
+        // proposes nil height to the column, so every such floor resolves to its
+        // own ideal instead of springboarding off the window.
+        .fixedSize(horizontal: false, vertical: true)
         // Hand off to the stream window: dim Glimmer's content so the
         // fullscreen surface visibly takes over and reverses on disconnect.
         .opacity(isHandedOff ? 0.4 : 1.0)

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -653,9 +653,10 @@ struct EmptyPairingState: View {
     @State private var showPair = false
 
     var body: some View {
+        // No leading/trailing Spacers: they centred this state inside a window
+        // taller than itself, and the window now sizes to its content, so there
+        // is no extra height to centre within - only height they would invent.
         VStack(spacing: 26) {
-            Spacer()
-
             ZStack {
                 // Floating glass medallion behind the hero symbol -
                 // accent-tinted so it picks up the system tint.
@@ -704,10 +705,9 @@ struct EmptyPairingState: View {
             }
             .buttonStyle(StreamButtonStyle())
             .controlSize(.large)
-
-            Spacer()
         }
         .padding(40)
+        .fixedSize(horizontal: false, vertical: true)
         .sheet(isPresented: $showPair) {
             PairSheet().environment(model)
         }


### PR DESCRIPTION
2026.8.2 set `.windowResizability(.contentSize)` and removed the trailing `Spacer`, and the window **still resized vertically**.

`.contentSize` can only pin a window whose content has a definite size, and two things were still handing it an open-ended one:

- **`StreamButton`'s label carries `.frame(maxWidth: .infinity, minHeight: 46)`.** A `minHeight` is a *floor*, not a size — the button accepts any height offered, so the column stayed vertically flexible and the window had something to grow into. Same shape of mistake as the hero's old `minHeight: 248`, one layer further down.
- **`EmptyPairingState` opened and closed with `Spacer()`**, whose only job was centring inside a window taller than itself.

Fixed by proposing nil height rather than hunting every floor: the connect column and the empty state each take their **ideal** height via `.fixedSize(horizontal: false, vertical: true)`, so a `minHeight` resolves to its own ideal instead of springboarding off the window. Any future child with a floor is covered by construction.

## Verified, not assumed

Driving the live window through the accessibility API and reading the size back:

```
tried 584x800 -> 584x494
tried 584x400 -> 584x494
tried 900x494 -> 584x494
```

Taller, shorter and wider all rejected. The window is 584×494 and fixed.

The three previous attempts at this shipped on inspection alone, which is how a resize bug survived two releases. This one has a repeatable check behind it.

210 tests pass; no new SwiftLint output.