### PR TITLE
fix(audio): post-wake prime-edge crash - AVFAudio exceptions can no longer kill the process

### DIFF
--- a/Glimmer.xcodeproj/project.pbxproj
+++ b/Glimmer.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		D2B00008 /* MouseAccelerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00007 /* MouseAccelerationTests.swift */; };
 		D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B00009 /* EnvKeepalivePolicyTests.swift */; };
 		D2B0000C /* PresentTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B0000B /* PresentTripTests.swift */; };
+		D2B0000E /* AudioPrimeEdgeSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B0000D /* AudioPrimeEdgeSafetyTests.swift */; };
 		D2000031 /* StreamCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000030 /* StreamCryptoTests.swift */; };
 		D2000033 /* PairingCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000032 /* PairingCryptoTests.swift */; };
 		D2000035 /* ParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2000034 /* ParserHelperTests.swift */; };
@@ -440,6 +441,7 @@
 		D2B00007 /* MouseAccelerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseAccelerationTests.swift; sourceTree = "<group>"; };
 		D2B00009 /* EnvKeepalivePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvKeepalivePolicyTests.swift; sourceTree = "<group>"; };
 		D2B0000B /* PresentTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentTripTests.swift; sourceTree = "<group>"; };
+		D2B0000D /* AudioPrimeEdgeSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPrimeEdgeSafetyTests.swift; sourceTree = "<group>"; };
 		D2000030 /* StreamCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptoTests.swift; sourceTree = "<group>"; };
 		D2000032 /* PairingCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCryptoTests.swift; sourceTree = "<group>"; };
 		D2000034 /* ParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserHelperTests.swift; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 				D2B00007 /* MouseAccelerationTests.swift */,
 				D2B00009 /* EnvKeepalivePolicyTests.swift */,
 				D2B0000B /* PresentTripTests.swift */,
+				D2B0000D /* AudioPrimeEdgeSafetyTests.swift */,
 				D2000030 /* StreamCryptoTests.swift */,
 				D2000032 /* PairingCryptoTests.swift */,
 				D2000034 /* ParserHelperTests.swift */,
@@ -1075,6 +1078,7 @@
 				D2B00008 /* MouseAccelerationTests.swift in Sources */,
 				D2B0000A /* EnvKeepalivePolicyTests.swift in Sources */,
 				D2B0000C /* PresentTripTests.swift in Sources */,
+				D2B0000E /* AudioPrimeEdgeSafetyTests.swift in Sources */,
 				D2000031 /* StreamCryptoTests.swift in Sources */,
 				D2000033 /* PairingCryptoTests.swift in Sources */,
 				D2000035 /* ParserHelperTests.swift in Sources */,

