### PR TITLE
feat(ui): app overflow dropdown, and margins that aren't cramped (2026.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026.8.4 - 2026-08-02
+
+The launcher sits at a comfortable size again, and every app on your PC is
+reachable without it changing shape.
+
+2026.8.3 pinned the window to its content, which left the host card nearly
+touching the frame. There is proper breathing room around it again, and the
+window is still a fixed size - nothing in the launcher grows, so being able to
+drag it larger only ever added empty space.
+
+If your PC has more than five apps, the extra ones now live in a dropdown at the
+end of the row instead of being reachable only through the Stream button's
+context menu. The menu opens over the window, so reaching a sixth app no longer
+resizes anything. App tiles also respond across their whole area now, rather
+than only where the icon sits.
+
 ## 2026.8.3 - 2026-08-02
 
 Streaming over a VPN is far more reliable, a weak link no longer freezes the

--- a/Glimmer/ContentView.swift
+++ b/Glimmer/ContentView.swift
@@ -210,7 +210,18 @@ private struct ConnectSurface: View {
         // down into was the empty area under the footer. The window now sizes to
         // this column (see .windowResizability in GlimmerApp), so there is no
         // leftover height to absorb and nothing to pin against.
-        .padding(.horizontal, 32)
+        // 80pt sides -> a 680pt window around the 520pt card. Bisected between
+        // two values checked on screen: 32 (584 window) read as cramped, the
+        // card nearly touching the frame; 130 (780, matching 7.7's default
+        // width) read as too big. The VERTICAL padding stays tight - the space
+        // under the footer was the part that read as waste, and 7.7's own top
+        // margin was 20.
+        //
+        // This is THE margin dial. It must stay in step with GlimmerApp's
+        // window minWidth (520 + 2x this): a floor below the real content width
+        // leaves the window a range to be dragged through, which is how the
+        // margins got squeezed flat once already.
+        .padding(.horizontal, 80)
         .padding(.vertical, 20)
         // TAKE THE IDEAL HEIGHT, NOT THE OFFERED ONE. Removing the Spacer was
         // not enough on its own: StreamButton's label carries

--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -312,43 +312,40 @@ struct AppIconsRow: View {
     let host: Host
     @Environment(AppModel.self) private var model
 
+    /// Most tiles the row will ever show inline. Five 70pt tiles span
+    /// 5x70 + 4x10 = 390 inside the hero's 472pt content box, so the row stays
+    /// one comfortable line at the card's FIXED width.
+    private static let maxInlineTiles = 5
+
+    /// Apps shown as tiles. At or under the inline cap every app gets one; past
+    /// it the last slot is spent on the overflow menu instead of a tile, so the
+    /// row is never wider than `maxInlineTiles`.
+    private var inlineApps: [LibraryApp] {
+        apps.count <= Self.maxInlineTiles
+            ? apps
+            : Array(apps.prefix(Self.maxInlineTiles - 1))
+    }
+
+    private var overflowApps: [LibraryApp] {
+        apps.count <= Self.maxInlineTiles
+            ? []
+            : Array(apps.dropFirst(Self.maxInlineTiles - 1))
+    }
+
     var body: some View {
         // One glass composite for the row - see ReadinessChip's container note.
         GlassEffectContainer(spacing: 10) {
             HStack(spacing: 10) {
-                ForEach(apps.prefix(4)) { app in
-                    Button {
-                        model.requestStream(app: app, on: host)
-                    } label: {
-                        VStack(spacing: 4) {
-                            Image(systemName: app.systemImage)
-                                .font(.system(size: 18, weight: .medium))
-                                .symbolRenderingMode(.hierarchical)
-                                .frame(width: 44, height: 44)
-                                .glassEffect(
-                                    .regular.interactive(),
-                                    in: .rect(cornerRadius: 10)
-                                )
-                                .overlay {
-                                    // Accent ring for the hero target (resume
-                                    // app, else default) so the ring always
-                                    // agrees with the hero button's verb.
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .stroke(
-                                            app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
-                                            lineWidth: 2
-                                        )
-                                }
-                            Text(app.name)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                        .frame(width: 70)
-                    }
-                    .buttonStyle(.plain)
-                    .help(model.isStreaming
-                        ? "Finish the current stream first" : "Stream \(app.name)")
+                ForEach(inlineApps) { app in
+                    appTile(app)
+                }
+                // Overflow goes in a MENU, not an expanding grid. The launcher
+                // window is sized to its content and deliberately not resizable,
+                // so anything that grows the card has to grow the window - which
+                // is what made the expand-in-place grid untenable. A menu opens
+                // OVER the window and costs no layout at all.
+                if !overflowApps.isEmpty {
+                    overflowMenu
                 }
             }
         }
@@ -359,6 +356,79 @@ struct AppIconsRow: View {
         .disabled(model.isStreaming)
         .opacity(model.isStreaming ? 0.45 : 1.0)
         .animation(.snappy(duration: 0.3), value: model.isStreaming)
+    }
+
+    private func appTile(_ app: LibraryApp) -> some View {
+        Button {
+            model.requestStream(app: app, on: host)
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: app.systemImage)
+                    .font(.system(size: 18, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: 44, height: 44)
+                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
+                    .overlay {
+                        // Accent ring for the hero target (resume app, else
+                        // default) so the ring always agrees with the hero
+                        // button's verb.
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(
+                                app.name == model.heroTargetAppName ? Color.accentColor : Color.clear,
+                                lineWidth: 2
+                            )
+                    }
+                Text(app.name)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            // A `.plain` Button only hit-tests its LABEL, so without this the
+            // padding around the icon and name was dead space. Fill the declared
+            // 70pt slot inside the label and claim it as the content shape.
+            // (Salvaged from #49, which got this part right.)
+            .frame(width: 70, height: 70)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(model.isStreaming
+            ? "Finish the current stream first" : "Stream \(app.name)")
+    }
+
+    /// The overflow dropdown: every app past the inline cap, in source order.
+    /// Reads as one more tile in the row, but opens a native menu over the
+    /// window instead of resizing anything.
+    private var overflowMenu: some View {
+        Menu {
+            ForEach(overflowApps) { app in
+                Button {
+                    model.requestStream(app: app, on: host)
+                } label: {
+                    Label(app.name, systemImage: app.systemImage)
+                }
+            }
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 18, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: 44, height: 44)
+                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
+                Text("\(overflowApps.count) more")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(width: 70, height: 70)
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 70, height: 70)
+        .help(model.isStreaming
+            ? "Finish the current stream first"
+            : "Show \(overflowApps.count) more app\(overflowApps.count == 1 ? "" : "s")")
+        .accessibilityLabel("\(overflowApps.count) more apps")
     }
 }
 

--- a/Glimmer/GlimmerApp.swift
+++ b/Glimmer/GlimmerApp.swift
@@ -47,12 +47,14 @@ struct GlimmerApp: App {
         Window("Glimmer", id: "main") {
             MainWindow()
                 .environment(model)
-                // WIDTH FLOOR ONLY. The hero is 520pt + 64pt surface padding =
-                // 584, which is also clear of the empty state's copy (wraps at
-                // 440). No height constraint and no ideal size: the window is
-                // sized from the content below, so anything stated here would
-                // just be a second opinion for it to argue with.
-                .frame(minWidth: 584)
+                // 520pt card + 80pt margins per side = 680. This MUST equal the
+                // connect surface's real width (ConnectSurface's .horizontal
+                // padding): a floor BELOW it leaves the window that much range
+                // to be dragged through, and it opens at the bottom of the range
+                // with the margins squeezed flat - which is exactly what a stale
+                // 584 here did. A floor equal to the content leaves nothing to
+                // drag.
+                .frame(minWidth: 680)
                 // Liquid Glass: on macOS 26 `.regularMaterial` resolves to
                 // the system material; future SDKs may expose a dedicated
                 // `.glassBackground` shape style for window containers.

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.3
-CURRENT_PROJECT_VERSION = 20260805
+MARKETING_VERSION = 2026.8.4
+CURRENT_PROJECT_VERSION = 20260806


### PR DESCRIPTION
## Margins

2026.8.3 pinned the window to its content and the card ended up nearly touching the frame. 80pt sides — a 680pt window around the 520pt card — is **bisected between two values checked on screen**, not picked: 32 (584 window) read as cramped, 130 (780, matching 7.7's default width) read as too big.

The margin dial and `GlimmerApp`'s window `minWidth` are **coupled**: minWidth must equal `520 + 2×` the padding. A floor below the real content width leaves the window that much range to be dragged through, and it opens at the *bottom* of that range with the margins squeezed flat — exactly what a stale `minWidth: 584` did after the padding moved. Both sites now say so in comments.

## Overflow dropdown, replacing #49's expanding grid

Up to five apps show as tiles (5×70 + 4×10 = 390 inside the card's 472pt content box); past that the last slot becomes a menu holding the rest.

This is the shape that fits a fixed-size window. A menu opens **over** the window and costs no layout, where the expand-in-place grid had to grow the card, which had to grow the window — the thing that made #49 untenable and took three attempts to unwind.

Also salvages the one part of #49 that was right independent of geometry: a `.plain` Button only hit-tests its label, so the padding around each icon was dead space. Tiles now fill their declared 70×70 slot and claim it as the content shape.

## Verification

Window driven through the accessibility API against the running app:

```
opens at 680x494   after_grow=680x494
```

210 tests pass; no new SwiftLint output.

**Not verified:** the dropdown with real overflow. The test host has two apps, so the menu has never rendered with a populated list.