### PR TITLE
fix(net): release OpenSSL per-thread state before GCD can retire the thread

### DIFF
--- a/Glimmer-Bridging-Header.h
+++ b/Glimmer-Bridging-Header.h
@@ -16,6 +16,10 @@
 #import <opus/opus_multistream.h>
 
 // OpenSSL primitives used by Identity + Pairing + Network.
+// crypto.h explicitly for OPENSSL_thread_stop - the per-thread state release
+// every pooled (GCD) thread that touches OpenSSL must run before it can be
+// retired (see ControlTransport's defer; the 2026-08-21 TSD-destructor crash).
+#import <openssl/crypto.h>
 #import <openssl/bio.h>
 #import <openssl/x509.h>
 #import <openssl/pem.h>

--- a/Glimmer/Stream/ControlTransport.swift
+++ b/Glimmer/Stream/ControlTransport.swift
@@ -40,6 +40,28 @@ enum ControlTransport {
                     timeout: TimeInterval) async throws -> Response {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Response, Error>) in
             ioQueue.async {
+                // OPENSSL PER-THREAD STATE RELEASE (the 2026-08-21 crash).
+                // `ioQueue` is a concurrent dispatch queue, so this block runs on
+                // POOLED GCD worker threads that the system retires when idle.
+                // libcrypto plants thread-local state (ERR stacks, the 3.x
+                // "master key" sparse array) on whatever thread runs a TLS
+                // handshake, and reclaims it in a pthread TSD DESTRUCTOR at
+                // thread exit. A 3-day process accumulated that state across
+                // dozens of workers; when GCD retired one ~15min after a wake,
+                // the destructor walked a days-old sparse array and crashed on
+                // freed memory (sa_doall → ossl_sa_free → clean_master_key,
+                // SIGSEGV at a 0x8080... poison address). OPENSSL_thread_stop is
+                // the API the OpenSSL docs REQUIRE of threads the library didn't
+                // create: it releases the per-thread state deterministically,
+                // HERE, microseconds after it was planted and while it is
+                // certainly valid - so thread retirement finds nothing to
+                // reclaim. Cost: per-call state re-creation, trivial next to the
+                // TLS handshake this block just performed. (The RTP/control
+                // paths run on OWNED long-lived threads and the audio decrypt
+                // path is plaintext for our hosts, so this transport is the one
+                // pooled-thread OpenSSL user; the Swift-concurrency cooperative
+                // pool's threads persist for the process lifetime.)
+                defer { OPENSSL_thread_stop() }
                 do {
                     cont.resume(returning: try performBlocking(
                         host: host, port: port, target: target, userAgent: userAgent,


### PR DESCRIPTION
## The crash (2026-08-21, 2026.8.11, 3-day-old process, ~15 min after wake)

SIGSEGV on an **anonymous GCD worker being retired** — not in any Glimmer frame, but in libcrypto's pthread TSD destructor:

```
sa_doall → ossl_sa_free → clean_master_key → _pthread_tsd_cleanup → _pthread_exit
KERN_INVALID_ADDRESS at 0x000080808282b131   (poison pattern)
```

## Mechanism

OpenSSL plants per-thread state (ERR stacks, the 3.x "master key" sparse array) on **whatever thread runs its calls**, and reclaims it in a destructor at *thread exit*. `ControlTransport` — the mutual-TLS client behind every `/serverinfo` poll and pairing call — runs on a **concurrent dispatch queue**: pooled workers the system retires when idle. Three days of polling planted state across dozens of workers; when GCD retired one ~15 minutes after a wake, the destructor walked days-old state and died. (Related upstream class: OpenSSL cleanup/TSD races — [#6214](https://github.com/openssl/openssl/issues/6214), [#5899](https://github.com/openssl/openssl/issues/5899), [#22939](https://github.com/openssl/openssl/issues/22939).)

## The fix

`OPENSSL_thread_stop()` — the call the [OpenSSL docs require](https://manpages.debian.org/experimental/libssl-doc/OPENSSL_cleanup.3ssl.en.html) of threads the library didn't create — now runs in a `defer` at the end of the transport's work unit. Per-thread state is released **deterministically, microseconds after it was planted and while it is certainly valid**; thread retirement then finds nothing to reclaim. Cost: per-call state re-creation, trivial next to the TLS handshake the block just performed.

**Scope audit:** this transport is the only pooled-thread OpenSSL user — RTP/control crypto runs on owned long-lived threads, audio decrypt is plaintext for our hosts, and the Swift-concurrency cooperative pool's threads persist for the process lifetime.

## Verification — stated plainly

No unit test can drive GCD thread retirement, so this ships on mechanism analysis plus the documented OpenSSL contract. The build proves the symbol resolves and links; **239 tests pass**. The field signal is this crash signature never recurring — and since it took three days of uptime to manifest, that verification is inherently slow.