### PR TITLE
fix(input): live-override guard - a double engage can no longer strand desktop mouse acceleration

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		D2B00004 /* BitrateDownshiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00003 /* BitrateDownshiftTests.swift */; };
 		D2B00002 /* StreamPathMTUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00001 /* StreamPathMTUTests.swift */; };
 		D2B00006 /* AudioPlayoutStallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00005 /* AudioPlayoutStallTests.swift */; };
+		D2B00008 /* MouseAccelerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00007 /* MouseAccelerationTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -434,6 +435,7 @@
 		D2B00003 /* BitrateDownshiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitrateDownshiftTests.swift; sourceTree = "<group>"; };
 		D2B00001 /* StreamPathMTUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPathMTUTests.swift; sourceTree = "<group>"; };
 		D2B00005 /* AudioPlayoutStallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayoutStallTests.swift; sourceTree = "<group>"; };
+		D2B00007 /* MouseAccelerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseAccelerationTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 				D2B00003 /* BitrateDownshiftTests.swift */,
 				D2B00001 /* StreamPathMTUTests.swift */,
 				D2B00005 /* AudioPlayoutStallTests.swift */,
+				D2B00007 /* MouseAccelerationTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -1063,6 +1066,7 @@
 				D2B00004 /* BitrateDownshiftTests.swift in Sources */,
 				D2B00002 /* StreamPathMTUTests.swift in Sources */,
 				D2B00006 /* AudioPlayoutStallTests.swift in Sources */,