--- a/Glimmer/Stream/AudioDecoder+Meter.swift
+++ b/Glimmer/Stream/AudioDecoder+Meter.swift
@@ -256,11 +256,16 @@ extension AudioDecoder {
         let aheadFrames = framesScheduled &- framesPlayed
         let aheadMs = meterSampleRate > 0 ? Double(aheadFrames) / meterSampleRate * 1000.0 : 0
         if aheadMs >= playoutTargetMs {
-            primed = true
             audioMeterLock.unlock()
             // Cushion is built - begin (or, re-prime, continue) gapless playback;
             // the already-queued buffers drain ahead of the playhead as the cushion.
-            playerNode.play()
+            // `primed` latches ONLY on a successful start (see
+            // startPlayoutAtPrimeEdge - the post-wake stopped-engine crash):
+            // on failure the next packet re-enters this edge and retries.
+            guard startPlayoutAtPrimeEdge() else { return }
+            audioMeterLock.lock()
+            primed = true
+            audioMeterLock.unlock()
             return
         }
         if !rebuildIsReprime {
@@ -276,9 +281,11 @@ extension AudioDecoder {
                 audioMeterLock.unlock()
                 return
             }
+            audioMeterLock.unlock()
+            guard startPlayoutAtPrimeEdge() else { return }
+            audioMeterLock.lock()
             primed = true
             audioMeterLock.unlock()
-            playerNode.play()
             return
         }
         // Mid-stream re-prime, fill short of target: give the catch-up clump its
@@ -317,10 +324,15 @@ extension AudioDecoder {
         // as-is rather than wedging the state machine un-primed.
         guard deficitMs >= Self.playoutCushionStepMs, frames > 0,
               let silence = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else {
+            // Sub-step deficit / failed alloc: prime as-is - but only if
+            // playback actually starts; a play failure (post-wake stopped
+            // engine) leaves the machine un-primed and this cheap path
+            // retries per packet. Bounded: with fill ≈ target the deficit
+            // stays sub-step, so the retries never re-enter the backfill.
+            guard startPlayoutAtPrimeEdge() else { return }
             audioMeterLock.lock()
             primed = true
             audioMeterLock.unlock()
-            playerNode.play()
             return
         }
         silence.frameLength = frames
@@ -344,7 +356,6 @@ extension AudioDecoder {
         // playing the anchor can sit ahead of `framesPlayed`; `publishAudioState`'s
         // guard reports drift as absent for that moment, then resumes clean.)
         driftAnchorFramesPlayed &+= silenceFrames
-        primed = true
         let targetMs = playoutTargetMs
         let route = audioRouteCache
         audioMeterLock.unlock()
@@ -354,7 +365,15 @@ extension AudioDecoder {
         playerNode.scheduleBuffer(silence) { [weak self] in
             self?.meterCompleteOnePlayout(frames: silenceFrames, isSilence: true)
         }
-        playerNode.play() // no-op mid-stream; keeps the prime edge uniform
+        // Uniform prime edge, made exception-safe: the silence stays scheduled
+        // either way (it plays when the engine returns); `primed` latches only
+        // on a successful start, and the sub-step guard above makes the
+        // per-packet retries cheap (fill ≈ target ⇒ no repeat backfill).
+        if startPlayoutAtPrimeEdge() {
+            audioMeterLock.lock()
+            primed = true
+            audioMeterLock.unlock()
+        }
         Diag.notice(
             "audio cushion backfill +\(Int(deficitMs.rounded()))ms silence → \(Int(targetMs))ms standing fill "
             + "- no catch-up clump within the re-prime grace (steady link); route \(route)",

--- a/Glimmer/Stream/AudioDecoder.swift
+++ b/Glimmer/Stream/AudioDecoder.swift
@@ -725,6 +725,51 @@ public final class AudioDecoder: @unchecked Sendable {
     /// `framesPlayed` so the next schedule takes the (re)arm edge - drift
     /// re-anchor, gate grace, cushion rebuild - and `maybePrime`'s cold-start
     /// pre-roll re-issues `play()`.
+    /// Start playback at a prime edge, SAFELY (the 2026-08-17 post-wake crash).
+    /// System sleep tears the audio hardware down mid-stream and stops the
+    /// engine; the resume edge's re-prime then called `playerNode.play()` 9s
+    /// after wake, which raises an NSException Swift cannot catch - process
+    /// dead on the audio receive thread. Two layers here: ensure the engine is
+    /// running first (post-wake it usually just needs a start(); failure arms
+    /// the existing bounded retry ladder), then run play() under the ObjC
+    /// exception shim so even an engine that LIES about isRunning (device
+    /// mid-transition) degrades to a false return instead of an abort.
+    /// Returns false when playback could not start - the caller must leave the
+    /// state machine UN-primed so the next packet retries the edge; packets
+    /// keep scheduling meanwhile, so recovery is one successful start away.
+    /// Caller is the decode path with `stateLock` held (AV calls serialized
+    /// against `shutdown()`), never inside `audioMeterLock`.
+    func startPlayoutAtPrimeEdge() -> Bool {
+        if !engine.isRunning {
+            // The start itself goes under the shim too: `engine.start()`
+            // reports missing-hardware failures as a thrown NSError, but some
+            // states (an incomplete graph, a device mid-teardown) RAISE an
+            // NSException instead - the test suite's empty-graph decoder
+            // proved that path aborts without the guard.
+            var startError: Error?
+            let noRaise = gl_objc_try {
+                do { try self.engine.start() } catch { startError = error }
+            }
+            guard noRaise, startError == nil, engine.isRunning else {
+                Diag.error("audio engine start at prime edge FAILED "
+                    + "(\(startError.map { $0.localizedDescription } ?? "NSException")) "
+                    + "- staying un-primed, retry armed", "Stream.Audio")
+                scheduleEngineRestartRetry()
+                return false
+            }
+            engineRestartRetries = 0
+            Diag.notice("audio engine restarted at the prime edge "
+                + "(stopped underneath us - system sleep?)", "Stream.Audio")
+        }
+        guard gl_objc_try({ self.playerNode.play() }) else {
+            Diag.error("audio playerNode.play() threw at the prime edge (device "
+                + "mid-transition?) - staying un-primed, will retry per packet",
+                "Stream.Audio")
+            return false
+        }
+        return true
+    }
+
     func recoverIfPlayoutStalled() {
         let now = DispatchTime.now().uptimeNanoseconds
         audioMeterLock.lock()

--- a/Glimmer/Stream/CHelpers.h
+++ b/Glimmer/Stream/CHelpers.h
@@ -171,6 +171,29 @@ connected:
     return fd;
 }
 
+// MARK: - ObjC exception guard (AV-call crash shield)
+// AVFAudio raises NSException from calls like -[AVAudioPlayerNode play] when
+// the engine stopped underneath it - system sleep tears the audio hardware
+// down mid-stream, so a resume-edge play() 9s after wake met a stopped engine
+// and the exception, uncatchable from Swift, aborted the whole process
+// (SIGABRT via std::terminate - the 2026-08-17 post-wake crash). This shim
+// runs a block under @try so the caller gets a Bool instead of a corpse; the
+// caught exception is logged here (name + reason) since it cannot cross the
+// boundary. ObjC-only (the bridging header compiles as ObjC; pure-C includes
+// of this header skip it).
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+static inline BOOL gl_objc_try(void (NS_NOESCAPE ^ _Nonnull block)(void)) {
+    @try {
+        block();
+        return YES;
+    } @catch (NSException *exception) {
+        NSLog(@"gl_objc_try caught %@: %@", exception.name, exception.reason);
+        return NO;
+    }
+}
+#endif
+
 // MARK: - Global mouse pointer-acceleration (relative-aim linearization)
 // macOS runs even relative (associate-false) HID deltas through its pointer-
 // acceleration curve before they reach kCGMouseEventDeltaX/Y, so a streamed game

--- a/GlimmerTests/AudioPrimeEdgeSafetyTests.swift
+++ b/GlimmerTests/AudioPrimeEdgeSafetyTests.swift
@@ -1,0 +1,62 @@
+//
+//  AudioPrimeEdgeSafetyTests.swift
+//
+//  The 2026-08-17 post-wake crash: system sleep stopped the audio engine
+//  mid-stream, and 9 seconds after wake the resume edge's re-prime called
+//  `playerNode.play()` - which raises an NSException Swift cannot catch, so
+//  the process aborted on the audio receive thread. The fix is layered:
+//  `gl_objc_try` (an ObjC @try shim - the belt) and `startPlayoutAtPrimeEdge`
+//  (engine-ensure + prime-latch-only-on-success - the suspenders). Both are
+//  testable WITHOUT audio hardware: a fresh AudioDecoder's player node is
+//  un-attached and its engine un-started, which is exactly the crash's
+//  precondition - under the old code, `maybePrime` at a full cushion would
+//  abort the test process itself.
+//
+
+import AVFAudio
+import Foundation
+import Testing
+@testable import Glimmer
+
+struct AudioPrimeEdgeSafetyTests {
+
+    /// The belt, in isolation: an ObjC exception raised inside the block must
+    /// come back as `false`, not a process abort.
+    @Test func objcTryCatchesRaisedException() {
+        let survived = gl_objc_try {
+            NSException(name: .genericException, reason: "test", userInfo: nil).raise()
+        }
+        #expect(!survived)
+    }
+
+    /// And a clean block reports success.
+    @Test func objcTryPassesCleanBlock() {
+        var ran = false
+        let survived = gl_objc_try { ran = true }
+        #expect(survived)
+        #expect(ran)
+    }
+
+    /// THE crash shape, end to end: a decoder whose engine never started and
+    /// whose node is un-attached (the post-sleep state) reaches the
+    /// target-reached prime edge. Under the old code this call aborted the
+    /// process; now it must return with the machine still UN-primed so the
+    /// next packet retries. (`engine.start()` on the empty graph fails or the
+    /// un-attached `play()` raises - either path must degrade, never crash.)
+    @Test func primeEdgeWithDeadEngineStaysUnprimedWithoutCrashing() {
+        let decoder = AudioDecoder()
+        decoder.audioMeterLock.lock()
+        decoder.meterSampleRate = 48_000
+        decoder.framesScheduled = 48_000   // fill far above any target
+        decoder.framesPlayed = 0
+        decoder.playoutTargetMs = 40
+        decoder.primed = false
+        decoder.audioMeterLock.unlock()
+        guard let fmt = AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2) else {
+            Issue.record("AVAudioFormat construction failed")
+            return
+        }
+        decoder.maybePrime(format: fmt)
+        #expect(!decoder.primed)
+    }
+}


### PR DESCRIPTION
## The crash (field, 2026-08-17, 2026.8.10 — and reproduced in the test suite)

System sleep tears the audio hardware down mid-stream and stops the `AVAudioEngine`. **9 seconds after wake**, the resume edge's re-prime called `playerNode.play()` → `AVAudioPlayerNodeImpl::StartImpl` raised an NSException — uncatchable from Swift — and the process aborted on the audio receive thread.

**Honest attribution:** the precondition (`play()` at a prime edge with a stopped engine) predates this week, but the 2026.8.7 flow-resume hygiene made the prime edge *prompt and certain* after every sleep — the first packets back force the re-arm within tens of ms, racing the async config-change repair. The fix that made resume correct made this race easy to lose.

## Two layers

1. **`gl_objc_try`** (CHelpers.h) — an ObjC `@try` shim, since Swift cannot catch NSExceptions. Any AVFAudio raise comes back as a `Bool`; name + reason logged at the boundary.
2. **`startPlayoutAtPrimeEdge`** — all four prime-edge `play()` sites route through one guarded helper: engine ensure-running (**`start()` itself under the shim** — the test suite proved `AVAudioEngineGraph::Initialize` *raises* on an incomplete graph rather than returning the promised NSError), `play()` under the shim, and `primed` latches **only on success**. On failure: stay un-primed, next packet retries, packets keep scheduling, the existing bounded engine-restart ladder arms. Recovery is one successful start away — never a crash, worst case a short silence.

## Verification

- `AudioPrimeEdgeSafetyTests` reproduces the crash shape end to end without audio hardware: a fresh decoder's un-attached node + un-started engine at a full-cushion prime edge. **Under the first version of this fix the test runner itself aborted** — which is exactly how the second guard hole (`engine.start()` raising) was found; that crash report is the one filed at 08:24 today. The test now passes.
- Shim unit coverage (raised exception → false, clean block → true).
- **239 tests, 21 suites, green.**