### PR TITLE
chore: release 2026.8.6 (high-refresh bitrate fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026.8.6 - 2026-08-04
+
+Sharper picture on high-refresh displays.
+
+Glimmer worked out its quality budget in a way that quietly penalised fast
+monitors: every time the frame rate doubled, each individual frame got about 30%
+fewer bits to work with. A 240Hz display therefore looked blockier than a 120Hz
+one at the same resolution - the opposite of what you buy a fast panel for.
+Streaming at 4K240 now gives each frame the same budget 4K120 gets, and 120Hz
+modes gain a little too. Anything at 60Hz or below is unchanged.
+
+Measured on a 4K240 HDR stream: each frame went from about 46 KB to 72 KB, with
+no added latency and no dropped packets.
+
+Because of this, high-refresh streams now ask your PC for more bandwidth than
+before. On a local network that costs nothing; over a VPN or the internet
+Glimmer still measures the connection first and asks for what it can carry.
+
 ## 2026.8.5 - 2026-08-02
 
 You can browse your PC's apps while a stream is running again.

--- a/Glimmer/Version.xcconfig
+++ b/Glimmer/Version.xcconfig
@@ -10,5 +10,5 @@
 // because the build is driven by `make` (which passes -xcconfig), the
 // version is NOT set in project.pbxproj - bump it HERE, build with `make`.
 
-MARKETING_VERSION = 2026.8.5
-CURRENT_PROJECT_VERSION = 20260807
+MARKETING_VERSION = 2026.8.6
+CURRENT_PROJECT_VERSION = 20260808


### PR DESCRIPTION
Version bump + changelog for 2026.8.6, shipping #63.

Build `20260808`, following `20260807` (8.5).

Measured on a live 4K240 HDR stream: bytes/frame 46,029 → 72,327 (+57%), goodput 37.4 → 60.7 Mbps, pre-FEC loss unchanged at 0.000%, glass-to-glass 15.1 → 15.3 ms.

210 tests pass.