### PR TITLE
fix(video): two freeze-until-reconnect wedges + WoL slot poisoning

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		D2B00006 /* AudioPlayoutStallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00005 /* AudioPlayoutStallTests.swift */; };
 		D2B00008 /* MouseAccelerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00007 /* MouseAccelerationTests.swift */; };
 		D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00009 /* EnvKeepalivePolicyTests.swift */; };
+		D2B0000C /* PresentTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B0000B /* PresentTripTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -438,6 +439,7 @@
 		D2B00005 /* AudioPlayoutStallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayoutStallTests.swift; sourceTree = "<group>"; };
 		D2B00007 /* MouseAccelerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseAccelerationTests.swift; sourceTree = "<group>"; };
 		D2B00009 /* EnvKeepalivePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvKeepalivePolicyTests.swift; sourceTree = "<group>"; };
+		D2B0000B /* PresentTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentTripTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -735,6 +737,7 @@
 				D2B00005 /* AudioPlayoutStallTests.swift */,
 				D2B00007 /* MouseAccelerationTests.swift */,
 				D2B00009 /* EnvKeepalivePolicyTests.swift */,
+				D2B0000B /* PresentTripTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -1071,6 +1074,7 @@
 				D2B00006 /* AudioPlayoutStallTests.swift in Sources */,
 				D2B00008 /* MouseAccelerationTests.swift in Sources */,
 				D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */,
