### PR TITLE
fix(net): wifi keepalive warm-up - the rough first half-minute on wifi

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		D2B00002 /* StreamPathMTUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00001 /* StreamPathMTUTests.swift */; };
 		D2B00006 /* AudioPlayoutStallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00005 /* AudioPlayoutStallTests.swift */; };
 		D2B00008 /* MouseAccelerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00007 /* MouseAccelerationTests.swift */; };
+		D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00009 /* EnvKeepalivePolicyTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -436,6 +437,7 @@
 		D2B00001 /* StreamPathMTUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamPathMTUTests.swift; sourceTree = "<group>"; };
 		D2B00005 /* AudioPlayoutStallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayoutStallTests.swift; sourceTree = "<group>"; };
 		D2B00007 /* MouseAccelerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseAccelerationTests.swift; sourceTree = "<group>"; };
+		D2B00009 /* EnvKeepalivePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvKeepalivePolicyTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -732,6 +734,7 @@
 				D2B00001 /* StreamPathMTUTests.swift */,
 				D2B00005 /* AudioPlayoutStallTests.swift */,
 				D2B00007 /* MouseAccelerationTests.swift */,
+				D2B00009 /* EnvKeepalivePolicyTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -1067,6 +1070,7 @@
 				D2B00002 /* StreamPathMTUTests.swift in Sources */,
 				D2B00006 /* AudioPlayoutStallTests.swift in Sources */,
 				D2B00008 /* MouseAccelerationTests.swift in Sources */,
