### PR TITLE
docs(contributing): UI-change and build-hygiene rules, from the 8.0-8.5 rabbit hole

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -341,6 +341,35 @@ Body wrapped at ~72 columns when one's needed.
 `no_coauthor_trailer` swiftlint rule on source files and by repo policy on
 commits. Same for any "Generated with Claude" attribution.
 
+## The bar
+
+**"It builds clean" is table stakes, not evidence.** Neither is "the tests
+pass". Both are necessary; neither says anything about whether the thing is any
+good.
+
+The bar for anything a user can see or feel is: **would someone with taste,
+looking at this for two seconds, be appalled?** If you would not put it in a
+demo, it is not done - however green the checks are.
+
+This is not hypothetical. Glimmer 2026.8.0 shipped a launcher whose host card
+floated in ~420pt of empty window. It compiled without a warning, 210 tests
+passed, SwiftLint was clean, and it was obviously wrong to anyone who opened it.
+It took five further releases to walk back, because each attempt was validated
+by reading the diff instead of looking at the app.
+
+Practically, before you call something done:
+
+- **Run it.** Not the test suite - the app, the way a user meets it.
+- **Look at it**, in the states a user will hit: empty, one host, many apps,
+  mid-stream, disconnected, the smallest and largest window you allow.
+- **Prove the claim you are making.** If the claim is "no longer resizable",
+  drive the window and read the size back (see [UI changes](#ui-changes)). If it
+  is "reconnects cleanly", pull the cable. A claim you have not exercised is a
+  guess with a commit message.
+- **Say what you did NOT verify.** An honest "the dropdown has never rendered
+  with more than two apps" is worth more than silence, and it is what lets the
+  next person aim their attention.
+
 ## Pull requests
 
 - `main` is the active development branch; releases are tags on it.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -114,6 +114,61 @@ sudo tccutil reset All io.ugfugl.Glimmer
 service name `tccutil` accepts. `All` is the working form, and it also clears
 Input Monitoring (the DualSense raw-HID grant), so expect to re-approve that.
 
+## UI changes
+
+The launcher window is **sized to its content and not resizable**
+(`.windowResizability(.contentSize)` in `GlimmerApp`). That only holds while
+every view in the column states a _definite_ size, which makes ordinary SwiftUI
+idioms load-bearing in a way that is easy to miss:
+
+- `minHeight:` / `minWidth:` are **floors, not sizes**. A view with a floor
+  accepts any larger size it is offered, so one of them anywhere in the column
+  hands the window something to grow into - the window becomes resizable again
+  and the offending view stretches to fill whatever the user drags out.
+- `.frame(maxWidth: .infinity)` has no size of its own to measure.
+- A trailing `Spacer()` exists to push content against a container taller than
+  itself. In a content-sized window there is no such space, so it can only
+  invent some.
+- `ConnectSurface` and `EmptyPairingState` therefore end in
+  `.fixedSize(horizontal: false, vertical: true)` - they take their ideal height
+  rather than the offered one. Keep it that way.
+
+The window's `minWidth` in `GlimmerApp` must equal the connect surface's real
+width (card width + 2x its horizontal padding). A floor _below_ the true content
+width leaves the window that much range to be dragged through, and it opens at
+the bottom of that range with the margins squeezed flat.
+
+**Verify geometry against the running app, not the source.** Every one of the
+above was shipped at least once on a source reading that looked right. Build,
+install, launch, then ask the window what it actually did:
+
+```bash
+osascript <<'EOS'
+tell application "System Events"
+  tell process "Glimmer"
+    set w to first window
+    set s0 to size of w
+    set out to "opens at " & ((item 1 of s0) as integer) & "x" & ((item 2 of s0) as integer)
+    try
+      set size of w to {1200, 900}
+    end try
+    delay 0.7
+    set s1 to size of w
+    return out & "  after_grow=" & ((item 1 of s1) as integer) & "x" & ((item 2 of s1) as integer)
+  end tell
+end tell
+EOS
+```
+
+If `after_grow` differs from the opening size, something in the column is still
+flexible. This takes about a minute and is not optional for a geometry change -
+a resize regression once survived two releases because it was only ever read,
+never run.
+
+A UI pull request should say which of these it touches, and include a
+before/after screenshot at the smallest and largest window the change allows.
+"Builds clean" is not evidence about layout.
+
 ## Lint
 
 `swiftlint` runs as a pre-commit hook. The baseline is intentionally non-strict:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,9 +52,9 @@ xcodebuild -project Glimmer.xcodeproj -scheme Glimmer -configuration Debug \
     -derivedDataPath ./build -destination 'platform=macOS' build
 ```
 
-For an inner-loop edit cycle, either use `make dev` (Release build with a stable
-self-signed dev signature so TCC grants survive rebuilds - see the Makefile
-comments), or work in Xcode against `Glimmer.xcodeproj`:
+For an inner-loop edit cycle, either use `make dev` (unit tests, then the
+notarized Release build, installed and relaunched - same signing path as
+`make install`), or work in Xcode against `Glimmer.xcodeproj`:
 
 1. Set the Glimmer scheme's Run xcconfig to `Glimmer/StreamLib.xcconfig` (Edit
    Scheme → Run → Info). It supplies the OpenSSL/Opus search paths and the
@@ -68,6 +68,51 @@ log stream --predicate 'subsystem == "io.ugfugl.Glimmer"' --level info
 ```
 
 See [PROFILING.md](PROFILING.md) for per-category predicates.
+
+### Build hygiene - don't mint app copies
+
+**Build once per thing you actually want to look at.** Not once per edit.
+
+macOS gives every distinct copy of the bundle its own privacy identity. Anything
+that registers a `Glimmer.app` with LaunchServices - and `make app` re-registers
+its Debug bundle on _every_ run - earns a separate row under **System Settings →
+Privacy & Security → Local Network**. Those rows are TCC records: they survive
+deleting the app, and they survive a reboot.
+
+One session of rebuild-on-every-edit produced **nine** registered copies (two
+checkouts' `build/`, two DerivedData trees, `/Applications`, Trash, Downloads)
+and eight Local Network entries. The app then could not reach a host on the LAN,
+and the failure surfaced as `Couldn't reach <ip>` - which reads as a network
+problem and is not one.
+
+Keep the inner loop cheap and batch the install:
+
+```bash
+make app     # compile-only check - fast, no install
+make test    # unit tests
+make dev     # ONLY when you want to actually use the build
+```
+
+Clean up copies you created:
+
+```bash
+LSREG=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/\
+LaunchServices.framework/Versions/A/Support/lsregister
+"$LSREG" -dump | grep -oE '/[^ ]*Glimmer\.app' | sort -u   # what macOS knows about
+"$LSREG" -u /path/to/stale/Glimmer.app                      # unregister one
+rm -rf build ~/Library/Developer/Xcode/DerivedData/Glimmer-*
+```
+
+Unregistering does **not** retract the privacy grants. Only this does, and only
+the user can run it:
+
+```bash
+sudo tccutil reset All io.ugfugl.Glimmer
+```
+
+`tccutil reset LocalNetwork <bundle-id>` is rejected - `LocalNetwork` is not a
+service name `tccutil` accepts. `All` is the working form, and it also clears
+Input Monitoring (the DualSense raw-HID grant), so expect to re-approve that.
 
 ## Lint
 


### PR DESCRIPTION
Two fixes to the Build section, both learned the hard way today.

### Correction

The guide claimed `make dev` uses *"a stable self-signed dev signature so TCC grants survive rebuilds"*. It doesn't — `dev` is `test reinstall`, which runs the unit tests and then the **same notarized Developer-ID Release path** as `make install`. There is no separate dev signature. Anyone following that sentence would expect their privacy grants to persist for a reason that doesn't exist.

### New: build hygiene

macOS gives every distinct copy of the bundle its own privacy identity, and **`make app` re-registers its Debug bundle with LaunchServices on every run**.

One session of rebuild-on-every-edit left **nine** registered `Glimmer.app` copies — two checkouts' `build/`, two DerivedData trees, `/Applications`, Trash, Downloads — and **eight Local Network entries**. The app then couldn't reach a host on the LAN, and the failure surfaced as `Couldn't reach <ip>`, which reads as a network problem and isn't one. Those TCC records survive deleting the app *and* a reboot.

Documents:
- the cheap inner loop (`make app` / `make test`, batch the install)
- enumerating and unregistering stale copies via `lsregister`
- the one command that actually retracts the grants: `sudo tccutil reset All io.ugfugl.Glimmer`
- that `tccutil reset LocalNetwork <id>` is **rejected** — `LocalNetwork` isn't a service name `tccutil` accepts — since that's a dead end worth signposting
- that `All` takes Input Monitoring (DualSense raw-HID) with it