### PR TITLE
fix(audio): playout-stall watchdog - silence no longer survives until reconnect

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		D2000027 /* SdpCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000026 /* SdpCodecTests.swift */; };
 		D2B00004 /* BitrateDownshiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00003 /* BitrateDownshiftTests.swift */; };
 		D2B00002 /* StreamPathMTUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00001 /* StreamPathMTUTests.swift */; };
+		D2B00006 /* AudioPlayoutStallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00005 /* AudioPlayoutStallTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -432,6 +433,7 @@
 		D2000026 /* SdpCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdpCodecTests.swift; sourceTree = "<group>"; };
 		D2B00003 /* BitrateDownshiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitrateDownshiftTests.swift; sourceTree = "<group>"; };
 		D2B00001 /* StreamPathMTUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPathMTUTests.swift; sourceTree = "<group>"; };
+		D2B00005 /* AudioPlayoutStallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayoutStallTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 				D2000026 /* SdpCodecTests.swift */,
 				D2B00003 /* BitrateDownshiftTests.swift */,
 				D2B00001 /* StreamPathMTUTests.swift */,
+				D2B00005 /* AudioPlayoutStallTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -1059,6 +1062,7 @@
 				D2000027 /* SdpCodecTests.swift in Sources */,
 				D2B00004 /* BitrateDownshiftTests.swift in Sources */,
 				D2B00002 /* StreamPathMTUTests.swift in Sources */,
