### PR TITLE
fix(ui): re-land the two non-geometry pieces of #49 lost in the revert

### DIFF
--- a/Glimmer/ContentViewSubviews.swift
+++ b/Glimmer/ContentViewSubviews.swift
@@ -349,11 +349,18 @@ struct AppIconsRow: View {
                 }
             }
         }
-        // Tiles park while a session exists (connecting, live, backgrounded):
-        // a click would spawn a SECOND concurrent session - stream()'s
-        // re-entrancy guard is the wall, this is the honest affordance. Dim
-        // as the visual cue (.plain buttons don't restyle on disable).
-        .disabled(model.isStreaming)
+        // Dim the whole row while a session exists (connecting, live,
+        // backgrounded) as the visual "parked" cue - .plain buttons don't
+        // restyle on disable, so the opacity IS the affordance.
+        //
+        // The DISABLE, though, is scoped to the launch affordances themselves
+        // (each tile, and each item inside the overflow menu) rather than
+        // blanket-applied here. A click on one would spawn a SECOND concurrent
+        // session - stream()'s re-entrancy guard is the wall, this is the honest
+        // signal. But OPENING the menu launches nothing, and disabling the whole
+        // row took that with it: mid-session you could not even look at which
+        // apps the PC has. Same distinction this file's review of #49 drew for
+        // the old expand/collapse controls; it was lost in the revert.
         .opacity(model.isStreaming ? 0.45 : 1.0)
         .animation(.snappy(duration: 0.3), value: model.isStreaming)
     }
@@ -391,6 +398,7 @@ struct AppIconsRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(model.isStreaming)
         .help(model.isStreaming
             ? "Finish the current stream first" : "Stream \(app.name)")
     }
@@ -406,6 +414,9 @@ struct AppIconsRow: View {
                 } label: {
                     Label(app.name, systemImage: app.systemImage)
                 }
+                // Each ITEM is a launch, so each item parks - the menu itself
+                // stays openable so the list is still readable mid-session.
+                .disabled(model.isStreaming)
             }
         } label: {
             VStack(spacing: 4) {
@@ -429,6 +440,7 @@ struct AppIconsRow: View {
             ? "Finish the current stream first"
             : "Show \(overflowApps.count) more app\(overflowApps.count == 1 ? "" : "s")")
         .accessibilityLabel("\(overflowApps.count) more apps")
+        .accessibilityHint("Shows the rest of this PC's apps")
     }
 }
 


### PR DESCRIPTION
Diffed #49's final state (`2a8ea39`) against `main` to find what the geometry revert took with it that had nothing to do with geometry. Two things.

### 1. The scoped disable

`.disabled(model.isStreaming)` sat on the whole row, so mid-session the overflow menu couldn't even be **opened** — you couldn't look at which apps the PC has. Opening a menu launches nothing; only its items do.

The disable now sits on each tile and each menu item, while the row keeps the dimmed "parked" opacity as the visual cue.

This is the same distinction my own review of #49 drew for its expand/collapse controls, and the fix I pushed to that branch. It was correct then, and got reverted along with the geometry it had nothing to do with.

### 2. Accessibility hint on the overflow control

#49 gave its expand button a label / value / hint; the dropdown had only a label. The hint is what tells a screen-reader user what activating it will actually do.

### Deliberately not coming back

Everything else #49 removed was geometry — the `ScrollView`, the `.infinity` frames, the `minHeight` floor, the expansion state and its reduce-motion animation. The overflow dropdown shipped in 2026.8.4 covers the actual need without any of it.

210 tests pass; no new SwiftLint output.