### PR TITLE
chore: release 2026.8.5 (browse apps while streaming)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.8.5 - 2026-08-02
+
+You can browse your PC's apps while a stream is running again.
+
+If a PC has more than five apps, the extras live in a dropdown at the end of the
+row. That dropdown was being switched off along with the app tiles whenever a
+session was live - which is right for the tiles, since tapping one would start a
+second stream, but it also meant you couldn't so much as look at the list
+mid-session. The dropdown now opens; only the launching is held back. Screen
+readers also get a proper description of what it does.
+
 ## 2026.8.4 - 2026-08-02
 
 The launcher sits at a comfortable size again, and every app on your PC is

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.4
-CURRENT_PROJECT_VERSION = 20260806
+MARKETING_VERSION = 2026.8.5
+CURRENT_PROJECT_VERSION = 20260807


### PR DESCRIPTION
Version bump + changelog for 2026.8.5, shipping #60.

Build `20260807`, following `20260806` (8.4).

210 tests pass.