+				D2B00006 /* AudioPlayoutStallTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -42,6 +42,17 @@ extension AudioDecoder {
     /// still a step short of target hands the measured deficit to the silence
     /// backfill (`backfillCushion`) - by then the clump had its full window.
     static let reprimeGraceNanos: UInt64 = 250_000_000
+    /// Playout-stall watchdog threshold (ns): wall time with ZERO completion
+    /// progress before a backlog-gate drop declares the node stalled. 3s is far
+    /// past any legitimate pause - the deepest cushion is 300ms of 5ms buffers,
+    /// so a consuming node completes every few ms; only a node that stopped
+    /// pulling (output device slept/vanished - the 2026-08-12 overnight wedge,
+    /// 9h silent with 200 pkt/s arriving) goes 3s dark while drops fire.
+    static let playoutStallThresholdNanos: UInt64 = 3_000_000_000
+    /// Minimum spacing (ns) between stall-recovery rebuilds: a truly dead
+    /// output device RETRIES on this cadence ("never a permanent give-up")
+    /// instead of thrashing the node/engine per dropped packet.
+    static let stallRecoveryRetryNanos: UInt64 = 5_000_000_000
     /// Safety fallback FLOOR: prime (start playback) after at most this many
     /// buffers regardless of the measured cushion, so a very low-bitrate /
     /// near-silent stream (where the depth never reaches the target before
@@ -116,6 +127,7 @@ extension AudioDecoder {
             let now = DispatchTime.now().uptimeNanoseconds
             if now >= gateGraceUntilNanos && now &- lastTrimNanos >= Self.playoutTrimMinIntervalNanos {
                 lastTrimNanos = now
+                noteDropForStallWatchdogLocked(now: now)
                 audioMeterLock.unlock()
                 TelemetryCounters.shared.audioTrimTotal.increment()
                 return true
@@ -133,6 +145,7 @@ extension AudioDecoder {
         if playoutStarted && aheadMs > effectiveOverrunCeilingMs {
             let now = DispatchTime.now().uptimeNanoseconds
             if now >= gateGraceUntilNanos {
+                noteDropForStallWatchdogLocked(now: now)
                 audioMeterLock.unlock()
                 TelemetryCounters.shared.audioOverrunTotal.increment()
                 return true
@@ -155,6 +168,11 @@ extension AudioDecoder {
             playoutStarted = true
             driftAnchorNanos = DispatchTime.now().uptimeNanoseconds
             driftAnchorFramesPlayed = framesPlayed
+            // Stall watchdog: the arm edge IS progress (a paused cold pre-roll or
+            // a post-recovery rebuild starts its 3s clock here, not at zero), and
+            // a recovery episode ends at the edge it exists to reach.
+            lastPlayoutProgressNanos = driftAnchorNanos
+            meterRecovering = false
             // COLD START: arm the floor-learning gate. Drains inside the host's
             // boot-ramp window (paced sub-realtime inflow) must not teach the
             // per-link floor - see cushionNoteUnderrunLocked.
@@ -354,6 +372,9 @@ extension AudioDecoder {
     func meterCompleteOnePlayout(frames: UInt64, isSilence: Bool = false) {
         audioMeterLock.lock()
         framesPlayed &+= frames
+        // Stall-watchdog heartbeat: a completion IS consumption. One clock read
+        // per completion (~200Hz) - the same budget as the trough math below.
+        lastPlayoutProgressNanos = DispatchTime.now().uptimeNanoseconds
         // A corrector-inserted silence buffer finished: release its resident
         // contribution so the av_skew fill correction tracks only buffered silence.
         if isSilence {
@@ -386,7 +407,10 @@ extension AudioDecoder {
         // trough, drained latch - so mid-session logic is untouched; ONLY the
         // evidence edges (ratchet/floor/persist/counter/NOTICE, and the decay
         // clock below) are gated.
-        let stopping = meterShutdown
+        // `meterRecovering` rides the same gate: the stall recovery's stop() fires
+        // an identical completion burst, and un-gated it would mint the same
+        // synthetic under-run (ratchet + persisted floor) the shutdown gate blocks.
+        let stopping = meterShutdown || meterRecovering
         let drainedNow = framesPlayed >= framesScheduled
         let isUnderrunEdge = drainedNow && !playoutDrained && !stopping
         if drainedNow { playoutDrained = true }
@@ -680,6 +704,61 @@ extension AudioDecoder {
         case kAudioDeviceTransportTypeAggregate: return "aggregate"
         case kAudioDeviceTransportTypeVirtual: return "virtual"
         default: return String(format: "0x%08x", transport)
+        }
+    }
+
+    // MARK: - Playout-stall watchdog (detection + recovery)
+    //
+    // MEASURED FAULT (2026-08-12, a 9h18m host-idle overnight): when audio
+    // resumed, the player node consumed ZERO frames (drift math: ~5000ms wall −
+    // 0 media − 171ms fill = the 4829ms the gauge froze at) while 200 pkt/s
+    // decoded into the backlog gates - the scheduled-ahead backlog pinned above
+    // the over-run ceiling, EVERY packet dropped (190/s ceiling + 10/s
+    // rate-limited trims = the full packet rate), `publishAudioState` never ran
+    // again (it sits behind a successful schedule), and the session stayed
+    // silent until reconnect. The H3/H4 config-change hop never fired, so
+    // nothing noticed "scheduling continuously, consuming nothing." This
+    // watchdog closes that class terminally: the DROP branches (the wedge's own
+    // symptom) latch a stall verdict when consumption has been dark past the
+    // threshold, and the decode path rebuilds the output the way a reconnect
+    // proved effective - node stop, engine ensure-running, pre-roll re-arm.
+    // The rebuild itself (`recoverIfPlayoutStalled`) lives in AudioDecoder.swift
+    // with the H3/H4 recovery it mirrors (it needs the private engine members).
+
+    /// Latch the stall verdict from a DROP branch (meter lock held, clock
+    /// already read). Consumption dark past the threshold + retry spacing
+    /// respected ⇒ the next decode-path packet runs the rebuild. `playoutStarted`
+    /// plus the arm-edge progress stamp keep a paused cold pre-roll (completions
+    /// legitimately silent) from ever reading as a stall - and a pre-roll never
+    /// reaches a drop branch anyway (fill < target ≤ ceiling, trim gated on
+    /// `primed`).
+    private func noteDropForStallWatchdogLocked(now: UInt64) {
+        guard playoutStarted, lastPlayoutProgressNanos != 0,
+              now &- lastPlayoutProgressNanos >= Self.playoutStallThresholdNanos,
+              now &- stallRecoveryLastAttemptNanos >= Self.stallRecoveryRetryNanos
+        else { return }
+        playoutStallPending = true
+    }
+
+    /// Packet flow resumed after a multi-second arrival gap (host-idle silence -
+    /// the receiver's gap tracker calls this on the recvQueue, so NO AV calls).
+    /// Hygiene, not recovery: force the drained latch so the NEXT schedule takes
+    /// the (re)arm edge - drift segment re-anchored (a 9h idle otherwise reads
+    /// as multi-second "drift", railing the resampler-converged verdict and
+    /// pinning the cushion deep), gate grace armed so the catch-up clump isn't
+    /// chopped, cushion rebuilt. Almost always a no-op: a ≥2s gap has long
+    /// since drained the ≤300ms cushion and the completion path latched
+    /// `playoutDrained` itself - this catches the drain edge going MISSING
+    /// (frozen completions), the wedge's precursor.
+    public func notePacketFlowResumed(afterGapMs: Double) {
+        audioMeterLock.lock()
+        let acted = playoutStarted && !playoutDrained
+        if acted { playoutDrained = true }
+        audioMeterLock.unlock()
+        if acted {
+            Diag.notice("audio flow resumed after \(Int(afterGapMs.rounded()))ms gap "
+                + "with the drain edge missing - forcing the re-arm (drift "
+                + "re-anchor + cushion rebuild)", "Stream.Audio")
         }
     }
 }

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -319,6 +319,31 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `audioMeterLock`.
     var quietSinceNanos: UInt64 = 0
 
+    // MARK: - P1 AUDIO playout-stall watchdog (the 2026-08-12 overnight wedge)
+    //
+    // Design narrative + detection/recovery: AudioDecoder+Meter.swift
+    // (`noteDropForStallWatchdogLocked` / `recoverIfPlayoutStalled`). Only the
+    // stored words live here; ALL guarded by `audioMeterLock`.
+    /// `DispatchTime` ns of the last observed playout PROGRESS: stamped on every
+    /// buffer completion and on each (re)arm edge - so a legitimately paused
+    /// cold pre-roll (armed = freshly stamped) can never read as a stall.
+    var lastPlayoutProgressNanos: UInt64 = 0
+    /// Latch set by the meter's DROP branches when scheduled audio has consumed
+    /// zero frames past the stall threshold while packets keep arriving: the
+    /// node stopped pulling (output device slept/vanished), the backlog pinned
+    /// above the gates, and every packet then drops forever - received,
+    /// decoded, discarded, silent until reconnect. Cleared on the decode path.
+    var playoutStallPending = false
+    /// `DispatchTime` ns of the last stall-recovery attempt - bounds the
+    /// rebuild cadence so a truly dead output device retries, not thrashes.
+    var stallRecoveryLastAttemptNanos: UInt64 = 0
+    /// True from the recovery's `playerNode.stop()` until the next (re)arm
+    /// edge: the completion handler's EVIDENCE gate treats it like
+    /// `meterShutdown`, so the stop()-fired completion burst can't mint a
+    /// synthetic under-run (ratchet + persisted floor - the
+    /// disguised-permanent-pin class).
+    var meterRecovering = false
+
     // MARK: - P1 AUDIO cushion LOSS FLOOR + per-host memory (the limit-cycle fix)
     //
     // Design narrative + persistence/seeding: AudioDecoder+CushionMemory.swift.
@@ -482,6 +507,11 @@ public final class AudioDecoder: @unchecked Sendable {
         floorQuietSinceNanos = seedNowNanos
         rebuildIsReprime = false
         lastUnderrunNoticeNanos = 0; underrunNoticesSuppressed = 0
+        // Playout-stall watchdog state (fresh session = no progress history yet).
+        lastPlayoutProgressNanos = 0
+        playoutStallPending = false
+        stallRecoveryLastAttemptNanos = 0
+        meterRecovering = false
         audioMeterLock.unlock()
         announceCushionSeed(seed)
         // A/V-skew session edge: the skew store's pair-anchor + accumulator
@@ -683,6 +713,57 @@ public final class AudioDecoder: @unchecked Sendable {
         }
     }
 
+    /// PLAYOUT-STALL RECOVERY (the 2026-08-12 overnight wedge; detection in
+    /// AudioDecoder+Meter.swift). Rebuild the output path after the meter
+    /// latched a stall: scheduled audio consumed ZERO frames past the threshold
+    /// while every arrival dropped at the backlog gates. Caller holds
+    /// `stateLock` (the decode path - the one place AV calls are serialized
+    /// against `shutdown()`, the same discipline as
+    /// `handleEngineConfigurationChange`). stop() fires the queued buffers'
+    /// completions on the meter path (no AV calls there); `meterRecovering`
+    /// gates their under-run EVIDENCE, and the completions reconcile
+    /// `framesPlayed` so the next schedule takes the (re)arm edge - drift
+    /// re-anchor, gate grace, cushion rebuild - and `maybePrime`'s cold-start
+    /// pre-roll re-issues `play()`.
+    func recoverIfPlayoutStalled() {
+        let now = DispatchTime.now().uptimeNanoseconds
+        audioMeterLock.lock()
+        guard playoutStallPending else { audioMeterLock.unlock(); return }
+        playoutStallPending = false
+        stallRecoveryLastAttemptNanos = now
+        meterRecovering = true
+        audioMeterLock.unlock()
+        guard !isShutdown else { return }
+        TelemetryCounters.shared.audioStallRecoveryTotal.increment()
+        Diag.error("audio playout STALLED: scheduled audio unconsumed ≥3s with "
+            + "every arrival dropped at the backlog gates (output device "
+            + "slept/vanished?) - rebuilding: node stop → engine ensure-running "
+            + "→ re-prime; route \(audioRouteCache)", "Stream.Audio")
+        playerNode.stop()
+        if !engine.isRunning {
+            do {
+                try engine.start()
+                engineRestartRetries = 0
+            } catch {
+                Diag.error("audio engine restart in stall recovery FAILED: "
+                    + "\(error.localizedDescription)", "Stream.Audio")
+                scheduleEngineRestartRetry()
+            }
+        }
+        let nowRunning = engine.isRunning
+        audioMeterLock.lock()
+        engineRunning = nowRunning
+        // Re-arm the pre-roll state machine (the H3/H4 idiom). `playoutStarted =
+        // false` makes the next arm edge a COLD start - correct, the node was
+        // just stopped, so the paused pre-roll + `play()` at target is exactly
+        // the rebuild it needs.
+        primed = false
+        playoutStarted = false
+        playoutDrained = false
+        buffersSinceArm = 0
+        audioMeterLock.unlock()
+    }
+
     private func handleEngineConfigurationChange() {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -858,7 +939,13 @@ public final class AudioDecoder: @unchecked Sendable {
         // OVER-RUN ceiling backstop for genuinely bad links. Both keep latency bounded.
         let decodedFrames = UInt64(decoded)
         if meterRegisterScheduleOrOverrun(frames: decodedFrames) {
-            return false  // trimmed/over-run: do not schedule (keeps A/V latency bounded)
+            // Trimmed/over-run: do not schedule (keeps A/V latency bounded). If the
+            // meter latched a playout STALL under this drop (node consuming nothing
+            // while every arrival hits the backlog gates), rebuild the output path
+            // now - this is the stateLock-serialized decode path, the one place AV
+            // calls are safe against shutdown (`recoverIfPlayoutStalled`).
+            recoverIfPlayoutStalled()
+            return false
         }
         playerNode.scheduleBuffer(pcm, completionHandler: { [weak self] in
             self?.meterCompleteOnePlayout(frames: decodedFrames)

--- a/Glimmer/Stream/Native/RtpAudioReceiver.swift
+++ b/Glimmer/Stream/Native/RtpAudioReceiver.swift
@@ -70,6 +70,15 @@ public protocol NativeAudioSink: AnyObject, Sendable {
     func decodeAndPlayPLC()
     /// Tear down the decoder + engine.
     func cleanup()
+    /// Packet flow RESUMED after a multi-second arrival gap (host-idle silence,
+    /// nap). Hygiene hook - the sink may re-arm its playout state so stale
+    /// segment anchors don't survive the gap; the default does nothing. Called
+    /// on the receive thread, so implementations must make NO AV calls.
+    func notePacketFlowResumed(afterGapMs: Double)
+}
+
+public extension NativeAudioSink {
+    func notePacketFlowResumed(afterGapMs: Double) {}
 }
 
 final class RtpAudioReceiver: @unchecked Sendable {
@@ -177,6 +186,11 @@ final class RtpAudioReceiver: @unchecked Sendable {
     // keeps this file under the SwiftLint length limit, like the video split). ---
     var audioMetricsWindowStartNanos: UInt64 = 0
     static let audioMetricsWindowNanos: UInt64 = 1_000_000_000  // 1s
+    /// Arrival gap (ns) past which the next datagram is a FLOW-RESUME edge
+    /// (host-idle silence ended) rather than link jitter - matches the skew
+    /// store's 2s pair-anchor freshness horizon, the sibling that already
+    /// treats a ≥2s-dark stream as a segment boundary.
+    static let flowResumeGapNanos: UInt64 = 2_000_000_000
     /// Last-flushed cumulative RtpAudioQueue stats, so each window publishes the
     /// delta into the monotonic TelemetryCounters audio totals.
     var lastFlushedAudioPackets: UInt32 = 0
@@ -586,6 +600,16 @@ final class RtpAudioReceiver: @unchecked Sendable {
                 counters.audioGapOver20msTotal.increment()
                 if gap > 50_000_000 { counters.audioGapOver50msTotal.increment() }
                 if gap > 100_000_000 { counters.audioGapOver100msTotal.increment() }
+            }
+            // FLOW-RESUME edge: past the pair-anchor freshness horizon (2s -
+            // AudioVideoSkewStore.freshnessNanos' rationale) the silence was a
+            // host-idle stretch, not jitter; this first datagram back is a
+            // segment boundary. Tell the sink so stale playout anchors don't
+            // span it (drift re-anchor + cushion rebuild; no-op when the drain
+            // edge already latched). Same recvQueue, one virtual call, only on
+            // a ≥2s-idle edge.
+            if gap >= Self.flowResumeGapNanos {
+                sink?.notePacketFlowResumed(afterGapMs: Double(gap) / 1_000_000)
             }
         }
         lastDatagramArrivalNanos = now

--- a/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
+++ b/Glimmer/Stream/TelemetryCounters+AudioGauges.swift
@@ -367,6 +367,19 @@ final class AudioVideoSkewStore: @unchecked Sendable {
     func noteAudioScheduled(rtp: UInt32) {
         let now = DispatchTime.now().uptimeNanoseconds
         os_unfair_lock_lock(lock)
+        // RATE-ANCHOR FRESHNESS (stale-anchor audit, 2026-08-12): a pre-resolve
+        // audio stall spanning the calibration window inflates elapsed-ms while
+        // the RTP stands still, depressing the measured rate toward 0 - and the
+        // two-window hold then AGREES with itself (both windows see the same
+        // depressed rate), latching the wrong family. The 2s freshness horizon
+        // that already governs the pair anchor restarts the calibration window
+        // instead; harmless post-resolve (the family is latched for the session).
+        if !audioRateResolved, audioNoteNanos != 0,
+           now &- audioNoteNanos > Self.freshnessNanos {
+            audioRateAnchorRtp = rtp
+            audioRateAnchorNanos = now
+            audioRatePendingFamily = nil
+        }
         audioLastRtp = rtp
         audioNoteNanos = now
         if audioRateAnchorNanos == 0 {

--- a/Glimmer/Stream/TelemetryCounters.swift
+++ b/Glimmer/Stream/TelemetryCounters.swift
@@ -276,6 +276,15 @@ final class TelemetryCounters: @unchecked Sendable {
     /// edge (skew, gap texture) and the resampler/ratchet are living close.
     let audioNearMissTotal = Counter()
 
+    /// AUDIO PLAYOUT-STALL RECOVERY (signal: AUDIO) - the watchdog rebuilt the
+    /// output path after scheduled audio sat unconsumed ≥3s with every arrival
+    /// dropped at the backlog gates: the node stopped pulling (output device
+    /// slept/vanished - the 2026-08-12 overnight wedge, 9h of packets received,
+    /// decoded, and discarded in silence). Zero in a healthy session; ANY
+    /// increment is a session that would previously have stayed silent until
+    /// reconnect.
+    let audioStallRecoveryTotal = Counter()
+
     /// OVER-TARGET force-release count (signal: PRESENT). Bumped on each pacer tick
     /// where the due gate would have latched not-due against a GENUINE drainable
     /// backlog (one frame above the adaptive jitter-buffer target that survived the
@@ -718,6 +727,7 @@ final class TelemetryCounters: @unchecked Sendable {
                         decoderRecreateTotal, decoderRecreateFirstTotal,
                         decoderRecreateResolutionTotal, decoderRecreateColorspaceTotal,
                         staleFrameRepeatTotal, staleEmptyQueueTotal, audioNearMissTotal,
+                        audioStallRecoveryTotal,
                         presentGapDroughtTotal, reorderHoldExceededTotal,
                         pacerOverTargetReleaseTotal,
                         tickMissDescheduledTotal, tickMissCoalescedTotal,

--- a/Glimmer/Stream/TelemetryExporter+Capture.swift
+++ b/Glimmer/Stream/TelemetryExporter+Capture.swift
@@ -127,6 +127,7 @@ extension TelemetryExporter {
         snap.staleEmptyQueueTotal = counters.staleEmptyQueueTotal.value
         snap.presentGapDroughtTotal = counters.presentGapDroughtTotal.value
         snap.audioNearMissTotal = counters.audioNearMissTotal.value
+        snap.audioStallRecoveryTotal = counters.audioStallRecoveryTotal.value
         snap.tickMissDescheduledTotal = counters.tickMissDescheduledTotal.value
         snap.tickMissCoalescedTotal = counters.tickMissCoalescedTotal.value
         snap.tickMissPreemptedTotal = counters.tickMissPreemptedTotal.value

--- a/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
+++ b/Glimmer/Stream/TelemetryExporter+RenderNDJSON.swift
@@ -139,6 +139,7 @@ extension TelemetryRenderer {
         builder.addCount("audio_trim_total", extras.audioTrimTotal)
         builder.add("audio_trims_per_s", extras.audioTrimsPerSecond)
         builder.addCount("audio_reprime_total", audio.rePrimeTotal)
+        builder.addCount("audio_stall_recovery_total", snap.audioStallRecoveryTotal)
         builder.add("audio_underruns_per_s", audio.underrunsPerSecond)
         builder.add("audio_overruns_per_s", audio.overrunsPerSecond)
         builder.add("audio_clock_drift_ms", audio.audioClockDriftMs)

--- a/Glimmer/Stream/TelemetrySnapshot.swift
+++ b/Glimmer/Stream/TelemetrySnapshot.swift
@@ -86,6 +86,10 @@ struct TelemetrySnapshot: Sendable {
     /// Steady-state audio fill dips under ~15ms that did NOT fully drain -
     /// cushion margin erosion visible before it becomes an audible under-run.
     var audioNearMissTotal: UInt64 = 0
+    /// Playout-stall watchdog rebuilds: the node stopped consuming while
+    /// packets kept arriving (a session that would previously have stayed
+    /// silent until reconnect). Zero in healthy sessions.
+    var audioStallRecoveryTotal: UInt64 = 0
     /// REORDER-DISPLACEMENT invariant (measurement only): session-max lateness
     /// of reordered packets vs the live reorder hold, the violation counter,
     /// and the distributions. margin = holdMs − maxMs is derived at render.

--- a/GlimmerTests/AudioPlayoutStallTests.swift
+++ b/GlimmerTests/AudioPlayoutStallTests.swift
@@ -1,0 +1,178 @@
+//
+//  AudioPlayoutStallTests.swift
+//
+//  Coverage for the playout-stall watchdog (the 2026-08-12 overnight wedge:
+//  audio resumed after a 9h host-idle stretch, the player node consumed zero
+//  frames, and every arriving packet was dropped at the backlog gates for the
+//  rest of the session - received, decoded, discarded, silent until reconnect).
+//
+//  The DETECTION half is a pure meter-state machine (audioMeterLock words, no
+//  AV calls), so it is testable exactly like the downshift controller: set the
+//  meter state a wedged session exhibits, drive the schedule/completion
+//  entry points, and assert the latch. The REBUILD half
+//  (`recoverIfPlayoutStalled`) makes real AVAudio calls and is exercised live,
+//  not here - these tests prove the latch protocol around it: when it arms,
+//  when it must not, and that the recovery episode's completion burst cannot
+//  mint under-run evidence.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+/// `.serialized`: two tests here bracket the SHARED `audioUnderrunTotal`
+/// counter with before/after reads (the evidence-gate pair), and parallel
+/// execution can interleave the control's +1 inside the gate test's window -
+/// an observed flake, not a hypothetical.
+@Suite(.serialized)
+struct AudioPlayoutStallTests {
+
+    /// A meter in the wedged session's exact state: playout started and primed,
+    /// a backlog pinned past the over-run ceiling (340ms default: 1s scheduled,
+    /// nothing played), grace expired - so the ceiling branch drops the packet.
+    private func wedgedDecoder() -> AudioDecoder {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.meterSampleRate = 48_000
+        decoder.playoutStarted = true
+        decoder.primed = true
+        decoder.playoutDrained = false
+        decoder.framesScheduled = 48_000   // 1000ms scheduled...
+        decoder.framesPlayed = 0           // ...none consumed - the frozen node
+        decoder.gateGraceUntilNanos = 0    // grace long expired
+        decoder.audioMeterLock.unlock()
+        return decoder
+    }
+
+    // MARK: - Detection latch
+
+    /// The wedge: consumption dark past the threshold while a drop fires - the
+    /// drop must latch the stall verdict (and still drop the packet; recovery
+    /// belongs to the decode path, not the meter).
+    @Test func ancientProgressLatchesStallOnDrop() {
+        let decoder = wedgedDecoder()
+        decoder.lastPlayoutProgressNanos = 1   // ancient (way past the 3s threshold)
+        let dropped = decoder.meterRegisterScheduleOrOverrun(frames: 240)
+        #expect(dropped)
+        #expect(decoder.playoutStallPending)
+    }
+
+    /// A healthy session dropping at the ceiling (a genuine burst) has FRESH
+    /// completion progress - the ceiling backstop must keep working exactly as
+    /// before, with no stall verdict.
+    @Test func freshProgressDropsWithoutLatching() {
+        let decoder = wedgedDecoder()
+        decoder.lastPlayoutProgressNanos = DispatchTime.now().uptimeNanoseconds
+        let dropped = decoder.meterRegisterScheduleOrOverrun(frames: 240)
+        #expect(dropped)
+        #expect(!decoder.playoutStallPending)
+    }
+
+    /// No progress stamp at all (playout never started its clock) must not
+    /// latch - the guard is `!= 0`, so a zero stamp can never read as "ancient".
+    @Test func zeroProgressStampNeverLatches() {
+        let decoder = wedgedDecoder()
+        decoder.lastPlayoutProgressNanos = 0
+        _ = decoder.meterRegisterScheduleOrOverrun(frames: 240)
+        #expect(!decoder.playoutStallPending)
+    }
+
+    /// A recovery attempt just ran: further drops inside the retry window must
+    /// NOT re-latch - a truly dead output device retries on the bounded
+    /// cadence instead of thrashing the node/engine per dropped packet.
+    @Test func recentRecoveryAttemptSuppressesRelatch() {
+        let decoder = wedgedDecoder()
+        decoder.lastPlayoutProgressNanos = 1
+        decoder.stallRecoveryLastAttemptNanos = DispatchTime.now().uptimeNanoseconds
+        _ = decoder.meterRegisterScheduleOrOverrun(frames: 240)
+        #expect(!decoder.playoutStallPending)
+    }
+
+    // MARK: - The (re)arm edge
+
+    /// The arm edge ends a recovery episode and starts the stall clock: it must
+    /// clear `meterRecovering` and stamp fresh progress (a paused cold pre-roll
+    /// begins its 3s window here, so it can never read as a stall).
+    @Test func armEdgeClearsRecoveryAndStampsProgress() {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.meterSampleRate = 48_000
+        decoder.playoutStarted = true
+        decoder.playoutDrained = true      // the drain forces the re-arm edge
+        decoder.primed = true
+        decoder.meterRecovering = true
+        decoder.audioMeterLock.unlock()
+        let dropped = decoder.meterRegisterScheduleOrOverrun(frames: 240)
+        #expect(!dropped)                  // the re-arm packet schedules
+        #expect(!decoder.meterRecovering)
+        #expect(decoder.lastPlayoutProgressNanos != 0)
+        #expect(!decoder.playoutDrained)
+    }
+
+    // MARK: - Recovery evidence gate
+
+    /// The recovery's `playerNode.stop()` fires a completion burst whose last
+    /// completion drains the playhead exactly like a starvation drain. Gated on
+    /// `meterRecovering` it must count NOTHING - un-gated it would ratchet the
+    /// cushion target and persist the floor (the disguised-permanent-pin class
+    /// the shutdown gate already blocks).
+    @Test func recoveryCompletionBurstMintsNoUnderrun() {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.meterSampleRate = 48_000
+        decoder.playoutStarted = true
+        decoder.primed = true
+        decoder.playoutDrained = false
+        decoder.framesScheduled = 240
+        decoder.framesPlayed = 0
+        decoder.meterRecovering = true
+        decoder.audioMeterLock.unlock()
+        let before = TelemetryCounters.shared.audioUnderrunTotal.value
+        decoder.meterCompleteOnePlayout(frames: 240)   // drains to empty
+        #expect(TelemetryCounters.shared.audioUnderrunTotal.value == before)
+        #expect(decoder.playoutDrained)                // bookkeeping still runs
+        #expect(decoder.lastPlayoutProgressNanos != 0) // progress still stamps
+    }
+
+    /// Control for the gate test: the SAME drain WITHOUT the recovery latch is
+    /// a real under-run and must count - proving the setup above genuinely
+    /// reaches the under-run edge (the no-count result is the gate, not a
+    /// mis-arranged test).
+    @Test func realDrainStillCountsUnderrun() {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.meterSampleRate = 48_000
+        decoder.playoutStarted = true
+        decoder.primed = true
+        decoder.playoutDrained = false
+        decoder.framesScheduled = 240
+        decoder.framesPlayed = 0
+        decoder.audioMeterLock.unlock()
+        let before = TelemetryCounters.shared.audioUnderrunTotal.value
+        decoder.meterCompleteOnePlayout(frames: 240)
+        #expect(TelemetryCounters.shared.audioUnderrunTotal.value == before + 1)
+    }
+
+    // MARK: - Flow-resume hygiene (the receiver's ≥2s-gap edge)
+
+    /// Flow resuming with the drain edge MISSING (frozen completions - the
+    /// wedge's precursor) must force the drained latch so the next schedule
+    /// takes the re-arm edge (drift re-anchor + cushion rebuild).
+    @Test func flowResumeForcesMissedDrainEdge() {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.playoutStarted = true
+        decoder.playoutDrained = false
+        decoder.audioMeterLock.unlock()
+        decoder.notePacketFlowResumed(afterGapMs: 9_000)
+        #expect(decoder.playoutDrained)
+    }
+
+    /// Before playout ever starts, a flow-resume edge is meaningless and must
+    /// change nothing (no false drain on a cold session's first packets).
+    @Test func flowResumeBeforePlayoutIsANoop() {
+        let decoder = AudioDecoder()
+        decoder.notePacketFlowResumed(afterGapMs: 9_000)
+        #expect(!decoder.playoutDrained)
+    }
+}


### PR DESCRIPTION
## The fault (measured, 2026-08-12)

A stream left running overnight went silent at 03:27Z when the host stopped sending audio (desktop idle, 9h18m) - and **stayed silent after audio resumed** at 12:45Z, for the rest of the session. `wake_total = 0`, `reconnect_total = 0`: the Mac never slept and video ran fine throughout.

Telemetry proved the wedge. Post-resume, the player node consumed **zero frames** (drift math: ~5000ms wall − 0 media − 171ms fill = the 4829ms the gauge froze at) while 200 pkt/s decoded into the backlog gates. The scheduled-ahead backlog pinned above the over-run ceiling, every packet dropped (190/s ceiling + 10/s rate-limited trims = the full packet rate), `publishAudioState` never ran again (it sits behind a successful schedule, so every gauge froze), and nothing noticed *scheduling continuously, consuming nothing*. The existing H3/H4 config-change recovery never fired.

## The fix, in load-bearing order

1. **Playout-stall watchdog.** The meter's drop branches - the wedge's own symptom - latch a stall verdict when completion progress has been dark ≥3s, and the decode path (`stateLock`, where AV calls are safe) rebuilds the output the way a reconnect proved effective: node stop → engine ensure-running → pre-roll re-arm. 5s retry cadence, never thrashes; the recovery completion burst is evidence-gated (`meterRecovering`) so it can't mint a synthetic under-run and ratchet the persisted cushion. Surfaced as `audio_stall_recovery_total` (zero in healthy sessions - any increment is a session that would previously have stayed silent until reconnect).

2. **Flow-resume hygiene.** The audio receiver's existing gap tracker signals the sink on a ≥2s-idle resume edge (matching the skew store's freshness horizon): if the drain edge went missing, force it, so the next schedule re-anchors the drift segment instead of folding a multi-hour idle into "drift" and railing the resampler-converged verdict.

3. **Clock-family calibration guard** (from the stale-anchor audit). A pre-resolve audio stall spanning the calibration window depresses the measured rate toward 0 and the two-window hold agrees with itself, latching the wrong clock; a ≥2s note gap now restarts the calibration window.

## Verification

- 219 tests pass (3 consecutive runs), including 9 new `AudioPlayoutStallTests`: the detection latch, retry spacing, the (re)arm edge, the evidence gate **with a control proving the under-run edge is genuinely reached**, and the flow-resume force/no-op paths.
- The detection half is pure meter-state (no AV calls) and tested directly; the rebuild half makes real AVAudio calls and needs a live-stream repro: mute host audio ~12min (past the 60ms drift bound), resume, expect audio within one cushion depth and `audio_stall_recovery_total` to stay 0 (hygiene path) - then a forced device-sleep variant to exercise the watchdog itself.

**Not exercised end-to-end against a real overnight wedge yet** - that verification needs a long-idle session and is the reason this is a draft.