+				D2B0000C /* PresentTripTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer/HostsStore.swift
+++ b/Glimmer/HostsStore.swift
@@ -369,9 +369,16 @@ extension AppModel {
                         }
                     }
                 }
+                // `mac` + `lunadevice` MUST be wiped with the slot (audit
+                // 2026-08-17): both are slot-indexed and read back by
+                // `loadHosts`, so leaving them meant a NEW host paired into a
+                // recycled slot inherited the OLD host's Wake-on-LAN target
+                // and luna power-control identity - wake/sleep/shutdown aimed
+                // at the wrong machine.
                 for key in ["hostname", "uuid", "name", "customname",
                             "localaddress", "manualaddress",
-                            "srvcert", "appversion", "gfeversion", "apps.size"] {
+                            "srvcert", "appversion", "gfeversion", "apps.size",
+                            "mac", "lunadevice"] {
                     defaults.removeObject(forKey: "\(prefix).\(key)")
                 }
                 // Leave the hole; `loadHosts` skips empty slots and other

--- a/Glimmer/Stream/StreamSession+PresentTrip.swift
+++ b/Glimmer/Stream/StreamSession+PresentTrip.swift
@@ -53,7 +53,23 @@ extension StreamSession {
         /// touch a latched `isReadyForMoreMediaData`. Never a trip condition
         /// on its own - it only re-aims recovery inside a tripped episode.
         let rendererRejecting: Bool
-        var tripped: Bool { linkDead || presentStalled || tickDeficit }
+        /// RENDERER-STARVATION trip (the depth-0 wedge, audit 2026-08-17): a
+        /// DEEP consecutive reject streak IS a trip in its own right, because
+        /// every other trip is structurally blind at depth 0. During warm
+        /// handover (and the pre-first-release stretch of a fresh pacer) every
+        /// submit bypasses the queue and direct-presents: depth pins at 0 and
+        /// totalReleases at 0, so `presentStalled`/`tickDeficit` can never
+        /// open, `linkDead` stays false on a ticking link, and warm-up itself
+        /// only exits on healthy tick windows a frozen screen may never
+        /// produce - a latched renderer then discarded EVERY decoded frame
+        /// indefinitely with healthy-looking fps_decoded. The streak is
+        /// jitter-proof by construction: it is consecutive (any accepted
+        /// present resets it), renderer-side (network jitter cannot move it),
+        /// and each increment is PROOF a decoded frame reached `willPresent` -
+        /// so no "frames are flowing" guard is needed and `totalReleases > 0`
+        /// is deliberately NOT required.
+        let rendererStarved: Bool
+        var tripped: Bool { linkDead || presentStalled || tickDeficit || rendererStarved }
     }
 
     // MARK: - Sticky recovery-ladder state (cluster memory across episodes)
@@ -118,6 +134,24 @@ extension StreamSession {
     /// only ever re-aims recovery INSIDE an episode the jitter-proof trips
     /// already opened.
     static let rendererRejectStreakTrip: Int = 8
+    /// Consecutive rejections at which the streak becomes a TRIP in its own
+    /// right (`rendererStarved`), not just a medicine selector - the only
+    /// signal that can open an episode at depth 0 (warm handover / fresh
+    /// pacer). 90 in a row ≈ 750ms of continuous refusal at 120fps (3s at
+    /// 30fps) with not one accepted present - an order of magnitude past the
+    /// ~8-reject transients healthy operation produces and comfortably past
+    /// the ~40 a latched renderer racks up before the paced trips could fire.
+    /// Deliberately far above `rendererRejectStreakTrip`: classification
+    /// re-aims an already-open episode cheaply at 8; OPENING an episode from
+    /// this signal alone demands the deep-wedge shape.
+    static let rendererStarvationStreakTrip: Int = 90
+
+    /// The renderer-starvation trip predicate, pure (unit-tested): a deep
+    /// consecutive reject streak outside the startup grace. See the
+    /// `PresentTrip.rendererStarved` doc for why no depth/release guard exists.
+    static func rendererStarvationTripped(rejectStreak: Int, inStartupGrace: Bool) -> Bool {
+        !inStartupGrace && rejectStreak >= rendererStarvationStreakTrip
+    }
 
     /// Compute the present-path trip flags for one watchdog evaluation. Also
     /// advances the two-tick link-silent tracking state (`sawLinkSilentLastTick`,
@@ -227,9 +261,16 @@ extension StreamSession {
         let rendererRejecting =
             live.presentRejectStreak >= StreamSession.rendererRejectStreakTrip
 
+        // RENDERER-STARVATION trip - see the PresentTrip field doc. A streak
+        // this deep implies rendererRejecting above, so the ladder's flush
+        // medicine (the proven cure for the latched-renderer class) is always
+        // selected for episodes this trip opens.
+        let rendererStarved = StreamSession.rendererStarvationTripped(
+            rejectStreak: live.presentRejectStreak, inStartupGrace: inStartupGrace)
+
         return PresentTrip(
             linkDead: linkDead, presentStalled: presentStalled, tickDeficit: tickDeficit,
-            rendererRejecting: rendererRejecting)
+            rendererRejecting: rendererRejecting, rendererStarved: rendererStarved)
     }
 
     /// Run the staged present-path recovery for a tripped episode. Stage 3 (past

--- a/Glimmer/Stream/StreamSession+Watchdog.swift
+++ b/Glimmer/Stream/StreamSession+Watchdog.swift
@@ -452,11 +452,12 @@ extension StreamSession {
             // frameWatchdogTimeout) stays error-level.
             self.log.notice(
                 // swiftlint:disable:next line_length
-                "Present-path stall detected - linkDead=\(trip.linkDead, privacy: .public) tickDeficit=\(trip.tickDeficit, privacy: .public) rendererRejecting=\(trip.rendererRejecting, privacy: .public) rejectStreak=\(live.presentRejectStreak, privacy: .public) sinceTick=\(live.secondsSinceLastTick * 1000, privacy: .public)ms sinceRelease=\(live.secondsSinceLastRelease * 1000, privacy: .public)ms ticks/s=\(live.recentTicksPerSecond, privacy: .public) releases/s=\(live.recentReleasesPerSecond, privacy: .public) depth=\(live.depth, privacy: .public) decodeIdle=\(decodeIdle * 1000, privacy: .public)ms clusterTrips=\(StreamSession.presentTripsInCluster, privacy: .public) - self-healing")
+                "Present-path stall detected - linkDead=\(trip.linkDead, privacy: .public) tickDeficit=\(trip.tickDeficit, privacy: .public) rendererRejecting=\(trip.rendererRejecting, privacy: .public) rendererStarved=\(trip.rendererStarved, privacy: .public) rejectStreak=\(live.presentRejectStreak, privacy: .public) sinceTick=\(live.secondsSinceLastTick * 1000, privacy: .public)ms sinceRelease=\(live.secondsSinceLastRelease * 1000, privacy: .public)ms ticks/s=\(live.recentTicksPerSecond, privacy: .public) releases/s=\(live.recentReleasesPerSecond, privacy: .public) depth=\(live.depth, privacy: .public) decodeIdle=\(decodeIdle * 1000, privacy: .public)ms clusterTrips=\(StreamSession.presentTripsInCluster, privacy: .public) - self-healing")
             Diag.info(
                 "Present-path stall detected (linkDead=\(trip.linkDead) "
                 + "tickDeficit=\(trip.tickDeficit) "
                 + "rendererRejecting=\(trip.rendererRejecting) "
+                + "rendererStarved=\(trip.rendererStarved) "
                 + "rejectStreak=\(live.presentRejectStreak) "
                 + "ticks/s=\(String(format: "%.1f", live.recentTicksPerSecond)) "
                 + "releases/s=\(String(format: "%.1f", live.recentReleasesPerSecond)) "

--- a/Glimmer/Stream/VideoDecoder+Decode.swift
+++ b/Glimmer/Stream/VideoDecoder+Decode.swift
@@ -132,6 +132,12 @@ extension VideoDecoder {
         let isIDR: Bool
         let rtpTimestamp: UInt32
         let totalLength: Int32
+        /// Stall-escalation verdict (see `reserveDecodeSlot`): the wedged VT
+        /// session must be REPLACED with this IDR, bypassing the byte-equal
+        /// param-set shortcut - a recovery IDR carries the SAME SPS/PPS, so
+        /// without the force the "rebuild" would no-op straight back into the
+        /// hosed session. false on every normal frame.
+        var forceSessionRecreate: Bool = false
     }
 
     /// Shared decode core, reached by the Swift-native VideoSink path
@@ -234,9 +240,16 @@ extension VideoDecoder {
         // (VideoDepacketizer.c:513-532). We deliberately do NOT also call
         // `backend?.requestIdrFrame()` here, so an overflow requests exactly one
         // IDR.
-        switch reserveDecodeSlot() {
+        var forceSessionRecreate = false
+        switch reserveDecodeSlot(isIDR: isIDR) {
         case .reserved:
             break
+        case .reservedForStallRecreate:
+            // The wedged session's slots were abandoned; this IDR must REPLACE
+            // the session, bypassing the byte-equal param-set shortcut (a
+            // recovery IDR carries identical SPS/PPS, so an unforced rebuild
+            // would no-op straight back into the hosed session).
+            forceSessionRecreate = true
         case .dropAndFlush:
             TelemetryCounters.shared.backlogOverflowTotal.increment()
             // This assembled frame is dropped before VT ever sees it - credit a
@@ -268,11 +281,13 @@ extension VideoDecoder {
         let needsParamRebuild =
             (newSps != nil) || (newPps != nil) || (newVps != nil)
             || (decompressionSession == nil && isIDR)
+            || forceSessionRecreate
 
         let pending = PendingDecode(
             pictureData: pictureData, newSps: newSps, newPps: newPps, newVps: newVps,
             needsParamRebuild: needsParamRebuild, isIDR: isIDR,
-            rtpTimestamp: rtpTimestamp, totalLength: totalLength)
+            rtpTimestamp: rtpTimestamp, totalLength: totalLength,
+            forceSessionRecreate: forceSessionRecreate)
 
         decodeQueue.async { [self] in
             // Teardown gate: stop() may have flipped isStreaming off (and
@@ -306,7 +321,8 @@ extension VideoDecoder {
         if pending.needsParamRebuild,
            !rebuildParamSetsAndSession(
                 newSps: pending.newSps, newPps: pending.newPps, newVps: pending.newVps,
-                format: format, pictureData: pictureData) {
+                format: format, pictureData: pictureData,
+                forceRecreate: pending.forceSessionRecreate) {
             // Param-rebuild / session-create failed: this frame never reaches
             // VT, so release its in-flight slot, credit a decoder-side discard
             // (it never reaches recordDecodeComplete), and request an IDR.
@@ -367,7 +383,8 @@ extension VideoDecoder {
     /// decompression session for the negotiated codec. Runs on the decode queue.
     /// Returns true on success; false means the caller should request an IDR.
     private nonisolated func rebuildParamSetsAndSession(
-        newSps: Data?, newPps: Data?, newVps: Data?, format: Int32, pictureData: Data
+        newSps: Data?, newPps: Data?, newVps: Data?, format: Int32, pictureData: Data,
+        forceRecreate: Bool = false
     ) -> Bool {
         let strippedSps = newSps.map(stripStartCode)
         let strippedPps = newPps.map(stripStartCode)
@@ -376,7 +393,10 @@ extension VideoDecoder {
         // Turbulent HEVC re-sends identical SPS/PPS/VPS on every IDR; the rebuild
         // is a no-op but its teardown + renderer flush + pacer clearQueue cluster
         // into hitches, so skip on byte-equal sets. (Inert for AV1: config is OBU.)
-        if decompressionSession != nil, formatDescription != nil,
+        // `forceRecreate` (the stall escalation) bypasses the shortcut: replacing
+        // the hosed session IS the point, and its params are byte-identical.
+        if !forceRecreate,
+           decompressionSession != nil, formatDescription != nil,
            newSps == nil || strippedSps == spsData,
            newPps == nil || strippedPps == ppsData,
            newVps == nil || strippedVps == vpsData,
@@ -534,6 +554,18 @@ extension VideoDecoder {
         /// VT has produced no output for the stall window). Drop this frame and
         /// flush-to-IDR. No slot was reserved.
         case dropAndFlush
+        /// STALL ESCALATION (wedge audit 2026-08-17): an IDR arrived while the
+        /// stall has persisted past `decodeStallEscalateSeconds` - the wedged
+        /// session's in-flight slots were abandoned (counter reset to this
+        /// IDR's own slot, the `handleCleanup` discipline) and the caller must
+        /// FORCE a session recreate with this frame. Without this case the
+        /// gate starved its own cure: every `.dropAndFlush` requests an IDR,
+        /// and the gate then dropped that IDR too - the recovery whose param
+        /// rebuild is the only mechanism that can replace a hosed VT session -
+        /// in a closed loop, forever, while ENet keepalives kept the frame
+        /// watchdog's teardown on hold (received, assembled, dropped, for
+        /// hours: the video twin of the 2026-08-12 audio wedge).
+        case reservedForStallRecreate
     }
 
     /// Reserve one in-flight-decode slot for a frame about to be dispatched, or
@@ -562,7 +594,7 @@ extension VideoDecoder {
     /// the frame (output callback) or on any abandon path. Lock-guarded because
     /// the count is read/written from both the receive thread (reserve) and the
     /// decode queue / VT output-callback thread (release).
-    private nonisolated func reserveDecodeSlot() -> DecodeSlotDecision {
+    private nonisolated func reserveDecodeSlot(isIDR: Bool) -> DecodeSlotDecision {
         inFlightDecodeLock.lock()
         let backlog = inFlightDecodes
 
@@ -579,8 +611,8 @@ extension VideoDecoder {
         // advances on every VT output callback, so a small value means VT is
         // actively retiring frames (a transient burst it will drain), while a
         // value past the stall window means VT has genuinely stopped producing.
-        let vtDraining =
-            secondsSinceLastDecodedFrame() < VideoDecoder.decodeStallWindowSeconds
+        let vtDark = secondsSinceLastDecodedFrame()
+        let vtDraining = vtDark < VideoDecoder.decodeStallWindowSeconds
         let underCeiling = backlog < maxInFlightDecodeCeiling
         consecutiveBacklogOverflow += 1
 
@@ -592,6 +624,31 @@ extension VideoDecoder {
             OSSignposter.decode.emitEvent(
                 "BacklogBurstAbsorbed", "depth=\(depth, privacy: .public)")
             return .reserved
+        }
+
+        // STALL ESCALATION - see `DecodeSlotDecision.reservedForStallRecreate`.
+        // An IDR during a stall SUSTAINED past the escalation window is the
+        // cure, not another casualty: abandon the wedged session's slots (the
+        // `handleCleanup` reset discipline; `releaseInFlightDecode` floors at
+        // 0, so a late callback from the doomed session cannot underflow -
+        // worst case it eats this IDR's slot early, briefly loosening a
+        // protective bound) and reserve this frame to drive a FORCED session
+        // recreate. The window is well past `decodeStallWindowSeconds`, so a
+        // burst VT is merely slow to drain never triggers a recreate - only a
+        // VT that has produced nothing across many IDR round-trips.
+        if isIDR, vtDark >= VideoDecoder.decodeStallEscalateSeconds {
+            inFlightDecodes = 1
+            consecutiveBacklogOverflow = 0
+            inFlightDecodeLock.unlock()
+            log.error(
+                // swiftlint:disable:next line_length
+                "Decode stall ESCALATION (\(backlog) in flight, VT dark \(String(format: "%.1f", vtDark))s) - abandoning wedged session, forcing recreate with this IDR")
+            Diag.error("Video decode stalled \(String(format: "%.1f", vtDark))s with "
+                + "\(backlog) frames wedged in VT - rebuilding the decode session in "
+                + "place with the arriving IDR", "Stream")
+            OSSignposter.decode.emitEvent(
+                "DecodeStallRecreate", "backlog=\(backlog, privacy: .public)")
+            return .reservedForStallRecreate
         }
 
         // Genuine sustained stall (VT not draining, or hit the ceiling). Drop +

--- a/Glimmer/Stream/VideoDecoder.swift
+++ b/Glimmer/Stream/VideoDecoder.swift
@@ -374,6 +374,15 @@ public final class VideoDecoder {
     /// present-watchdog's 250ms stall trip, so the decode side resyncs before the
     /// present path notices.
     nonisolated static let decodeStallWindowSeconds = 0.150
+    /// Stall ESCALATION window (wedge audit 2026-08-17): an IDR arriving after
+    /// VT has produced NOTHING for this long forces a session recreate instead
+    /// of dying at the backlog gate - the gate's own flush-to-IDR requests the
+    /// recovery keyframe, and dropping that keyframe too closed the loop
+    /// forever (the video twin of the audio silence wedge). 2s = ~13x the
+    /// stall window and several 1Hz IDR round-trips, so a VT that is merely
+    /// slow to drain a burst never triggers a teardown; a VT that is genuinely
+    /// hosed recreates within ~2-3s instead of freezing until manual reconnect.
+    nonisolated static let decodeStallEscalateSeconds = 2.0
 
     // True when start() has been called but stop() hasn't. We refuse to
     // touch the decode/enqueue path outside that window.

--- a/GlimmerTests/PresentTripTests.swift
+++ b/GlimmerTests/PresentTripTests.swift
@@ -1,0 +1,59 @@
+//
+//  PresentTripTests.swift
+//
+//  The renderer-starvation trip (wedge audit 2026-08-17): during warm handover
+//  and the pre-first-release stretch of a fresh pacer, every submit
+//  direct-presents - depth pins at 0 and totalReleases at 0, so every
+//  pre-existing trip (presentStalled, tickDeficit: both require depth > 0;
+//  linkDead: false on a ticking link) was structurally blind while a latched
+//  renderer discarded every decoded frame forever. The deep consecutive
+//  reject streak is the one signal that survives depth 0 - each increment is
+//  proof a decoded frame reached willPresent and was refused - and it now
+//  opens an episode in its own right.
+//
+
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct PresentTripTests {
+
+    /// THE wedge shape: depth 0, zero releases, deep reject streak - the trip
+    /// must open (and carry the rendererRejecting classification so the ladder
+    /// selects the flush medicine, the proven cure for the latched renderer).
+    @Test func depthZeroStarvationOpensEpisode() {
+        let trip = StreamSession.PresentTrip(
+            linkDead: false, presentStalled: false, tickDeficit: false,
+            rendererRejecting: true, rendererStarved: true)
+        #expect(trip.tripped)
+    }
+
+    /// Transient rejections below the starvation threshold classify but never
+    /// trip on their own - the pre-existing contract, preserved.
+    @Test func classificationAloneDoesNotTrip() {
+        let trip = StreamSession.PresentTrip(
+            linkDead: false, presentStalled: false, tickDeficit: false,
+            rendererRejecting: true, rendererStarved: false)
+        #expect(!trip.tripped)
+    }
+
+    /// Threshold boundary: 90 consecutive refusals trips, 89 does not.
+    @Test func starvationThresholdBoundary() {
+        #expect(StreamSession.rendererStarvationTripped(rejectStreak: 90, inStartupGrace: false))
+        #expect(!StreamSession.rendererStarvationTripped(rejectStreak: 89, inStartupGrace: false))
+    }
+
+    /// Startup grace suppresses the trip - cadence-lock and priming churn must
+    /// not masquerade as a wedge, same as every other trip.
+    @Test func startupGraceSuppresses() {
+        #expect(!StreamSession.rendererStarvationTripped(rejectStreak: 500, inStartupGrace: true))
+    }
+
+    /// The trip threshold must sit far above the classification threshold:
+    /// classification re-aims an already-open episode cheaply; OPENING an
+    /// episode from the streak alone demands the deep-wedge shape.
+    @Test func tripThresholdFarAboveClassification() {
+        #expect(StreamSession.rendererStarvationStreakTrip
+            >= 10 * StreamSession.rendererRejectStreakTrip)
+    }
+}


### PR DESCRIPTION
Three confirmed findings from today's six-lens adversarially-verified bug hunt (14 agents; every claim here survived a dedicated refuter with line citations).

## 1. Renderer-starvation trip — the HIGH (`PresentTrip`/`FramePacer`)

During warm handover and a fresh pacer's pre-first-release stretch, every submit direct-presents: **depth pins 0, totalReleases 0** — and every existing watchdog trip was structurally blind there (`presentStalled`/`tickDeficit` require `depth > 0`, `linkDead` is false on a ticking link, and warm-up exits only on healthy tick windows a frozen screen never produces). A latched renderer (`isReadyForMoreMediaData` — the documented field wedge that survived link rebuilds) then discarded **every decoded frame forever** with healthy-looking `fps_decoded`.

A deep consecutive reject streak (90 ≈ 750ms at 120fps with not one accepted present) is now a **trip in its own right**: jitter-proof by construction — consecutive (any success resets it), renderer-side (network jitter can't move it), and each increment is proof a decoded frame reached `willPresent`. The existing ladder already carries the cure (`rendererRejecting` → flush → stage-3 give-up); it just couldn't be *reached* at depth 0. No warm-up timeout was added deliberately — flipping to paced mode under a still-throttled governor is the cold-cutover freeze warm handover exists to prevent, and the new trip covers the harmful case without it.

## 2. Decode-stall escalation — the gate that starved its own cure (`VideoDecoder`)

Once VT stops retiring frames, the backlog gate returned `.dropAndFlush` for every frame — **including the recovery IDR its own flush requested**, whose param rebuild is the only mechanism that can replace a hosed session. ENet-alive keepalives held teardown off indefinitely: received, assembled, dropped, for hours — the video twin of the 2026-08-12 audio wedge.

An IDR arriving after VT has been dark ≥2s (13× the stall window, several IDR round-trips) now abandons the wedged session's slots (the `handleCleanup` reset discipline; `releaseInFlightDecode` floors at 0) and **forces a session recreate with that IDR** — explicitly bypassing the byte-equal SPS/PPS shortcut, which would otherwise no-op straight back into the hosed session.

## 3. Unpair Wake-on-LAN poisoning (`HostsStore`)

The unpair wipe list omitted the slot-indexed `mac` and `lunadevice` keys, so a new host paired into a recycled slot inherited the **old host's WoL target and luna power-control identity** — wake/sleep/shutdown aimed at the wrong machine. Both keys now wipe with the slot.

## Verification

- **236 tests pass**; 5 new `PresentTripTests`: the depth-0 wedge opens an episode, classification alone still never trips, the 90/89 boundary, grace suppression, and the 10× trip-vs-classification threshold separation.
- Stated plainly: the decode escalation and the unpair fix are build-verified and log-observable (`DecodeStallRecreate` signpost + Diag error line) but **not unit-tested** — the former needs a live hosed VT session, the latter a real UserDefaults store. Field verification: any future freeze should now show either a `rendererStarved=true` stall line or a `DecodeStallRecreate` event instead of freezing silently.