+				D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer/Stream/EnvSignalController.swift
+++ b/Glimmer/Stream/EnvSignalController.swift
@@ -202,6 +202,20 @@ final class EnvSignalController: @unchecked Sendable {
     /// falls back to the validated fast dial - stale knowledge never relaxes
     /// the countermeasure.
     static let routeTrustHorizonNanos: UInt64 = 30_000_000_000
+    /// Wi-Fi keepalive WARM-UP window (ns), measured from the ping-loop
+    /// bring-up edge (stream start or silent reconnect). For its duration the
+    /// wifi branch pins the FAST cadence unconditionally - ignoring the
+    /// "active input holds the radio awake" relaxation - because in a stream's
+    /// opening stretch that assumption is measurably false: the AP-side
+    /// power-save / aggregation ramp gaps the DOWNLINK even with steady
+    /// uplink input traffic (2026-08-17, 6GHz at -43dBm: 36 gaps >100ms in
+    /// the first 30s while the cadence flapped fast↔relaxed, then ZERO for
+    /// the next 150s once fast pings pinned - the clear→gap→caution→fast→
+    /// clear→relaxed limit cycle). 90s matches the independently measured
+    /// ~80s wifi warm-up the audio floor-learning gate already covers
+    /// (AudioDecoder+Meter.startupFloorGateNanos, measured 2026-07-21).
+    /// Cost: ~13Hz of tiny UDP pings for 90s - negligible airtime.
+    static let wifiWarmupPingNanos: UInt64 = 90_000_000_000
     /// Send-due slop: the ping threads wake on the fast quantum and gate the
     /// send on elapsed-since-last-ping; without a few ms of slop a 74.9ms
     /// wake against a 75ms interval would skip to 150ms cadence.
@@ -223,6 +237,12 @@ final class EnvSignalController: @unchecked Sendable {
     /// Monotonic instant of the last exporter feed (0 = never) - the cadence
     /// only trusts the route within `routeTrustHorizonNanos` of this.
     private var lastFedNanos: UInt64 = 0
+    /// Monotonic instant of the most recent ping-loop bring-up edge (stream
+    /// start or silent reconnect; stamped in `expireRouteClaim`, the shared
+    /// bring-up path) - the wifi keepalive warm-up window measures from here.
+    /// A reconnect re-earns the warm-up deliberately: the radio renegotiates
+    /// its power-save posture on every fresh flow. 0 = no session yet.
+    private var pingLoopStartNanos: UInt64 = 0
 
     // MARK: - Published reconciler decision (lock-guarded)
     //
@@ -316,6 +336,7 @@ final class EnvSignalController: @unchecked Sendable {
         lock.lock()
         streamLinkValue = LinkClass.unknown.rawValue
         lastFedNanos = 0
+        pingLoopStartNanos = DispatchTime.now().uptimeNanoseconds
         lock.unlock()
     }
 
@@ -323,34 +344,54 @@ final class EnvSignalController: @unchecked Sendable {
 
     /// The steady keepalive interval the RTP ping loops should honor RIGHT
     /// NOW. Called from both dedicated ping threads each wake (~13Hz); cost is
-    /// two short lock reads. Decision table (the header carries the WHY):
-    ///   * wired (fresh)  → relaxed 500ms - a wired NIC doesn't doze, so the
-    ///     fast cadence would just spend packets for nothing.
-    ///   * wifi (fresh)   → fast 75ms when input-idle OR state ≥ CAUTION
-    ///     (doze window open / link already degraded); relaxed 500ms during
-    ///     active-input CLEAR play (input traffic holds the radio awake).
-    ///   * tunnel/unknown/stale → fast 75ms: route truth absent or possibly
-    ///     riding the radio - keep the validated countermeasure. Never a
-    ///     permanent give-up: the next exporter feed or route probe re-opens
-    ///     the relaxed path within a second.
+    /// two short lock reads. Gathers the live inputs and delegates the table
+    /// to `resolveSteadyPingInterval` (pure, unit-tested).
     func steadyPingInterval() -> TimeInterval {
         let nowNanos = DispatchTime.now().uptimeNanoseconds
         lock.lock()
         let link = streamLinkValue
         let current = stateValue
         let fed = lastFedNanos
+        let loopStart = pingLoopStartNanos
         lock.unlock()
         let routeFresh = fed != 0 && nowNanos &- fed <= Self.routeTrustHorizonNanos
-        guard routeFresh else { return Self.fastPingIntervalSeconds }
-        switch LinkClass(label: link) {
+        let inWarmup = loopStart != 0 && nowNanos &- loopStart < Self.wifiWarmupPingNanos
+        return Self.resolveSteadyPingInterval(
+            link: LinkClass(label: link), state: current, routeFresh: routeFresh,
+            inputIdle: isInputIdle(nowNanos: nowNanos), inWarmup: inWarmup)
+    }
+
+    /// The keepalive decision table, pure (the header carries the WHY):
+    ///   * stale route    → fast 75ms: route truth absent or possibly riding
+    ///     the radio - keep the validated countermeasure. Never a permanent
+    ///     give-up: the next exporter feed re-opens the relaxed path.
+    ///   * wired (fresh)  → relaxed 500ms - a wired NIC doesn't doze, so the
+    ///     fast cadence would just spend packets for nothing (warm-up
+    ///     included: there is no radio to hold awake).
+    ///   * wifi WARM-UP   → fast 75ms unconditionally for the first
+    ///     `wifiWarmupPingNanos` of a session/reconnect: the "input traffic
+    ///     holds the radio awake" relaxation below is measurably false while
+    ///     the AP's power-save/aggregation posture is still ramping - the
+    ///     gaps hit the DOWNLINK regardless of uplink input (36 gaps >100ms
+    ///     in a measured first-30s, zero once fast pings pinned).
+    ///   * wifi (fresh)   → fast 75ms when input-idle OR state ≥ CAUTION
+    ///     (doze window open / link already degraded); relaxed 500ms during
+    ///     active-input CLEAR play (input traffic holds the radio awake).
+    ///   * tunnel/unknown → fast 75ms.
+    static func resolveSteadyPingInterval(
+        link: LinkClass, state: EnvState, routeFresh: Bool,
+        inputIdle: Bool, inWarmup: Bool
+    ) -> TimeInterval {
+        guard routeFresh else { return fastPingIntervalSeconds }
+        switch link {
         case .wired:
-            return Self.relaxedPingIntervalSeconds
+            return relaxedPingIntervalSeconds
         case .wifi:
-            if current != .clear { return Self.fastPingIntervalSeconds }
-            return isInputIdle(nowNanos: nowNanos)
-                ? Self.fastPingIntervalSeconds : Self.relaxedPingIntervalSeconds
+            if inWarmup { return fastPingIntervalSeconds }
+            if state != .clear { return fastPingIntervalSeconds }
+            return inputIdle ? fastPingIntervalSeconds : relaxedPingIntervalSeconds
         case .tunnel, .unknown:
-            return Self.fastPingIntervalSeconds
+            return fastPingIntervalSeconds
         }
     }
 

--- a/GlimmerTests/EnvKeepalivePolicyTests.swift
+++ b/GlimmerTests/EnvKeepalivePolicyTests.swift
@@ -1,0 +1,76 @@
+//
+//  EnvKeepalivePolicyTests.swift
+//
+//  The conditional-keepalive decision table, including the wifi WARM-UP row
+//  added 2026-08-17. Measured fault: a 6GHz session at -43dBm took 36 gaps
+//  >100ms in its first 30 seconds - then zero for the next 150 - because
+//  "clear state + active input" relaxed the cadence to 500ms while the AP's
+//  power-save/aggregation posture was still ramping, and the radio dozed
+//  between packets (the clear→gap→caution→fast→clear→relaxed limit cycle).
+//  The table is pure (`resolveSteadyPingInterval`), so every row is asserted
+//  directly; the instance wrapper only gathers the live inputs.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct EnvKeepalivePolicyTests {
+
+    private let fast = EnvSignalController.fastPingIntervalSeconds
+    private let relaxed = EnvSignalController.relaxedPingIntervalSeconds
+
+    private func resolve(
+        link: EnvSignalController.LinkClass, state: EnvSignalController.EnvState = .clear,
+        routeFresh: Bool = true, inputIdle: Bool = false, inWarmup: Bool = false
+    ) -> TimeInterval {
+        EnvSignalController.resolveSteadyPingInterval(
+            link: link, state: state, routeFresh: routeFresh,
+            inputIdle: inputIdle, inWarmup: inWarmup)
+    }
+
+    /// THE fix: wifi + clear + active input used to relax to 500ms from the
+    /// first second - inside the warm-up window it must pin fast, because the
+    /// downlink gaps regardless of uplink input while the AP posture ramps.
+    @Test func wifiWarmupPinsFastDespiteClearActiveInput() {
+        #expect(resolve(link: .wifi, state: .clear, inputIdle: false, inWarmup: true) == fast)
+    }
+
+    /// Past the warm-up, the pre-existing table is unchanged: clear + active
+    /// input relaxes (input traffic genuinely holds the radio awake by then).
+    @Test func wifiSteadyClearActiveInputRelaxes() {
+        #expect(resolve(link: .wifi, state: .clear, inputIdle: false, inWarmup: false) == relaxed)
+    }
+
+    /// Idle input opens the doze window - fast, warm-up or not.
+    @Test func wifiIdleInputStaysFast() {
+        #expect(resolve(link: .wifi, inputIdle: true, inWarmup: false) == fast)
+        #expect(resolve(link: .wifi, inputIdle: true, inWarmup: true) == fast)
+    }
+
+    /// Any non-clear verdict keeps the countermeasure regardless of warm-up.
+    @Test func wifiCautionAndDistressStayFast() {
+        #expect(resolve(link: .wifi, state: .caution) == fast)
+        #expect(resolve(link: .wifi, state: .distress) == fast)
+    }
+
+    /// A wired NIC doesn't doze - relaxed even during warm-up; the fast
+    /// cadence there would spend packets for nothing.
+    @Test func wiredRelaxesEvenInWarmup() {
+        #expect(resolve(link: .wired, inWarmup: true) == relaxed)
+        #expect(resolve(link: .wired, inWarmup: false) == relaxed)
+    }
+
+    /// Stale route truth always falls back to the validated fast dial - the
+    /// guard outranks every other input, including a wired claim.
+    @Test func staleRouteAlwaysFast() {
+        #expect(resolve(link: .wired, routeFresh: false) == fast)
+        #expect(resolve(link: .wifi, routeFresh: false, inWarmup: false) == fast)
+    }
+
+    /// Tunnel and unknown routes may be riding the radio - fast, always.
+    @Test func tunnelAndUnknownStayFast() {
+        #expect(resolve(link: .tunnel) == fast)
+        #expect(resolve(link: .unknown, inWarmup: false) == fast)
+    }
+}


### PR DESCRIPTION
## The fault (measured 2026-08-17, 6GHz at -43dBm, 1.8h session)

| window | jitter p95 | late % | stale repeats/s | gaps >100ms | keepalive avg |
|---|---|---|---|---|---|
| 0-30s | **8.4ms** | 5.6 | **41.8** | **36** | 178ms |
| 30-90s | 0.098ms | 0.0 | 2.4 | 0 | 75ms |
| 90-180s | 0.18ms | 0.0 | 0.8 | 0 | 75ms |

**36 hundred-ms gaps in the first 30 seconds, then zero** - with the radio at near-full rate the whole time (tx 2293 Mbps from the first sample, RSSI -43). Not jitter "settling": the conditional keepalive's wifi row relaxes to 500ms during clear-state active-input play ("input traffic holds the radio awake"), but in the opening stretch that assumption is measurably false - the AP's power-save/aggregation posture is still ramping and the **downlink** gaps regardless of uplink input. The observable was a limit cycle - clear+input → relaxed → gap burst → caution/distress → fast → recovers → clear → relaxed → gap - with the keepalive **averaging 178ms** across the burst window. Once fast pings pinned at 75ms, the gaps stopped entirely.

## The fix

A **90s wifi warm-up window** from the ping-loop bring-up edge during which the wifi branch pins the fast cadence unconditionally. 90s matches the independently measured ~80s wifi warm-up the audio floor-learning gate already covers (`startupFloorGateNanos`, 2026-07-21). Everything else is unchanged: wired stays relaxed (no radio to hold awake), tunnel/unknown/stale were already fast, and post-warm-up wifi keeps the input-aware relaxation. A silent reconnect re-earns the warm-up deliberately - the radio renegotiates its posture on every fresh flow. Cost: ~13Hz of tiny UDP pings for 90s of a session.

## Verification

- The decision table is now a pure `resolveSteadyPingInterval` (the instance method only gathers live inputs); **every row is asserted** in the new `EnvKeepalivePolicyTests` - the previously-wrong warm-up row, the preserved post-warm-up relaxation, wired/tunnel/stale invariants. 231 tests pass.
- Field verification is the next wifi session's telemetry: expect the 0-30s window's `net_gaps_over_100ms` near zero and `keepalive_interval_ms` pinned at 75 - and, if the theory fully holds, the 30-90s `env_state` distress overhang should mostly disappear with it.