+				D2B00008 /* MouseAccelerationTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer/Stream/InputForwarder+Capture.swift
+++ b/Glimmer/Stream/InputForwarder+Capture.swift
@@ -484,7 +484,9 @@ enum MouseAccelerationControl {
     /// Engage linear mode. Returns the saved prior acceleration to hand back on
     /// disengage, or nil when there is nothing of ours to undo: the read failed,
     /// the user already runs linear (prior < 0), or the write was refused. Stamps
-    /// the crash-safety sentinel only when it actually overrides.
+    /// the crash-safety sentinel only when it actually overrides. When the
+    /// sentinel shows an engagement is ALREADY live, the prior comes from the
+    /// sentinel, never the read-back (see the live-override guard below).
     static func engageLinear() -> Double? {
         let prior = gl_get_mouse_acceleration()
         // < -1.5 = the (deprecated, private) IOKit acceleration API failed or is
@@ -499,15 +501,50 @@ enum MouseAccelerationControl {
             }
             return nil
         }
-        // prior in [-1, 0): the user already runs linear - nothing of ours to undo.
-        guard prior >= 0 else { return nil }
         let defaults = UserDefaults.standard
+        // LIVE-OVERRIDE GUARD (the read-back trap): with the override engaged the
+        // system reads the acceleration back as 0.0 - NOT the negative sentinel
+        // value we wrote - so the old `guard prior >= 0` "already linear" check
+        // could never fire, and a second engage while an override was live (a
+        // concurrent second copy, a raced restore, a crashed session's leftover)
+        // adopted OUR OWN override as "the user's prior". The eventual restore
+        // then stranded the desktop at 0.0 - acceleration off - persisted across
+        // launches by the sentinel. The sentinel IS the discriminator: stamped
+        // means an engagement is live and it holds the user's real curve. Adopt
+        // the resolved prior (self-healing - the restore chain still ends at the
+        // user's setting), re-assert linear, and restamp. The re-assert result is
+        // deliberately ignored: the desktop is ALREADY overridden, so this
+        // session's exit must restore the adopted prior regardless.
+        if defaults.object(forKey: pendingRestoreKey) != nil {
+            let adopted = resolvePrior(readBack: prior,
+                                       sentinel: defaults.double(forKey: pendingRestoreKey))
+            defaults.set(adopted, forKey: pendingRestoreKey)
+            _ = gl_set_mouse_acceleration(linear)
+            return adopted
+        }
+        // prior in [-1, 0): the user already runs linear - nothing of ours to
+        // undo. (Sentinel absent, so a read-back of exactly 0.0 is a GENUINE
+        // user setting - the slider's lowest stop - saved and restored like any
+        // other; only a negative read means the linear sentinel is user-set.)
+        guard prior >= 0 else { return nil }
         defaults.set(prior, forKey: pendingRestoreKey)
         guard gl_set_mouse_acceleration(linear) == 1 else {
             defaults.removeObject(forKey: pendingRestoreKey)
             return nil
         }
         return prior
+    }
+
+    /// The prior to hand the restore chain when an engagement is already LIVE
+    /// (sentinel stamped). Pure - unit-tested without touching IOKit.
+    /// - `readBack > 0`: a real curve is live after all (a stale sentinel from
+    ///   an interrupted restore) - the fresh read is the truth.
+    /// - `readBack <= 0`: the override is live and the read-back is our own
+    ///   linear (reads 0.0, never negative) - the sentinel holds the user's
+    ///   real curve. Clamped >= 0 so a corrupt sentinel can never make the
+    ///   restore chain write a negative (stuck-linear) value.
+    static func resolvePrior(readBack: Double, sentinel: Double) -> Double {
+        readBack > 0 ? readBack : max(sentinel, 0)
     }
 
     /// Restore a previously-saved acceleration value and clear the sentinel.

--- a/GlimmerTests/MouseAccelerationTests.swift
+++ b/GlimmerTests/MouseAccelerationTests.swift
@@ -1,0 +1,52 @@
+//
+//  MouseAccelerationTests.swift
+//
+//  Coverage for the live-override guard in MouseAccelerationControl: with the
+//  linear override engaged, IOKit reads the acceleration back as 0.0 - NOT the
+//  negative sentinel value written - so a second engage (a concurrent second
+//  copy, a raced restore, a crashed session's leftover) used to adopt Glimmer's
+//  own override as "the user's prior" and the eventual restore stranded the
+//  desktop at acceleration 0.0, persisted across launches. `resolvePrior` is
+//  the pure discriminator (the crash sentinel holds the user's real curve);
+//  the IOKit read/write plumbing around it is deliberately NOT exercised here -
+//  a unit test must never write the machine's global pointer acceleration.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct MouseAccelerationTests {
+
+    /// THE bug: override live (reads back 0.0), sentinel holds the user's real
+    /// 1.5 - the restore chain must end at 1.5, never adopt the 0.0.
+    @Test func liveOverrideAdoptsSentinelNotReadBack() {
+        #expect(MouseAccelerationControl.resolvePrior(readBack: 0.0, sentinel: 1.5) == 1.5)
+    }
+
+    /// A stale sentinel (interrupted restore left it behind, but a real curve is
+    /// live again): the fresh read is the truth - including when the user moved
+    /// the slider since the sentinel was stamped.
+    @Test func staleSentinelYieldsToLiveCurve() {
+        #expect(MouseAccelerationControl.resolvePrior(readBack: 2.0, sentinel: 1.5) == 2.0)
+    }
+
+    /// A negative read-back with the sentinel stamped is still the live
+    /// override (however the OS chooses to report it) - the sentinel wins.
+    @Test func negativeReadBackAdoptsSentinel() {
+        #expect(MouseAccelerationControl.resolvePrior(readBack: -1.0, sentinel: 1.5) == 1.5)
+    }
+
+    /// A corrupt (negative) sentinel must clamp to 0, never propagate a
+    /// negative into the restore chain - restoring a negative would strand the
+    /// pointer in linear mode permanently.
+    @Test func corruptSentinelClampsToZero() {
+        #expect(MouseAccelerationControl.resolvePrior(readBack: 0.0, sentinel: -3.0) == 0.0)
+    }
+
+    /// A genuine user 0.0 stamped by an earlier engage round-trips unchanged -
+    /// the guard preserves, it never invents values.
+    @Test func zeroSentinelRoundTrips() {
+        #expect(MouseAccelerationControl.resolvePrior(readBack: 0.0, sentinel: 0.0) == 0.0)
+    }
+}


### PR DESCRIPTION
## The bug (found during the Aug 12 sensitivity investigation, fixed now)

`MouseAccelerationControl.engageLinear`'s "user already runs linear" check was dead code:

```swift
guard prior >= 0 else { return nil }   // can never fire
```

Glimmer writes **-1.0** to disable the pointer-acceleration curve, but IOKit reads the engaged override back as **0.0, never negative**. So a second engage while an override was live - a concurrent second running copy (the nine-copies era made that real), a raced restore, or a crashed session's leftover - adopted Glimmer's *own override* as "the user's prior", stamped the crash sentinel with it, and the eventual restore stranded the desktop at **acceleration 0.0** instead of the user's curve, persisted across launches by the very sentinel meant to prevent exactly this.

## The fix

The crash sentinel is the discriminator: stamped ⇒ an engagement is live and the sentinel holds the user's real curve. `engageLinear` resolves the prior through a pure helper:

- read-back **> 0** → a real curve is live (stale sentinel from an interrupted restore) - trust the fresh read
- read-back **≤ 0** → the override is live - the sentinel wins, clamped ≥ 0 so a corrupt value can never wedge the pointer in linear mode

Self-healing: engaging over a leftover override re-adopts the real curve, and the restore chain still ends at the user's setting. A genuine user 0.0 with no sentinel round-trips unchanged.

## Verification

- 224 tests pass; 5 new `MouseAccelerationTests` cover the resolver: the stranding case, stale sentinel, negative read-back, corrupt-clamp, genuine-zero round-trip.
- The IOKit plumbing is **deliberately untested** - a unit test must never write the machine's global pointer acceleration. The plumbing delta is four lines around the tested resolver.
- Current machine state verified clean before the fix (accel 1.5, sentinel absent), so this ships from a known-good baseline.