### PR TITLE
chore: release 2026.8.3 (fixed-size launcher, verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.8.2 - 2026-08-02
+## 2026.8.3 - 2026-08-02
 
 Streaming over a VPN is far more reliable, a weak link no longer freezes the
 picture indefinitely, and the launcher window no longer opens mostly empty.
@@ -30,8 +30,8 @@ picture returns. It steps down at most twice, never on a local network, and
 never raises the quality back on its own.
 
 The launcher window is now exactly as big as what's in it, and no longer
-resizable. Nothing in it grows - one host card, a row of chips, a button - so
-dragging it larger only ever added empty space.
+resizable in either direction. Nothing in it grows - one host card, a row of
+chips, a button - so dragging it larger only ever added empty space.
 
 ## 2026.7.7 - 2026-07-22
 

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.2
-CURRENT_PROJECT_VERSION = 20260804
+MARKETING_VERSION = 2026.8.3
+CURRENT_PROJECT_VERSION = 20260805

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,14 +6,6 @@
     <description>Glimmer auto-update feed</description>
     <language>en</language>
     <item>
-      <title>2026.8.2</title>
-      <pubDate>Sun, 02 Aug 2026 12:43:15 GMT</pubDate>
-      <sparkle:version>20260804</sparkle:version>
-      <sparkle:shortVersionString>2026.8.2</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://github.com/Se7enbrc/glimmer/releases/download/2026.8.2/Glimmer-2026.8.2.zip" type="application/octet-stream" sparkle:edSignature="nQ6LS448vF1QfuHzreukKFVP5xyO4VKbHNCw0devvdVCzVTb5F9dfDirzay32KHTMAquk0xZEsyNZGXBJDCABA==" length="8221424" />
-    </item>
-    <item>
       <title>2026.7.7</title>
       <pubDate>Wed, 22 Jul 2026 18:11:28 GMT</pubDate>
       <sparkle:version>20260708</sparkle:version>


### PR DESCRIPTION
Supersedes 2026.8.2, which is being deleted for the same reason 8.0 and 8.1 were: it shipped the resize bug it claimed to fix.

- **CHANGELOG**: the 8.2 entry is *renamed* to 8.3 rather than appended to — 8.2 won't exist to install, so describing it separately would only send readers looking for it.
- **appcast.xml**: drops the 8.2 item ahead of the release being deleted, so no client is ever pointed at a 404.
- **Build `20260805`**: `20260804` is burned whether or not the release survives.

Unlike 8.2, the "no longer resizable" claim in this entry was checked against the **running window** rather than the source:

```
tried 584x800 -> 584x494
tried 584x400 -> 584x494
tried 900x494 -> 584x494
```

210 tests pass.